### PR TITLE
force git to load files with lf instead of crlf on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ts text eol=lf


### PR DESCRIPTION
I am on Windows and According to this https://eslint.org/docs/rules/linebreak-style#using-this-rule-with-version-control-systems
forcing LF should fix this, and it does look like it is fixed when I make a change to the file and discard it so it is loaded from git again.
![image](https://user-images.githubusercontent.com/9084377/145699230-6d28f2ba-0b72-4df4-ac6a-7d80e00fb1cc.png)

Alternatively we could disable the rule?