### PR TITLE
road/container bugs, terminal cost, extension size update on RCL

### DIFF
--- a/src/mods/controller/processor.ts
+++ b/src/mods/controller/processor.ts
@@ -18,7 +18,7 @@ export function claim(controller: StructureController, user: string) {
 }
 
 function updateExtensionCapacities(room: Room) {
-	// Extensions only change capacity a RCL 6/7/8
+	// Extensions only change capacity at RCL 6/7/8
 	if (room['#level'] > 5) {
 		const newCap = C.EXTENSION_ENERGY_CAPACITY[room['#level']];
 		for (const structure of room.find(C.FIND_STRUCTURES)) {

--- a/src/mods/market/terminal.ts
+++ b/src/mods/market/terminal.ts
@@ -114,4 +114,4 @@ registerBuildableStructure(C.STRUCTURE_TERMINAL, {
 	create(site) {
 		return create(site.pos, site['#user']);
 	},
-);
+});

--- a/src/mods/market/terminal.ts
+++ b/src/mods/market/terminal.ts
@@ -109,9 +109,9 @@ registerBuildableStructure(C.STRUCTURE_TERMINAL, {
 	obstacle: true,
 	checkPlacement(room, pos) {
 		return checkPlacement(room, pos) === C.OK ?
-			C.CONSTRUCTION_COST.spawn : null;
+			C.CONSTRUCTION_COST.terminal : null;
 	},
 	create(site) {
 		return create(site.pos, site['#user']);
 	},
-});
+);

--- a/src/mods/resource/container.ts
+++ b/src/mods/resource/container.ts
@@ -41,10 +41,10 @@ export function create(pos: RoomPosition) {
 registerBuildableStructure(C.STRUCTURE_CONTAINER, {
 	obstacle: false,
 	checkPlacement(room, pos) {
-		// Don't allow double containers
+		// Can't build on anything but road or rampart
 		for (const object of room['#lookAt'](pos)) {
 			asUnion(object);
-			if (object.structureType === 'container') {
+			if (object.structureType != 'road' && object.structureType != 'rampart') {
 				return null;
 			}
 		}

--- a/src/mods/resource/store.ts
+++ b/src/mods/resource/store.ts
@@ -253,6 +253,10 @@ export class SingleStore<Type extends ResourceType> extends withOverlay(Store, s
 	['#subtract'](type: ResourceType, amount: number) {
 		this[type] = this['#amount'] -= amount;
 	}
+
+	['#updateCapacity'](amount: number) {
+		this['#capacity'] = amount;
+	}
 }
 
 /**

--- a/src/mods/road/road.ts
+++ b/src/mods/road/road.ts
@@ -5,6 +5,7 @@ import { Game } from 'xxscreeps/game';
 import { isBorder } from 'xxscreeps/game/position';
 import { Structure, structureFormat } from 'xxscreeps/mods/structure/structure';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema';
+import { asUnion } from 'xxscreeps/utility/utility';
 import { registerBuildableStructure } from 'xxscreeps/mods/construction';
 
 export const format = declare('Road', () => compose(shape, StructureRoad));
@@ -47,6 +48,16 @@ registerBuildableStructure(C.STRUCTURE_ROAD, {
 	checkPlacement(room, pos) {
 		const terrain = room.getTerrain().get(pos.x, pos.y);
 		const cost = C.CONSTRUCTION_COST.road;
+
+		// Don't allow double roads
+		for (const object of room['#lookAt'](pos)) {
+			asUnion(object);
+			if(object.structureType === 'road') {
+				return null;
+			}
+		}	
+
+		// Decide cost based on terrain
 		switch (terrain) {
 			case C.TERRAIN_MASK_SWAMP: return cost * C.CONSTRUCTION_COST_ROAD_SWAMP_RATIO;
 			case C.TERRAIN_MASK_WALL: return isBorder(pos.x, pos.y) ? null :


### PR DESCRIPTION
Roads: can no longer be constructed on top of themselves
Containers: can no longer be constructed on top of themselves nor obstacles and construct with the correct hits
Terminals: correct construction cost
Extensions: correctly update capacity on change in RCL at levels 6/7/8