### PR TITLE
Update readme links in regards to the vscode YAML extension and config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ backend:
   steamApiKey: <your steam key>
 ```
 
-If you're using VS Code and you have the YAML extension installed all the options should
+If you're using VS Code and you have the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) installed all the options should
 autocomplete. If not you can read the [config
-schema](https://github.com/laverdet/xxscreeps/blob/main/src/config/schema.ts).
+schema](src/config/config.ts).
 
 ## Docker
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import os from 'os';
 
+// When making changes to the schema, remember to generate a new typescript json schema with the below command
 // npx typescript-json-schema tsconfig.json Schema --include ./src/config/config.ts --defaultProps --required -o ./src/config/config.schema.json
 export type Schema = {
 	/**


### PR DESCRIPTION
- Adds link to the vscode YAML extension
- fixes broken link to the config schema
- clarifies you are supposed to generate a new schema if you modify the config.ts