### PR TITLE
Added vscode test snippets

### DIFF
--- a/.vscode/tests.json.code-snippets
+++ b/.vscode/tests.json.code-snippets
@@ -1,0 +1,92 @@
+{
+  // Place your xxscreeps workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  // "Print to console": {
+  // 	"scope": "javascript,typescript",
+  // 	"prefix": "log",
+  // 	"body": [
+  // 		"console.log('$1');",
+  // 		"$2"
+  // 	],
+  // 	"description": "Log output to console"
+  // }
+  "simulation": {
+    "scope": "typescript",
+    "prefix": "sim",
+    "body": [
+      "const ${1:simulation} = simulate({",
+      "\tW0N0: room => {",
+      "\t\t//room['#level'] = 3;",
+      "\t\t//room['#user'] = '100';",
+      "\t\t//room['#insertObject'](createCreep(new RoomPosition(24, 25, 'W0N0'), [ C.MOVE ], 'creep1', '100'));",
+      "\t\t$0",
+      "\t},",
+      "});"
+    ],
+    "description": "simulation"
+  },
+
+  "test": {
+    "scope": "typescript",
+    "prefix": "test",
+    "body": [
+      "test('${1:Test}', () => ${2:simulation}(async({ player, tick }) => {",
+      "\tawait player('${3:100}', Game => {",
+      "\t\t$0",
+      "\t});",
+      "",
+      "\tawait tick();",
+      "",
+      "}));"
+    ],
+    "description": "Adds a new test entry that sets up a place to run player code and ticks the code afterwards"
+  },
+  "describe": {
+    "scope": "typescript",
+    "prefix": "describe",
+    "body": [
+      "describe('${1}', () => {",
+      "\t$0",
+      "});"
+    ],
+    "description": "Adds a new container/description for tests to reside in"
+  },
+  "test-init": {
+    "scope": "typescript",
+    "prefix": "test-init",
+    "body": [
+		"import * as C from 'xxscreeps/game/constants';",
+		"import { assert, describe, simulate, test } from 'xxscreeps/test';",
+		"// import { RoomPosition } from 'xxscreeps/game/position';",
+		"// import { create as createCreep } from 'xxscreeps/mods/creep/creep';",
+		"",
+		"// TODO: remember to add test.ts as a provider in index.ts",
+		"",
+		"describe('${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}', () => {",
+		"\tconst simulation = simulate({",
+		"\t\tW0N0: room => {",
+		"\t\t\t//room['#level'] = 3;",
+		"\t\t\t//room['#user'] = '100';",
+		"\t\t\t//room['#insertObject'](createCreep(new RoomPosition(24, 25, 'W0N0'), [ C.MOVE ], 'creep1', '100'));",
+		"\t\t},",
+		"\t});",
+		"",
+		"\ttest('Test', () => simulation(async({ player, tick }) => {",
+		"\t\tawait player('100', Game => {",
+		"\t\t\t$0",
+		"\t\t});",
+		"",
+		"\t\tawait tick();",
+		"\t\t",
+		"\t}));",
+		"}); ",
+		
+    ],
+    "description": "initializes a new file with a test container"
+  }
+}


### PR DESCRIPTION
Added some vscode snippets for writing tests

`test-init` 
![test-snippets](https://user-images.githubusercontent.com/9084377/146096484-a17ed091-50cd-4f00-baef-0cd6a58f9fc4.gif)
`simulate` 
![test-snippets-sim](https://user-images.githubusercontent.com/9084377/146096509-d70bf727-3c30-4247-a1af-2f234ce3aa0d.gif)
`test` 
![test-snippets-test](https://user-images.githubusercontent.com/9084377/146096519-c7dd0b33-1bf9-46ac-bbd1-e6bd9744022b.gif)
`describe` 
![test-snippets-describe](https://user-images.githubusercontent.com/9084377/146096526-8364dbcc-2c87-4500-a62e-746d2522c74e.gif)

