### PR TITLE
Add friendly error message on run command that doesn't exist

### DIFF
--- a/src/config/entry.ts
+++ b/src/config/entry.ts
@@ -68,14 +68,25 @@ if (missingFlags.length) {
 	if (specifier && !specifier.startsWith('-')) {
 		// Run
 		const base = new URL('../..', import.meta.url);
-		await import(`${new URL({
+		const commands: Record<string, string | undefined> = {
 			import: './dist/scripts/scrape-world.js',
 			start: './dist/engine/service/launcher.js',
 			main: './dist/engine/service/main.js',
 			backend: './dist/backend/server.js',
 			processor: './dist/engine/service/processor.js',
 			runner: './dist/engine/service/runner.js',
-		}[specifier] ?? specifier, base)}`);
+		};
+
+		let modulePath;
+
+		try {
+			modulePath = await import.meta.resolve(`${new URL(commands[specifier] ?? specifier, base)}`);
+		} catch (error) {
+			if (error.code !== 'ERR_MODULE_NOT_FOUND') { throw error }
+			console.log(`Invalid command or module "${specifier}", built in commands are ${Object.keys(commands).join(', ')}`);
+		}
+
+		if (modulePath !== undefined) { await import(modulePath) }
 	} else {
 		// Start repl
 		if (!isMainThread) {


### PR DESCRIPTION
I ran `npx xxscreeps export` instead of `import` and got a cryptic error message

a friendly error message would have saved me a little time, that's what this is

the message looks like this
```
➜  xxscreeps git:(main) ✗ npx xxscreeps foo
Invalid command or module "foo", built in commands are import, start, main, backend, processor, runner
```

the `import, start, main, backend, processor, runner` is not static, it grabs the keys from the object containing the command aliases to the module paths which I moved into a variable, so I could reference it multiple times

that variable is named `commands` but let me know if you want it changed to be more descriptive
I catch the error with a `.catch()` on the `import()` but let me know if you want that changed to a `try {} catch {}`

I also rethrow the error if the `error.code` is not `"ERR_MODULE_NOT_FOUND"` but let me know if there's something else preferred

thanks