### PR TITLE
Fix RoomVisual.poly() when called with a list of points in array format

### DIFF
--- a/src/mods/visual/visual.ts
+++ b/src/mods/visual/visual.ts
@@ -212,10 +212,12 @@ export class RoomVisual {
 	/**
 	 * Draw a polyline.
 	 */
-	poly(points: (LocalPoint | RoomPoint)[], style?: PolyStyle) {
+	poly(points: (LocalPoint | RoomPoint | [number, number])[], style?: PolyStyle) {
 		const pairs = [
 			...Fn.map(points, point =>
-				[ ...extractPositions([ point ], this.#isMap) ] as [ number, number ]),
+				Array.isArray(point) ?
+					point :
+					[ ...extractPositions([ point ], this.#isMap) ] as [ number, number ]),
 		];
 		this.#visuals.push({ [Variant]: 'p', points: pairs, s: (style as any) ?? {} });
 		return this;


### PR DESCRIPTION

from the documentation https://docs.screeps.com/api/#RoomVisual.poly

poly(points, [style])
===============


points : An array of points. Every item should be either an array with 2 numbers (i.e. [10,15]), or a RoomPosition object.

