### PR TITLE
Add vscode .devcontainer settings for dockerized development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:16-bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.166.0/containers/docker-existing-dockerfile
+{
+    "name": "xxscreeps-dev",
+  
+    // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+    "dockerFile": "Dockerfile",
+  
+    // Set *default* container specific settings.json values on container create.
+    // "settings": {
+    // },
+  
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+      "ms-vscode.vscode-typescript-next"
+  ],
+  
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+  
+    // Uncomment the next line to run commands after the container is created - for example installing curl.
+    // "postCreateCommand": "apt-get update && apt-get install -y curl",
+  
+    // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+    "runArgs": [ "--network=host" ],
+  
+    // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+    // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+  
+    // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+    // "remoteUser": "vscode"
+  }
+  

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.vscode-remote-extensionpack"
+    ]
+}


### PR DESCRIPTION
This PR is adding basic settings for dockerizing dev environment in vscode. Developing inside a docker container allows for easy setup and isolates the dev environment from your machine, preventing the project from polluting the global installation. Also, for easy access to different node version without using nvm.