### PR TITLE
feature: Implement StructureLab parity — boostCreep, reverseReaction, unboostCreep (exposes TOUGH damage reduction implementation need)

### DIFF
--- a/src/mods/chemistry/backend.ts
+++ b/src/mods/chemistry/backend.ts
@@ -4,17 +4,23 @@ import { renderStore } from 'xxscreeps/mods/resource/backend.js';
 import { StructureLab } from './lab.js';
 
 bindRenderer(StructureLab, (lab, next, previousTime) => {
-	// Combine reaction1 & reaction2 into expected action log format
+	// Combine paired action log entries into the format the client expects
 	const actionLog = function() {
-		const actionLog = renderActionLog(lab['#actionLog'], previousTime);
-		if (actionLog.reaction1 && actionLog.reaction2) {
-			return {
-				reaction: {
-					x1: actionLog.reaction1.x, y1: actionLog.reaction1.y,
-					x2: actionLog.reaction2.x, y2: actionLog.reaction2.y,
-				},
+		const raw = renderActionLog(lab['#actionLog'], previousTime);
+		const result: Record<string, { x1: number; y1: number; x2: number; y2: number }> = {};
+		if (raw.reaction1 && raw.reaction2) {
+			result.runReaction = {
+				x1: raw.reaction1.x, y1: raw.reaction1.y,
+				x2: raw.reaction2.x, y2: raw.reaction2.y,
 			};
 		}
+		if (raw.reverseReaction1 && raw.reverseReaction2) {
+			result.reverseReaction = {
+				x1: raw.reverseReaction1.x, y1: raw.reverseReaction1.y,
+				x2: raw.reverseReaction2.x, y2: raw.reverseReaction2.y,
+			};
+		}
+		return Object.keys(result).length ? result : undefined;
 	}();
 	return {
 		...next(),

--- a/src/mods/chemistry/game.ts
+++ b/src/mods/chemistry/game.ts
@@ -33,7 +33,7 @@ declare module 'xxscreeps/game/room/index.js' {
 }
 
 // Action log types
-const actionSchema = registerEnumerated('ActionLog.action', 'reaction1', 'reaction2');
+const actionSchema = registerEnumerated('ActionLog.action', 'reaction1', 'reaction2', 'reverseReaction1', 'reverseReaction2');
 declare module 'xxscreeps/game/object.js' {
 	interface Schema { chemistry: typeof actionSchema }
 }

--- a/src/mods/chemistry/index.ts
+++ b/src/mods/chemistry/index.ts
@@ -6,5 +6,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/src/mods/chemistry/lab.ts
+++ b/src/mods/chemistry/lab.ts
@@ -1,6 +1,6 @@
-import type { Creep } from 'xxscreeps/mods/creep/creep.js';
 import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
+import { Creep } from 'xxscreeps/mods/creep/creep.js';
 import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
@@ -48,9 +48,10 @@ export class StructureLab extends withOverlay(OwnedStructure, shape) {
 			() => intents.save(this, 'runReaction', lab1.id, lab2.id));
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	boostCreep(creep: Creep, bodyPartsCount?: number) {
-		return C.ERR_INVALID_TARGET as C.ErrorCode;
+		return chainIntentChecks(
+			() => checkBoostCreep(this, creep, bodyPartsCount),
+			() => intents.save(this, 'boostCreep', creep.id, bodyPartsCount ?? 0));
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -93,6 +94,29 @@ declare module 'xxscreeps/game/runtime.js' {
 
 export function getReactionProduct(mineral1?: ResourceType, mineral2?: ResourceType) {
 	return (C.REACTIONS as Partial<Record<string, Partial<Record<string, ResourceType>>>>)[mineral1!]?.[mineral2!];
+}
+
+export function checkBoostCreep(lab: StructureLab, creep: Creep | null | undefined, bodyPartsCount?: number) {
+	const mineralType = lab.mineralType;
+	return chainIntentChecks(
+		() => checkMyStructure(lab, StructureLab),
+		() => checkTarget(creep, Creep),
+		() => checkRange(lab, creep!, 1),
+		() => {
+			if (lab.store[C.RESOURCE_ENERGY] < C.LAB_BOOST_ENERGY) {
+				return C.ERR_NOT_ENOUGH_RESOURCES;
+			}
+			if (!mineralType || lab.store[mineralType as keyof typeof labStoreFormat] < C.LAB_BOOST_MINERAL) {
+				return C.ERR_NOT_ENOUGH_RESOURCES;
+			}
+		},
+		() => {
+			const nonBoostedCount = creep!.body.filter(
+				p => !p.boost && (C.BOOSTS as any)[p.type]?.[mineralType!]).length;
+			if (!nonBoostedCount || (bodyPartsCount && bodyPartsCount > nonBoostedCount)) {
+				return C.ERR_NOT_FOUND;
+			}
+		});
 }
 
 export function checkRunReaction(lab: StructureLab, left: StructureLab, right: StructureLab) {

--- a/src/mods/chemistry/lab.ts
+++ b/src/mods/chemistry/lab.ts
@@ -60,9 +60,10 @@ export class StructureLab extends withOverlay(OwnedStructure, shape) {
 			() => intents.save(this, 'reverseReaction', lab1.id, lab2.id));
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	unboostCreep(creep: Creep) {
-		return C.ERR_INVALID_TARGET as C.ErrorCode;
+		return chainIntentChecks(
+			() => checkUnboostCreep(this, creep),
+			() => intents.save(this, 'unboostCreep', creep.id));
 	}
 }
 
@@ -170,6 +171,45 @@ export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | nul
 				return C.ERR_FULL;
 			}
 		});
+}
+
+export function checkUnboostCreep(lab: StructureLab, creep: Creep | null | undefined) {
+	return chainIntentChecks(
+		() => checkTarget(creep, Creep),
+		() => {
+			if (!lab.my || !creep!.my) {
+				return C.ERR_NOT_OWNER;
+			}
+		},
+		() => checkMyStructure(lab, StructureLab),
+		() => checkRange(lab, creep!, 1),
+		() => {
+			if (lab.cooldown) {
+				return C.ERR_TIRED;
+			}
+		},
+		() => {
+			if (!creep!.body.some(p => !!p.boost)) {
+				return C.ERR_NOT_FOUND;
+			}
+		});
+}
+
+export function calcTotalReactionsTime(mineral: string): number {
+	// Build reagent lookup: compound -> [reagent1, reagent2]
+	const reactions = C.REACTIONS as Record<string, Record<string, string>>;
+	const reagents: Record<string, [string, string]> = {};
+	for (const r1 in reactions) {
+		for (const r2 in reactions[r1]) {
+			reagents[reactions[r1][r2]] = [ r2, r1 ];
+		}
+	}
+	const calcStep = (m: string): number => {
+		const time = (C.REACTION_TIME as Record<string, number>)[m];
+		if (!time) return 0;
+		return time + calcStep(reagents[m][0]) + calcStep(reagents[m][1]);
+	};
+	return calcStep(mineral);
 }
 
 export function checkRunReaction(lab: StructureLab, left: StructureLab, right: StructureLab) {

--- a/src/mods/chemistry/lab.ts
+++ b/src/mods/chemistry/lab.ts
@@ -54,9 +54,10 @@ export class StructureLab extends withOverlay(OwnedStructure, shape) {
 			() => intents.save(this, 'boostCreep', creep.id, bodyPartsCount ?? 0));
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	reverseReaction(lab1: StructureLab, lab2: StructureLab) {
-		return C.ERR_INVALID_TARGET as C.ErrorCode;
+		return chainIntentChecks(
+			() => checkReverseReaction(this, lab1, lab2),
+			() => intents.save(this, 'reverseReaction', lab1.id, lab2.id));
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -115,6 +116,58 @@ export function checkBoostCreep(lab: StructureLab, creep: Creep | null | undefin
 				p => !p.boost && (C.BOOSTS as any)[p.type]?.[mineralType!]).length;
 			if (!nonBoostedCount || (bodyPartsCount && bodyPartsCount > nonBoostedCount)) {
 				return C.ERR_NOT_FOUND;
+			}
+		});
+}
+
+export function getReactionVariants(compound: ResourceType): [ResourceType, ResourceType][] {
+	const result: [ResourceType, ResourceType][] = [];
+	const reactions = C.REACTIONS as Record<string, Record<string, string>>;
+	for (const r1 in reactions) {
+		for (const r2 in reactions[r1]) {
+			if (reactions[r1][r2] === compound) {
+				result.push([ r1 as ResourceType, r2 as ResourceType ]);
+			}
+		}
+	}
+	return result;
+}
+
+export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | null | undefined, lab2: StructureLab | null | undefined) {
+	return chainIntentChecks(
+		() => checkMyStructure(lab, StructureLab),
+		() => checkTarget(lab1, StructureLab),
+		() => checkTarget(lab2, StructureLab),
+		() => checkRange(lab, lab1!, 2),
+		() => checkRange(lab, lab2!, 2),
+		() => {
+			if (lab1!.id === lab2!.id) {
+				return C.ERR_INVALID_ARGS;
+			}
+		},
+		() => {
+			if (lab.cooldown) {
+				return C.ERR_TIRED;
+			}
+		},
+		() => checkHasResource(lab, lab.mineralType, C.LAB_REACTION_AMOUNT),
+		() => {
+			const mineralType = lab.mineralType!;
+			const variants = getReactionVariants(mineralType);
+			const variant = variants.find(v =>
+				(!lab1!.mineralType || lab1!.mineralType === v[0]) &&
+				(!lab2!.mineralType || lab2!.mineralType === v[1]));
+			if (!variant) {
+				return C.ERR_INVALID_ARGS;
+			}
+			// Check destination labs can receive reagents
+			const lab1Mineral = lab1!.mineralType;
+			const lab2Mineral = lab2!.mineralType;
+			if (lab1Mineral && (lab1!.store[lab1Mineral as keyof typeof labStoreFormat] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
+				return C.ERR_FULL;
+			}
+			if (lab2Mineral && (lab2!.store[lab2Mineral as keyof typeof labStoreFormat] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
+				return C.ERR_FULL;
 			}
 		});
 }

--- a/src/mods/chemistry/lab.ts
+++ b/src/mods/chemistry/lab.ts
@@ -32,7 +32,7 @@ export class StructureLab extends withOverlay(OwnedStructure, shape) {
 	/** @deprecated */
 	@enumerable get energyCapacity() { return this.store.getCapacity(C.RESOURCE_ENERGY); }
 	/** @deprecated */
-	@enumerable get mineralAmount() { return this.store[this.mineralType as keyof typeof labStoreFormat]; }
+	@enumerable get mineralAmount() { const type = this.mineralType; return type ? this.store[type] : 0; }
 	/** @deprecated */
 	@enumerable get mineralCapacity() { return C.LAB_MINERAL_CAPACITY; }
 
@@ -103,18 +103,24 @@ export function checkBoostCreep(lab: StructureLab, creep: Creep | null | undefin
 	return chainIntentChecks(
 		() => checkMyStructure(lab, StructureLab),
 		() => checkTarget(creep, Creep),
+		() => {
+			if (creep!.spawning) {
+				return C.ERR_INVALID_TARGET;
+			}
+		},
 		() => checkRange(lab, creep!, 1),
 		() => {
 			if (lab.store[C.RESOURCE_ENERGY] < C.LAB_BOOST_ENERGY) {
 				return C.ERR_NOT_ENOUGH_RESOURCES;
 			}
-			if (!mineralType || lab.store[mineralType as keyof typeof labStoreFormat] < C.LAB_BOOST_MINERAL) {
+			if (!mineralType || lab.store[mineralType] < C.LAB_BOOST_MINERAL) {
 				return C.ERR_NOT_ENOUGH_RESOURCES;
 			}
 		},
 		() => {
+			const boosts = C.BOOSTS as Partial<Record<string, Partial<Record<string, unknown>>>>;
 			const nonBoostedCount = creep!.body.filter(
-				p => !p.boost && (C.BOOSTS as any)[p.type]?.[mineralType!]).length;
+				p => !p.boost && boosts[p.type]?.[mineralType!]).length;
 			if (!nonBoostedCount || (bodyPartsCount && bodyPartsCount > nonBoostedCount)) {
 				return C.ERR_NOT_FOUND;
 			}
@@ -137,6 +143,11 @@ export function getReactionVariants(compound: ResourceType): [ResourceType, Reso
 export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | null | undefined, lab2: StructureLab | null | undefined) {
 	return chainIntentChecks(
 		() => checkMyStructure(lab, StructureLab),
+		() => {
+			if (lab.cooldown) {
+				return C.ERR_TIRED;
+			}
+		},
 		() => checkTarget(lab1, StructureLab),
 		() => checkTarget(lab2, StructureLab),
 		() => checkRange(lab, lab1!, 2),
@@ -144,11 +155,6 @@ export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | nul
 		() => {
 			if (lab1!.id === lab2!.id) {
 				return C.ERR_INVALID_ARGS;
-			}
-		},
-		() => {
-			if (lab.cooldown) {
-				return C.ERR_TIRED;
 			}
 		},
 		() => checkHasResource(lab, lab.mineralType, C.LAB_REACTION_AMOUNT),
@@ -164,10 +170,10 @@ export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | nul
 			// Check destination labs can receive reagents
 			const lab1Mineral = lab1!.mineralType;
 			const lab2Mineral = lab2!.mineralType;
-			if (lab1Mineral && (lab1!.store[lab1Mineral as keyof typeof labStoreFormat] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
+			if (lab1Mineral && (lab1!.store[lab1Mineral] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
 				return C.ERR_FULL;
 			}
-			if (lab2Mineral && (lab2!.store[lab2Mineral as keyof typeof labStoreFormat] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
+			if (lab2Mineral && (lab2!.store[lab2Mineral] + C.LAB_REACTION_AMOUNT) > C.LAB_MINERAL_CAPACITY) {
 				return C.ERR_FULL;
 			}
 		});
@@ -176,13 +182,12 @@ export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | nul
 export function checkUnboostCreep(lab: StructureLab, creep: Creep | null | undefined) {
 	return chainIntentChecks(
 		() => checkTarget(creep, Creep),
+		() => checkMyStructure(lab, StructureLab),
 		() => {
-			if (!lab.my || !creep!.my) {
+			if (!creep!.my) {
 				return C.ERR_NOT_OWNER;
 			}
 		},
-		() => checkMyStructure(lab, StructureLab),
-		() => checkRange(lab, creep!, 1),
 		() => {
 			if (lab.cooldown) {
 				return C.ERR_TIRED;
@@ -192,7 +197,8 @@ export function checkUnboostCreep(lab: StructureLab, creep: Creep | null | undef
 			if (!creep!.body.some(p => !!p.boost)) {
 				return C.ERR_NOT_FOUND;
 			}
-		});
+		},
+		() => checkRange(lab, creep!, 1));
 }
 
 export function calcTotalReactionsTime(mineral: string): number {
@@ -219,16 +225,16 @@ export function checkRunReaction(lab: StructureLab, left: StructureLab, right: S
 	}
 	return chainIntentChecks(
 		() => checkMyStructure(lab, StructureLab),
+		() => {
+			if (lab.cooldown) {
+				return C.ERR_TIRED;
+			}
+		},
 		() => checkTarget(left, StructureLab),
 		() => checkTarget(right, StructureLab),
 		() => checkRange(lab, left, 2),
 		() => checkRange(lab, right, 2),
 		() => checkHasCapacity(lab, reaction, C.LAB_REACTION_AMOUNT),
 		() => checkHasResource(left, left.mineralType, C.LAB_REACTION_AMOUNT),
-		() => checkHasResource(right, right.mineralType, C.LAB_REACTION_AMOUNT),
-		() => {
-			if (lab.cooldown) {
-				return C.ERR_TIRED;
-			}
-		});
+		() => checkHasResource(right, right.mineralType, C.LAB_REACTION_AMOUNT));
 }

--- a/src/mods/chemistry/lab.ts
+++ b/src/mods/chemistry/lab.ts
@@ -1,3 +1,4 @@
+import type { Creep } from 'xxscreeps/mods/creep/creep.js';
 import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
 import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
@@ -45,6 +46,21 @@ export class StructureLab extends withOverlay(OwnedStructure, shape) {
 		return chainIntentChecks(
 			() => checkRunReaction(this, lab1, lab2),
 			() => intents.save(this, 'runReaction', lab1.id, lab2.id));
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	boostCreep(creep: Creep, bodyPartsCount?: number) {
+		return C.ERR_INVALID_TARGET as C.ErrorCode;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	reverseReaction(lab1: StructureLab, lab2: StructureLab) {
+		return C.ERR_INVALID_TARGET as C.ErrorCode;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	unboostCreep(creep: Creep) {
+		return C.ERR_INVALID_TARGET as C.ErrorCode;
 	}
 }
 

--- a/src/mods/chemistry/processor.ts
+++ b/src/mods/chemistry/processor.ts
@@ -3,7 +3,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { Creep, calculateCarry } from 'xxscreeps/mods/creep/creep.js';
-import { StructureLab, checkBoostCreep, checkRunReaction, getReactionProduct } from './lab.js';
+import { StructureLab, checkBoostCreep, checkReverseReaction, checkRunReaction, getReactionProduct, getReactionVariants } from './lab.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { chemistry: typeof intents }
@@ -60,6 +60,25 @@ const intents = [
 		creep.store['#capacity'] = calculateCarry(creep.body);
 
 		saveAction(creep, 'healed', lab.pos);
+		context.didUpdate();
+	}),
+
+	registerIntentProcessor(StructureLab, 'reverseReaction', {}, (lab, context, id1: string, id2: string) => {
+		const lab1 = Game.getObjectById<StructureLab>(id1)!;
+		const lab2 = Game.getObjectById<StructureLab>(id2)!;
+		if (checkReverseReaction(lab, lab1, lab2) !== C.OK) {
+			return;
+		}
+		const mineralType = lab.mineralType!;
+		const variants = getReactionVariants(mineralType);
+		const variant = variants.find(v =>
+			(!lab1.mineralType || lab1.mineralType === v[0]) &&
+			(!lab2.mineralType || lab2.mineralType === v[1]))!;
+
+		lab.store['#subtract'](mineralType, C.LAB_REACTION_AMOUNT);
+		lab1.store['#add'](variant[0], C.LAB_REACTION_AMOUNT);
+		lab2.store['#add'](variant[1], C.LAB_REACTION_AMOUNT);
+		lab['#cooldownTime'] = Game.time + C.REACTION_TIME[mineralType as keyof typeof C.REACTION_TIME];
 		context.didUpdate();
 	}),
 ];

--- a/src/mods/chemistry/processor.ts
+++ b/src/mods/chemistry/processor.ts
@@ -16,7 +16,7 @@ const intents = [
 			lab.store['#add'](product, C.LAB_REACTION_AMOUNT);
 			left.store['#subtract'](left.mineralType!, C.LAB_REACTION_AMOUNT);
 			right.store['#subtract'](right.mineralType!, C.LAB_REACTION_AMOUNT);
-			lab['#cooldownTime'] = Game.time + C.LAB_COOLDOWN;
+			lab['#cooldownTime'] = Game.time + C.REACTION_TIME[product as keyof typeof C.REACTION_TIME];
 			saveAction(lab, 'reaction1', left.pos);
 			saveAction(lab, 'reaction2', left.pos);
 			context.didUpdate();

--- a/src/mods/chemistry/processor.ts
+++ b/src/mods/chemistry/processor.ts
@@ -3,7 +3,8 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { Creep, calculateCarry } from 'xxscreeps/mods/creep/creep.js';
-import { StructureLab, checkBoostCreep, checkReverseReaction, checkRunReaction, getReactionProduct, getReactionVariants } from './lab.js';
+import { drop as dropResource } from 'xxscreeps/mods/resource/processor/resource.js';
+import { StructureLab, calcTotalReactionsTime, checkBoostCreep, checkReverseReaction, checkRunReaction, checkUnboostCreep, getReactionProduct, getReactionVariants } from './lab.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { chemistry: typeof intents }
@@ -79,6 +80,49 @@ const intents = [
 		lab1.store['#add'](variant[0], C.LAB_REACTION_AMOUNT);
 		lab2.store['#add'](variant[1], C.LAB_REACTION_AMOUNT);
 		lab['#cooldownTime'] = Game.time + C.REACTION_TIME[mineralType as keyof typeof C.REACTION_TIME];
+		context.didUpdate();
+	}),
+
+	registerIntentProcessor(StructureLab, 'unboostCreep', {}, (lab, context, creepId: string) => {
+		const creep = Game.getObjectById<Creep>(creepId)!;
+		if (checkUnboostCreep(lab, creep) !== C.OK) {
+			return;
+		}
+
+		// Count boosted parts by boost type
+		const boostedParts: Record<string, number> = {};
+		for (const part of creep.body) {
+			if (part.boost) {
+				boostedParts[part.boost] = (boostedParts[part.boost] ?? 0) + 1;
+			}
+		}
+
+		// Strip all boosts
+		for (const part of creep.body) {
+			part.boost = undefined;
+		}
+
+		// Recalculate carry capacity
+		creep.store['#capacity'] = calculateCarry(creep.body);
+
+		// Drop resources and calculate cooldown
+		let cooldown = 0;
+		for (const resource of C.RESOURCES_ALL) {
+			const count = boostedParts[resource];
+			if (!count) continue;
+
+			const mineralReturn = count * C.LAB_UNBOOST_MINERAL;
+			if (mineralReturn > 0) {
+				dropResource(creep.pos, resource, mineralReturn);
+			}
+
+			cooldown += count * calcTotalReactionsTime(resource) * C.LAB_UNBOOST_MINERAL / C.LAB_REACTION_AMOUNT;
+		}
+
+		if (cooldown > 0) {
+			lab['#cooldownTime'] = Game.time + cooldown;
+		}
+
 		context.didUpdate();
 	}),
 ];

--- a/src/mods/chemistry/processor.ts
+++ b/src/mods/chemistry/processor.ts
@@ -2,7 +2,8 @@ import { registerIntentProcessor } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
-import { StructureLab, checkRunReaction, getReactionProduct } from './lab.js';
+import { Creep, calculateCarry } from 'xxscreeps/mods/creep/creep.js';
+import { StructureLab, checkBoostCreep, checkRunReaction, getReactionProduct } from './lab.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { chemistry: typeof intents }
@@ -21,5 +22,44 @@ const intents = [
 			saveAction(lab, 'reaction2', left.pos);
 			context.didUpdate();
 		}
+	}),
+
+	registerIntentProcessor(StructureLab, 'boostCreep', {}, (lab, context, creepId: string, bodyPartsCount: number) => {
+		const creep = Game.getObjectById<Creep>(creepId)!;
+		if (checkBoostCreep(lab, creep, bodyPartsCount || undefined) !== C.OK) {
+			return;
+		}
+		const mineralType = lab.mineralType!;
+
+		// Find non-boosted parts matching this mineral's boost type
+		let nonBoostedParts = creep.body.filter(
+			p => !p.boost && (C.BOOSTS as any)[p.type]?.[mineralType]);
+
+		// TOUGH parts boosted first (ascending index), all others last-to-first (reversed)
+		if (nonBoostedParts.length > 0 && nonBoostedParts[0].type !== C.TOUGH) {
+			nonBoostedParts = [ ...nonBoostedParts ].reverse();
+		}
+
+		if (bodyPartsCount) {
+			nonBoostedParts = nonBoostedParts.slice(0, bodyPartsCount);
+		}
+
+		// Apply boosts while resources allow
+		while (
+			lab.store[C.RESOURCE_ENERGY] >= C.LAB_BOOST_ENERGY &&
+			(lab.store as any)[mineralType] >= C.LAB_BOOST_MINERAL &&
+			nonBoostedParts.length
+		) {
+			nonBoostedParts[0].boost = mineralType;
+			lab.store['#subtract'](mineralType, C.LAB_BOOST_MINERAL);
+			lab.store['#subtract'](C.RESOURCE_ENERGY, C.LAB_BOOST_ENERGY);
+			nonBoostedParts.splice(0, 1);
+		}
+
+		// Recalculate carry capacity in case CARRY parts were boosted
+		creep.store['#capacity'] = calculateCarry(creep.body);
+
+		saveAction(creep, 'healed', lab.pos);
+		context.didUpdate();
 	}),
 ];

--- a/src/mods/chemistry/processor.ts
+++ b/src/mods/chemistry/processor.ts
@@ -18,9 +18,9 @@ const intents = [
 			lab.store['#add'](product, C.LAB_REACTION_AMOUNT);
 			left.store['#subtract'](left.mineralType!, C.LAB_REACTION_AMOUNT);
 			right.store['#subtract'](right.mineralType!, C.LAB_REACTION_AMOUNT);
-			lab['#cooldownTime'] = Game.time + C.REACTION_TIME[product as keyof typeof C.REACTION_TIME];
+			lab['#cooldownTime'] = Game.time + (C.REACTION_TIME as Partial<Record<string, number>>)[product]!;
 			saveAction(lab, 'reaction1', left.pos);
-			saveAction(lab, 'reaction2', left.pos);
+			saveAction(lab, 'reaction2', right.pos);
 			context.didUpdate();
 		}
 	}),
@@ -33,8 +33,9 @@ const intents = [
 		const mineralType = lab.mineralType!;
 
 		// Find non-boosted parts matching this mineral's boost type
+		const boosts = C.BOOSTS as Partial<Record<string, Partial<Record<string, unknown>>>>;
 		let nonBoostedParts = creep.body.filter(
-			p => !p.boost && (C.BOOSTS as any)[p.type]?.[mineralType]);
+			p => !p.boost && boosts[p.type]?.[mineralType]);
 
 		// TOUGH parts boosted first (ascending index), all others last-to-first (reversed)
 		if (nonBoostedParts.length > 0 && nonBoostedParts[0].type !== C.TOUGH) {
@@ -46,15 +47,15 @@ const intents = [
 		}
 
 		// Apply boosts while resources allow
-		while (
+		for (let i = 0;
+			i < nonBoostedParts.length &&
 			lab.store[C.RESOURCE_ENERGY] >= C.LAB_BOOST_ENERGY &&
-			(lab.store as any)[mineralType] >= C.LAB_BOOST_MINERAL &&
-			nonBoostedParts.length
+			lab.store[mineralType] >= C.LAB_BOOST_MINERAL;
+			++i
 		) {
-			nonBoostedParts[0].boost = mineralType;
+			nonBoostedParts[i].boost = mineralType;
 			lab.store['#subtract'](mineralType, C.LAB_BOOST_MINERAL);
 			lab.store['#subtract'](C.RESOURCE_ENERGY, C.LAB_BOOST_ENERGY);
-			nonBoostedParts.splice(0, 1);
 		}
 
 		// Recalculate carry capacity in case CARRY parts were boosted
@@ -79,7 +80,9 @@ const intents = [
 		lab.store['#subtract'](mineralType, C.LAB_REACTION_AMOUNT);
 		lab1.store['#add'](variant[0], C.LAB_REACTION_AMOUNT);
 		lab2.store['#add'](variant[1], C.LAB_REACTION_AMOUNT);
-		lab['#cooldownTime'] = Game.time + C.REACTION_TIME[mineralType as keyof typeof C.REACTION_TIME];
+		lab['#cooldownTime'] = Game.time + (C.REACTION_TIME as Partial<Record<string, number>>)[mineralType]!;
+		saveAction(lab, 'reverseReaction1', lab1.pos);
+		saveAction(lab, 'reverseReaction2', lab2.pos);
 		context.didUpdate();
 	}),
 
@@ -111,6 +114,10 @@ const intents = [
 			const count = boostedParts[resource];
 			if (!count) continue;
 
+			const energyReturn = count * C.LAB_UNBOOST_ENERGY;
+			if (energyReturn > 0) {
+				dropResource(creep.pos, C.RESOURCE_ENERGY, energyReturn);
+			}
 			const mineralReturn = count * C.LAB_UNBOOST_MINERAL;
 			if (mineralReturn > 0) {
 				dropResource(creep.pos, resource, mineralReturn);

--- a/src/mods/chemistry/test.ts
+++ b/src/mods/chemistry/test.ts
@@ -125,7 +125,7 @@ describe('Chemistry', () => {
 					'GO', 300, 2000));
 				// Lab with WORK boost mineral (UO = harvest) + energy
 				room['#insertObject'](createLabWithResources(
-					new RoomPosition(27, 25, 'W1N1'), '100',
+					new RoomPosition(26, 25, 'W1N1'), '100',
 					'UO', 300, 2000));
 				// Creep with mixed body adjacent to labs
 				room['#insertObject'](createCreep(
@@ -503,11 +503,11 @@ describe('Chemistry', () => {
 					'UO', 300, 2000));
 				// Lab with KH (carry boost) + energy
 				room['#insertObject'](createLabWithResources(
-					new RoomPosition(27, 25, 'W1N1'), '100',
+					new RoomPosition(26, 25, 'W1N1'), '100',
 					'KH', 300, 2000));
 				// Lab with ZO (fatigue/move boost) + energy
 				room['#insertObject'](createLabWithResources(
-					new RoomPosition(23, 25, 'W1N1'), '100',
+					new RoomPosition(24, 25, 'W1N1'), '100',
 					'ZO', 300, 2000));
 				// Worker creep adjacent to labs
 				room['#insertObject'](createCreep(

--- a/src/mods/chemistry/test.ts
+++ b/src/mods/chemistry/test.ts
@@ -1,6 +1,6 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
-import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createCreep, calculatePower } from 'xxscreeps/mods/creep/creep.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create as createLab } from './lab.js';
@@ -8,10 +8,10 @@ import { create as createLab } from './lab.js';
 // Helper to create a lab with resources pre-loaded
 function createLabWithResources(pos: RoomPosition, owner: string, mineral?: string, mineralAmount?: number, energy?: number) {
 	const lab = createLab(pos, owner);
-	if (energy) {
+	if (energy !== undefined) {
 		lab.store['#add'](C.RESOURCE_ENERGY, energy);
 	}
-	if (mineral && mineralAmount) {
+	if (mineral !== undefined && mineralAmount !== undefined) {
 		lab.store['#add'](mineral as any, mineralAmount);
 	}
 	return lab;
@@ -91,6 +91,31 @@ describe('Chemistry', () => {
 				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
 				assert.strictEqual(labH.store[C.RESOURCE_HYDROGEN], 100 - C.LAB_REACTION_AMOUNT);
 				assert.strictEqual(labO.store[C.RESOURCE_OXYGEN], 100 - C.LAB_REACTION_AMOUNT);
+			});
+		}));
+
+		test('runReaction action log points to correct source labs', () => reactionSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => !l.mineralType)!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				output.runReaction(labH, labO);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => l.mineralType === 'OH')!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				const actionLog = output['#actionLog'];
+				const r1 = actionLog.find(a => a.type === 'reaction1');
+				const r2 = actionLog.find(a => a.type === 'reaction2');
+				assert.ok(r1 && r2, 'both reaction action log entries should exist');
+				assert.strictEqual(r1!.x, labH.pos.x, 'reaction1 x should match source lab 1');
+				assert.strictEqual(r1!.y, labH.pos.y, 'reaction1 y should match source lab 1');
+				assert.strictEqual(r2!.x, labO.pos.x, 'reaction2 x should match source lab 2');
+				assert.strictEqual(r2!.y, labO.pos.y, 'reaction2 y should match source lab 2');
 			});
 		}));
 
@@ -514,11 +539,20 @@ describe('Chemistry', () => {
 				room['#insertObject'](createLabWithResources(
 					new RoomPosition(24, 25, 'W1N1'), '100',
 					'ZO', 300, 2000));
+				// Lab with UH (attack boost) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(27, 25, 'W1N1'), '100',
+					'UH', 300, 2000));
 				// Worker creep adjacent to labs
 				room['#insertObject'](createCreep(
 					new RoomPosition(25, 26, 'W1N1'),
 					[C.WORK, C.WORK, C.CARRY, C.CARRY, C.MOVE, C.MOVE],
 					'worker', '100'));
+				// Attacker creep adjacent to labs
+				room['#insertObject'](createCreep(
+					new RoomPosition(26, 26, 'W1N1'),
+					[C.ATTACK, C.ATTACK, C.MOVE],
+					'attacker', '100'));
 				room['#level'] = 7;
 				room['#user'] =
 					room.controller!['#user'] = '100';
@@ -538,6 +572,54 @@ describe('Chemistry', () => {
 				// 2 CARRY parts * CARRY_CAPACITY(50) * 2 = 200 (up from 100)
 				assert.strictEqual(creep.store.getCapacity(), 2 * C.CARRY_CAPACITY * C.BOOSTS.carry.KH.capacity,
 					'boosted carry capacity should reflect KH multiplier');
+			});
+		}));
+
+		test('harvest boost increases work power', () => boostEffectSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labUO = labs.find(l => l.mineralType === 'UO')!;
+				labUO.boostCreep(Game.creeps.worker);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.worker;
+				// 2 WORK parts boosted with UO (harvest × 3)
+				const power = calculatePower(creep, C.WORK, C.HARVEST_POWER, 'harvest');
+				assert.strictEqual(power, 2 * C.HARVEST_POWER * C.BOOSTS.work.UO.harvest,
+					'boosted harvest power should reflect UO multiplier');
+			});
+		}));
+
+		test('move boost increases fatigue reduction', () => boostEffectSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labZO = labs.find(l => l.mineralType === 'ZO')!;
+				labZO.boostCreep(Game.creeps.worker);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.worker;
+				// 2 MOVE parts boosted with ZO (fatigue × 2)
+				const power = calculatePower(creep, C.MOVE, 2, 'fatigue');
+				assert.strictEqual(power, 2 * 2 * C.BOOSTS.move.ZO.fatigue,
+					'boosted move power should reflect ZO multiplier');
+			});
+		}));
+
+		test('attack boost increases attack power', () => boostEffectSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labUH = labs.find(l => l.mineralType === 'UH')!;
+				labUH.boostCreep(Game.creeps.attacker);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.attacker;
+				// 2 ATTACK parts boosted with UH (attack × 2)
+				const power = calculatePower(creep, C.ATTACK, C.ATTACK_POWER, 'attack');
+				assert.strictEqual(power, 2 * C.ATTACK_POWER * C.BOOSTS.attack.UH.attack,
+					'boosted attack power should reflect UH multiplier');
 			});
 		}));
 	});

--- a/src/mods/chemistry/test.ts
+++ b/src/mods/chemistry/test.ts
@@ -432,11 +432,14 @@ describe('Chemistry', () => {
 			await player('100', Game => {
 				const creep = Game.creeps.unboosted;
 				// LAB_UNBOOST_MINERAL (15) per boosted part: 2 TOUGH parts = 30 GO dropped
+				// After 1 tick of decay: ceil(30/1000) = 1 lost
+				const expectedDrop = 2 * C.LAB_UNBOOST_MINERAL;
+				const expectedAfterDecay = expectedDrop - Math.ceil(expectedDrop / C.ENERGY_DECAY);
 				const resources = creep.room.lookForAt(C.LOOK_RESOURCES, creep.pos);
 				const goResource = resources.find(r => r.resourceType === 'GO');
 				assert.ok(goResource, 'GO resource should be dropped at creep position');
-				assert.strictEqual(goResource!.amount, 2 * C.LAB_UNBOOST_MINERAL,
-					'dropped amount should be LAB_UNBOOST_MINERAL per boosted part');
+				assert.strictEqual(goResource!.amount, expectedAfterDecay,
+					'dropped amount should be LAB_UNBOOST_MINERAL per boosted part (minus 1 tick decay)');
 			});
 		}));
 
@@ -479,8 +482,10 @@ describe('Chemistry', () => {
 			});
 			await tick();
 			// Move the creep far away via poke
-			await poke('W1N1', '100', Game => {
-				Game.creeps.unboosted['#posId'] = new RoomPosition(10, 10, 'W1N1')['#id'];
+			await poke('W1N1', '100', (Game, room) => {
+				const creep = Game.creeps.unboosted;
+				creep.pos.x = 10;
+				creep.pos.y = 10;
 			});
 			await player('100', Game => {
 				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);

--- a/src/mods/chemistry/test.ts
+++ b/src/mods/chemistry/test.ts
@@ -1,0 +1,539 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { create as createLab } from './lab.js';
+
+// Helper to create a lab with resources pre-loaded
+function createLabWithResources(pos: RoomPosition, owner: string, mineral?: string, mineralAmount?: number, energy?: number) {
+	const lab = createLab(pos, owner);
+	if (energy) {
+		lab.store['#add'](C.RESOURCE_ENERGY, energy);
+	}
+	if (mineral && mineralAmount) {
+		lab.store['#add'](mineral as any, mineralAmount);
+	}
+	return lab;
+}
+
+describe('Chemistry', () => {
+
+	// =========================================================================
+	// runReaction
+	// =========================================================================
+	describe('runReaction', () => {
+		const reactionSim = simulate({
+			W1N1: room => {
+				// Output lab in the center
+				room['#insertObject'](createLab(new RoomPosition(25, 25, 'W1N1'), '100'));
+				// Source lab 1 with Hydrogen (within range 2)
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(25, 23, 'W1N1'), '100',
+					C.RESOURCE_HYDROGEN, 100, 0));
+				// Source lab 2 with Oxygen (within range 2)
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(25, 27, 'W1N1'), '100',
+					C.RESOURCE_OXYGEN, 100, 0));
+				room['#level'] = 7;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		});
+
+		test('runReaction produces correct compound', () => reactionSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => !l.mineralType)!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				assert.strictEqual(output.runReaction(labH, labO), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => l.mineralType === 'OH')!;
+				assert.ok(output, 'output lab should contain OH');
+				assert.strictEqual(output.store[C.RESOURCE_HYDROXIDE], C.LAB_REACTION_AMOUNT);
+			});
+		}));
+
+		test('runReaction uses per-product cooldown', () => reactionSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => !l.mineralType)!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				output.runReaction(labH, labO);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => l.mineralType === 'OH')!;
+				// OH has REACTION_TIME of 20, not the generic LAB_COOLDOWN of 10
+				assert.strictEqual(output.cooldown, C.REACTION_TIME.OH,
+					`cooldown should be REACTION_TIME.OH (${C.REACTION_TIME.OH}), not LAB_COOLDOWN (${C.LAB_COOLDOWN})`);
+			});
+		}));
+
+		test('runReaction deducts reagents from source labs', () => reactionSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => !l.mineralType)!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				output.runReaction(labH, labO);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				assert.strictEqual(labH.store[C.RESOURCE_HYDROGEN], 100 - C.LAB_REACTION_AMOUNT);
+				assert.strictEqual(labO.store[C.RESOURCE_OXYGEN], 100 - C.LAB_REACTION_AMOUNT);
+			});
+		}));
+
+		test('runReaction fails on cooldown', () => reactionSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => !l.mineralType)!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				output.runReaction(labH, labO);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(l => l.mineralType === 'OH')!;
+				const labH = labs.find(l => l.mineralType === C.RESOURCE_HYDROGEN)!;
+				const labO = labs.find(l => l.mineralType === C.RESOURCE_OXYGEN)!;
+				assert.strictEqual(output.runReaction(labH, labO), C.ERR_TIRED);
+			});
+		}));
+	});
+
+	// =========================================================================
+	// boostCreep
+	// =========================================================================
+	describe('boostCreep', () => {
+		const boostSim = simulate({
+			W1N1: room => {
+				// Lab with TOUGH boost mineral (GO = damage reduction) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(25, 25, 'W1N1'), '100',
+					'GO', 300, 2000));
+				// Lab with WORK boost mineral (UO = harvest) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(27, 25, 'W1N1'), '100',
+					'UO', 300, 2000));
+				// Creep with mixed body adjacent to labs
+				room['#insertObject'](createCreep(
+					new RoomPosition(25, 26, 'W1N1'),
+					[C.TOUGH, C.TOUGH, C.WORK, C.WORK, C.WORK, C.CARRY, C.MOVE, C.MOVE],
+					'boostme', '100'));
+				// Creep far away (out of range)
+				room['#insertObject'](createCreep(
+					new RoomPosition(10, 10, 'W1N1'),
+					[C.TOUGH, C.MOVE],
+					'faraway', '100'));
+				room['#level'] = 7;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		});
+
+		test('boostCreep method exists', () => boostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const lab = labs[0];
+				assert.strictEqual(typeof lab.boostCreep, 'function',
+					'StructureLab should have a boostCreep method');
+			});
+		}));
+
+		test('boostCreep returns OK for valid target', () => boostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				const result = labGO.boostCreep(Game.creeps.boostme);
+				assert.strictEqual(result, C.OK, 'boostCreep should return OK');
+			});
+		}));
+
+		test('boostCreep applies boost to body parts', () => boostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				labGO.boostCreep(Game.creeps.boostme);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.boostme;
+				const boostedParts = creep.body.filter(p => p.boost);
+				assert.ok(boostedParts.length > 0, 'creep should have boosted parts');
+				// GO boosts TOUGH parts
+				const boostedTough = creep.body.filter(p => p.type === C.TOUGH && p.boost === 'GO');
+				assert.strictEqual(boostedTough.length, 2, 'both TOUGH parts should be boosted with GO');
+			});
+		}));
+
+		test('boostCreep deducts resources from lab', () => boostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				labGO.boostCreep(Game.creeps.boostme);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				// 2 TOUGH parts * LAB_BOOST_MINERAL (30) = 60 mineral consumed
+				assert.strictEqual(labGO.store[C.RESOURCE_GHODIUM_OXIDE], 300 - (2 * C.LAB_BOOST_MINERAL));
+				// 2 TOUGH parts * LAB_BOOST_ENERGY (20) = 40 energy consumed
+				assert.strictEqual(labGO.store[C.RESOURCE_ENERGY], 2000 - (2 * C.LAB_BOOST_ENERGY));
+			});
+		}));
+
+		test('boostCreep respects bodyPartsCount limit', () => boostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labUO = labs.find(l => l.mineralType === 'UO')!;
+				// Only boost 1 of 3 WORK parts
+				labUO.boostCreep(Game.creeps.boostme, 1);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.boostme;
+				const boostedWork = creep.body.filter(p => p.type === C.WORK && p.boost === 'UO');
+				assert.strictEqual(boostedWork.length, 1, 'only 1 WORK part should be boosted');
+			});
+		}));
+
+		test('boostCreep fails out of range', () => boostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				const result = labGO.boostCreep(Game.creeps.faraway);
+				assert.strictEqual(result, C.ERR_NOT_IN_RANGE);
+			});
+		}));
+
+		test('boostCreep fails with insufficient resources', () => boostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				// Lab with GO has enough for TOUGH, but let's test with UO lab on a creep without WORK
+				// Actually test: bodyPartsCount > available matching unboosted parts
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				const result = labGO.boostCreep(Game.creeps.boostme, 5);
+				// Only 2 TOUGH parts available, requesting 5
+				assert.strictEqual(result, C.ERR_NOT_FOUND);
+			});
+		}));
+
+		test('boostCreep TOUGH parts boosted first, others last-to-first', () => boostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labUO = labs.find(l => l.mineralType === 'UO')!;
+				// Boost 2 of 3 WORK parts — should boost last two (reversed order)
+				labUO.boostCreep(Game.creeps.boostme, 2);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.boostme;
+				const workParts = creep.body.filter(p => p.type === C.WORK);
+				// body is [TOUGH, TOUGH, WORK, WORK, WORK, CARRY, MOVE, MOVE]
+				// Non-TOUGH parts are boosted last-to-first, so WORK indices 4,3 get boosted (not 2)
+				assert.ok(!workParts[0].boost, 'first WORK part should NOT be boosted');
+				assert.strictEqual(workParts[1].boost, 'UO', 'second WORK part should be boosted');
+				assert.strictEqual(workParts[2].boost, 'UO', 'third WORK part should be boosted');
+			});
+		}));
+	});
+
+	// =========================================================================
+	// reverseReaction
+	// =========================================================================
+	describe('reverseReaction', () => {
+		const reverseSim = simulate({
+			W1N1: room => {
+				// Source lab with OH compound to decompose
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(25, 25, 'W1N1'), '100',
+					'OH', 100, 0));
+				// Destination lab 1 (empty, will receive H)
+				room['#insertObject'](createLab(new RoomPosition(25, 23, 'W1N1'), '100'));
+				// Destination lab 2 (empty, will receive O)
+				room['#insertObject'](createLab(new RoomPosition(25, 27, 'W1N1'), '100'));
+				room['#level'] = 7;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		});
+
+		test('reverseReaction method exists', () => reverseSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const lab = labs[0];
+				assert.strictEqual(typeof lab.reverseReaction, 'function',
+					'StructureLab should have a reverseReaction method');
+			});
+		}));
+
+		test('reverseReaction returns OK for valid decomposition', () => reverseSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.mineralType === 'OH')!;
+				const empties = labs.filter(l => !l.mineralType);
+				const result = labOH.reverseReaction(empties[0], empties[1]);
+				assert.strictEqual(result, C.OK, 'reverseReaction should return OK');
+			});
+		}));
+
+		test('reverseReaction decomposes compound into reagents', () => reverseSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.mineralType === 'OH')!;
+				const empties = labs.filter(l => !l.mineralType);
+				labOH.reverseReaction(empties[0], empties[1]);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				// OH decomposes to H + O
+				const labOH = labs.find(l => l.pos.isEqualTo(25, 25))!;
+				assert.strictEqual(labOH.store[C.RESOURCE_HYDROXIDE], 100 - C.LAB_REACTION_AMOUNT,
+					'compound should be consumed');
+				// The two destination labs should have received reagents
+				const destLabs = labs.filter(l => !l.pos.isEqualTo(25, 25));
+				const minerals = destLabs.map(l => l.mineralType).sort();
+				assert.deepStrictEqual(minerals, [C.RESOURCE_HYDROGEN, C.RESOURCE_OXYGEN].sort(),
+					'destination labs should contain H and O');
+			});
+		}));
+
+		test('reverseReaction sets cooldown', () => reverseSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.mineralType === 'OH')!;
+				const empties = labs.filter(l => !l.mineralType);
+				labOH.reverseReaction(empties[0], empties[1]);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.pos.isEqualTo(25, 25))!;
+				assert.strictEqual(labOH.cooldown, C.REACTION_TIME.OH,
+					'cooldown should match REACTION_TIME for the compound');
+			});
+		}));
+
+		test('reverseReaction fails with lab1 == lab2', () => reverseSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.mineralType === 'OH')!;
+				const empty = labs.find(l => !l.mineralType)!;
+				const result = labOH.reverseReaction(empty, empty);
+				assert.strictEqual(result, C.ERR_INVALID_ARGS);
+			});
+		}));
+
+		test('reverseReaction fails on cooldown', () => reverseSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.mineralType === 'OH')!;
+				const empties = labs.filter(l => !l.mineralType);
+				labOH.reverseReaction(empties[0], empties[1]);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(l => l.pos.isEqualTo(25, 25))!;
+				const others = labs.filter(l => !l.pos.isEqualTo(25, 25));
+				assert.strictEqual(labOH.reverseReaction(others[0], others[1]), C.ERR_TIRED);
+			});
+		}));
+	});
+
+	// =========================================================================
+	// unboostCreep
+	// =========================================================================
+	describe('unboostCreep', () => {
+		const unboostSim = simulate({
+			W1N1: room => {
+				// Lab for unboosting (needs no specific mineral)
+				room['#insertObject'](createLab(new RoomPosition(25, 25, 'W1N1'), '100'));
+				// Lab with GO to apply boosts first
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(27, 25, 'W1N1'), '100',
+					'GO', 300, 2000));
+				// Creep to be boosted then unboosted
+				room['#insertObject'](createCreep(
+					new RoomPosition(26, 25, 'W1N1'),
+					[C.TOUGH, C.TOUGH, C.MOVE, C.MOVE],
+					'unboosted', '100'));
+				room['#level'] = 7;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		});
+
+		test('unboostCreep method exists', () => unboostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const lab = labs[0];
+				assert.strictEqual(typeof lab.unboostCreep, 'function',
+					'StructureLab should have an unboostCreep method');
+			});
+		}));
+
+		test('unboostCreep removes all boosts', () => unboostSim(async ({ player, tick }) => {
+			// First boost the creep
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				assert.strictEqual(labGO.boostCreep(Game.creeps.unboosted), C.OK);
+			});
+			await tick();
+			// Verify boost was applied
+			await player('100', Game => {
+				const creep = Game.creeps.unboosted;
+				assert.ok(creep.body.some(p => p.boost === 'GO'), 'creep should be boosted');
+			});
+			// Now unboost
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const unboostLab = labs.find(l => !l.mineralType)!;
+				assert.strictEqual(unboostLab.unboostCreep(Game.creeps.unboosted), C.OK);
+			});
+			await tick();
+			// Verify boosts removed
+			await player('100', Game => {
+				const creep = Game.creeps.unboosted;
+				const boostedParts = creep.body.filter(p => p.boost);
+				assert.strictEqual(boostedParts.length, 0, 'all boosts should be removed');
+			});
+		}));
+
+		test('unboostCreep drops resources at creep position', () => unboostSim(async ({ player, tick }) => {
+			// Boost then unboost
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				labGO.boostCreep(Game.creeps.unboosted);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const unboostLab = labs.find(l => !l.mineralType)!;
+				unboostLab.unboostCreep(Game.creeps.unboosted);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.unboosted;
+				// LAB_UNBOOST_MINERAL (15) per boosted part: 2 TOUGH parts = 30 GO dropped
+				const resources = creep.room.lookForAt(C.LOOK_RESOURCES, creep.pos);
+				const goResource = resources.find(r => r.resourceType === 'GO');
+				assert.ok(goResource, 'GO resource should be dropped at creep position');
+				assert.strictEqual(goResource!.amount, 2 * C.LAB_UNBOOST_MINERAL,
+					'dropped amount should be LAB_UNBOOST_MINERAL per boosted part');
+			});
+		}));
+
+		test('unboostCreep sets cooldown on lab', () => unboostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				labGO.boostCreep(Game.creeps.unboosted);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const unboostLab = labs.find(l => !l.mineralType)!;
+				unboostLab.unboostCreep(Game.creeps.unboosted);
+			});
+			await tick();
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const unboostLab = labs.find(l => l.pos.isEqualTo(25, 25))!;
+				assert.ok(unboostLab.cooldown > 0, 'lab should have a cooldown after unboosting');
+			});
+		}));
+
+		test('unboostCreep fails on unboosted creep', () => unboostSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const lab = labs.find(l => !l.mineralType)!;
+				const result = lab.unboostCreep(Game.creeps.unboosted);
+				assert.strictEqual(result, C.ERR_NOT_FOUND,
+					'should fail when creep has no boosts');
+			});
+		}));
+
+		test('unboostCreep fails out of range', () => unboostSim(async ({ player, tick, poke }) => {
+			// Boost the creep first
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labGO = labs.find(l => l.mineralType === 'GO')!;
+				labGO.boostCreep(Game.creeps.unboosted);
+			});
+			await tick();
+			// Move the creep far away via poke
+			await poke('W1N1', '100', Game => {
+				Game.creeps.unboosted['#posId'] = new RoomPosition(10, 10, 'W1N1')['#id'];
+			});
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const lab = labs.find(l => !l.mineralType)!;
+				const result = lab.unboostCreep(Game.creeps.unboosted);
+				assert.strictEqual(result, C.ERR_NOT_IN_RANGE);
+			});
+		}));
+	});
+
+	// =========================================================================
+	// Boost multiplier effects
+	// =========================================================================
+	describe('boost multipliers', () => {
+		const boostEffectSim = simulate({
+			W1N1: room => {
+				// Lab with UO (harvest boost) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(25, 25, 'W1N1'), '100',
+					'UO', 300, 2000));
+				// Lab with KH (carry boost) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(27, 25, 'W1N1'), '100',
+					'KH', 300, 2000));
+				// Lab with ZO (fatigue/move boost) + energy
+				room['#insertObject'](createLabWithResources(
+					new RoomPosition(23, 25, 'W1N1'), '100',
+					'ZO', 300, 2000));
+				// Worker creep adjacent to labs
+				room['#insertObject'](createCreep(
+					new RoomPosition(25, 26, 'W1N1'),
+					[C.WORK, C.WORK, C.CARRY, C.CARRY, C.MOVE, C.MOVE],
+					'worker', '100'));
+				room['#level'] = 7;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		});
+
+		test('carry boost increases store capacity', () => boostEffectSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labKH = labs.find(l => l.mineralType === 'KH')!;
+				labKH.boostCreep(Game.creeps.worker);
+			});
+			await tick();
+			await player('100', Game => {
+				const creep = Game.creeps.worker;
+				// KH gives capacity * 2 per boosted CARRY part
+				// 2 CARRY parts * CARRY_CAPACITY(50) * 2 = 200 (up from 100)
+				assert.strictEqual(creep.store.getCapacity(), 2 * C.CARRY_CAPACITY * C.BOOSTS.carry.KH.capacity,
+					'boosted carry capacity should reflect KH multiplier');
+			});
+		}));
+	});
+});

--- a/src/mods/combat/creep.ts
+++ b/src/mods/combat/creep.ts
@@ -101,7 +101,7 @@ Creep.prototype['#applyDamage'] = function(this: Creep, power, type, source) {
 			source instanceof Creep &&
 			!this.room.controller?.safeMode
 	) {
-		const counterAttack = calculatePower(this, C.ATTACK, C.ATTACK_POWER);
+		const counterAttack = calculatePower(this, C.ATTACK, C.ATTACK_POWER, 'attack');
 		if (counterAttack) {
 			const damage = captureDamage(source, counterAttack, C.EVENT_ATTACK_TYPE_HIT_BACK, null);
 			if (damage > 0) {

--- a/src/mods/combat/processor.ts
+++ b/src/mods/combat/processor.ts
@@ -20,7 +20,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<Creep | DestructibleStructure>(id)!;
 		if (checkAttack(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.ATTACK, C.ATTACK_POWER);
+			const power = calculatePower(creep, C.ATTACK, C.ATTACK_POWER, 'attack');
 			const damage = captureDamage(target, power, C.EVENT_ATTACK_TYPE_MELEE, creep);
 			if (damage > 0) {
 				target['#applyDamage'](damage, C.EVENT_ATTACK_TYPE_MELEE, creep);
@@ -43,7 +43,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<Creep | DestructibleStructure>(id)!;
 		if (checkRangedAttack(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER);
+			const power = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER, 'rangedAttack');
 			const damage = captureDamage(target, power, C.RANGED_ATTACK_POWER, creep);
 			if (damage > 0) {
 				target['#applyDamage'](damage, C.RANGED_ATTACK_POWER, creep);
@@ -71,7 +71,7 @@ const intents = [
 				Math.min(49, creep.pos.y + 3),
 				Math.min(49, creep.pos.x + 3),
 				(xx, yy) => new RoomPosition(xx, yy, creep.room.name));
-			const basePower = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER);
+			const basePower = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER, 'rangedMassAttack');
 			for (const pos of area) {
 
 				// Sort objects by layer
@@ -114,7 +114,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<Creep>(id)!;
 		if (checkHeal(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.HEAL, C.HEAL_POWER);
+			const power = calculatePower(creep, C.HEAL, C.HEAL_POWER, 'heal');
 			target.tickHitsDelta = (target.tickHitsDelta ?? 0) + power;
 			appendEventLog(target.room, {
 				event: C.EVENT_HEAL,
@@ -136,7 +136,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<Creep>(id)!;
 		if (checkRangedHeal(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.HEAL, C.RANGED_HEAL_POWER);
+			const power = calculatePower(creep, C.HEAL, C.RANGED_HEAL_POWER, 'rangedHeal');
 			target.tickHitsDelta = (target.tickHitsDelta ?? 0) + power;
 			appendEventLog(target.room, {
 				event: C.EVENT_HEAL,

--- a/src/mods/construction/processor.ts
+++ b/src/mods/construction/processor.ts
@@ -42,7 +42,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<ConstructionSite>(id)!;
 		if (checkBuild(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.WORK, C.BUILD_POWER);
+			const power = calculatePower(creep, C.WORK, C.BUILD_POWER, 'build');
 			const energy = Math.min(
 				target.progressTotal - target.progress,
 				creep.store.energy,
@@ -63,7 +63,7 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<DestructibleStructure>(id)!;
 		if (checkDismantle(creep, target) === C.OK) {
-			const effect = Math.min(calculatePower(creep, C.WORK, C.DISMANTLE_POWER), target.hits);
+			const effect = Math.min(calculatePower(creep, C.WORK, C.DISMANTLE_POWER, 'dismantle'), target.hits);
 			if (effect > 0) {
 				const energy = Math.floor(effect * C.DISMANTLE_COST);
 				const overflow = Math.max(energy - creep.store.getFreeCapacity(C.RESOURCE_ENERGY), 0);
@@ -86,7 +86,7 @@ const intents = [
 		const target = Game.getObjectById<DestructibleStructure>(id)!;
 		if (checkRepair(creep, target) === C.OK) {
 			const effect = Math.min(
-				calculatePower(creep, C.WORK, C.REPAIR_POWER),
+				calculatePower(creep, C.WORK, C.REPAIR_POWER, 'repair'),
 				target.hitsMax - target.hits,
 				creep.store.energy / C.REPAIR_COST);
 			if (effect > 0) {

--- a/src/mods/controller/processor.ts
+++ b/src/mods/controller/processor.ts
@@ -168,7 +168,7 @@ const intents = [
 		if (CreepLib.checkUpgradeController(creep, controller) === C.OK) {
 			// Calculate power, deduct energy
 			controller.upgradePowerThisTick ??= 0;
-			let power = calculatePower(creep, C.WORK, C.UPGRADE_CONTROLLER_POWER);
+			let power = calculatePower(creep, C.WORK, C.UPGRADE_CONTROLLER_POWER, 'upgradeController');
 			if (controller.level === 8) {
 				power = Math.min(power, C.CONTROLLER_MAX_UPGRADE_PER_TICK - controller.upgradePowerThisTick);
 			}

--- a/src/mods/creep/creep.ts
+++ b/src/mods/creep/creep.ts
@@ -431,9 +431,9 @@ export function calculateCarry(body: Creep['body']) {
 		part => {
 			if (part.type !== C.CARRY) return 0;
 			if (part.boost) {
-				const boosts = (C.BOOSTS as any)[C.CARRY]?.[part.boost];
-				if (boosts?.capacity) {
-					return C.CARRY_CAPACITY * boosts.capacity;
+				const multiplier = (C.BOOSTS as BoostsLookup)[C.CARRY]?.[part.boost]?.capacity;
+				if (multiplier) {
+					return C.CARRY_CAPACITY * multiplier;
 				}
 			}
 			return C.CARRY_CAPACITY;
@@ -537,13 +537,16 @@ export function calculateCost(creep: Creep) {
 	return Fn.accumulate(creep.body, bodyPart => C.BODYPART_COST[bodyPart.type]);
 }
 
+type BoostEffects = Partial<Record<string, number>>;
+type BoostsLookup = Partial<Record<string, Partial<Record<string, BoostEffects>>>>;
+
 export function calculatePower(creep: Creep, part: PartType, power: number, boostMethod?: string) {
 	return Fn.accumulate(creep.body, bodyPart => {
 		if (bodyPart.type === part && bodyPart.hits > 0) {
 			if (boostMethod && bodyPart.boost) {
-				const boosts = (C.BOOSTS as any)[part]?.[bodyPart.boost];
-				if (boosts?.[boostMethod]) {
-					return power * boosts[boostMethod];
+				const multiplier = (C.BOOSTS as BoostsLookup)[part]?.[bodyPart.boost]?.[boostMethod];
+				if (multiplier) {
+					return power * multiplier;
 				}
 			}
 			return power;

--- a/src/mods/creep/creep.ts
+++ b/src/mods/creep/creep.ts
@@ -428,7 +428,16 @@ export function create(pos: RoomPosition, parts: PartType[], name: string, owner
 export function calculateCarry(body: Creep['body']) {
 	return Fn.accumulate(
 		Fn.filter(body, part => part.hits > 0),
-		part => part.type === C.CARRY ? C.CARRY_CAPACITY : 0);
+		part => {
+			if (part.type !== C.CARRY) return 0;
+			if (part.boost) {
+				const boosts = (C.BOOSTS as any)[C.CARRY]?.[part.boost];
+				if (boosts?.capacity) {
+					return C.CARRY_CAPACITY * boosts.capacity;
+				}
+			}
+			return C.CARRY_CAPACITY;
+		});
 }
 
 registerObstacleChecker(params => {
@@ -528,9 +537,15 @@ export function calculateCost(creep: Creep) {
 	return Fn.accumulate(creep.body, bodyPart => C.BODYPART_COST[bodyPart.type]);
 }
 
-export function calculatePower(creep: Creep, part: PartType, power: number) {
+export function calculatePower(creep: Creep, part: PartType, power: number, boostMethod?: string) {
 	return Fn.accumulate(creep.body, bodyPart => {
 		if (bodyPart.type === part && bodyPart.hits > 0) {
+			if (boostMethod && bodyPart.boost) {
+				const boosts = (C.BOOSTS as any)[part]?.[bodyPart.boost];
+				if (boosts?.[boostMethod]) {
+					return power * boosts[boostMethod];
+				}
+			}
 			return power;
 		}
 		return 0;

--- a/src/mods/creep/processor.ts
+++ b/src/mods/creep/processor.ts
@@ -110,7 +110,7 @@ const intents = [
 					let weight = 0;
 					let member: Creep | undefined = creep;
 					while (true) {
-						power += CreepLib.calculatePower(member, C.MOVE, 1);
+						power += CreepLib.calculatePower(member, C.MOVE, 1, 'fatigue');
 						weight += CreepLib.calculateWeight(member);
 						const puller = pulledToPuller.get(member);
 						if (puller) {
@@ -273,7 +273,7 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 	const puller = pulledToPuller.get(creep);
 	if (creep.fatigue > 0 || puller) {
 		// Calculate power, reduce own fatigue
-		let power = CreepLib.calculatePower(creep, C.MOVE, 2);
+		let power = CreepLib.calculatePower(creep, C.MOVE, 2, 'fatigue');
 		const delta = Math.min(creep.fatigue, power);
 		creep.fatigue -= delta;
 		power -= delta;

--- a/src/mods/mineral/processor.ts
+++ b/src/mods/mineral/processor.ts
@@ -9,7 +9,7 @@ import { Fn } from 'xxscreeps/utility/fn.js';
 import { Mineral } from './mineral.js';
 
 registerHarvestProcessor(Mineral, (creep, mineral) => {
-	const power = calculatePower(creep, C.WORK, C.HARVEST_MINERAL_POWER);
+	const power = calculatePower(creep, C.WORK, C.HARVEST_MINERAL_POWER, 'harvest');
 	const amount = Math.min(mineral.mineralAmount, power);
 	const overflow = Math.max(amount - creep.store.getFreeCapacity(mineral.mineralType), 0);
 	creep.store['#add'](mineral.mineralType, amount - overflow);

--- a/src/mods/source/processor.ts
+++ b/src/mods/source/processor.ts
@@ -15,7 +15,7 @@ import { StructureKeeperLair } from './keeper-lair.js';
 import { Source } from './source.js';
 
 registerHarvestProcessor(Source, (creep, source) => {
-	const power = calculatePower(creep, C.WORK, C.HARVEST_POWER);
+	const power = calculatePower(creep, C.WORK, C.HARVEST_POWER, 'harvest');
 	const energy = Math.min(source.energy, power);
 	const overflow = Math.max(energy - creep.store.getFreeCapacity('energy'), 0);
 	creep.store['#add'](C.RESOURCE_ENERGY, energy - overflow);


### PR DESCRIPTION
## Summary

Brings StructureLab close to full parity with the official Screeps engine. Adds three missing lab methods, fixes pre-existing bugs in runReaction, adds boost multiplier support to all relevant processors, and includes a comprehensive test suite. Now that boosting is fully working, it exposes remaining work needed to utilize boosted TOUGH parts in damage reduction. That was considered out of scope for this feature, but remains needed in a separate PR in the future.

## What changed

### New lab methods
- **boostCreep**: Full validation + processor. TOUGH parts boosted first (ascending index), all others last-to-first. Deducts mineral + energy per part, recalculates carry capacity. Rejects spawning creeps.
- **reverseReaction**: Decomposes compounds back into reagents. Validates destination lab compatibility and capacity. Uses `getReactionVariants` to find valid reagent pairs.
- **unboostCreep**: Strips all boosts, drops mineral resources at creep position, sets cooldown based on recursive total reaction time. Matches official engine structure including the `LAB_UNBOOST_ENERGY` drop path (currently a no-op since the constant is 0).

### Boost multiplier support
- `calculatePower` gains an optional `boostMethod` parameter that applies `BOOSTS[part][boost][method]` multipliers.
- `calculateCarry` applies carry boost multipliers to store capacity.
- All 12 `calculatePower` call sites across 7 processor files updated with their boost method strings (attack, rangedAttack, rangedMassAttack, heal, rangedHeal, build, dismantle, repair, upgradeController, fatigue, harvest).

### Pre-existing bug fixes
- **runReaction cooldown**: Used generic `LAB_COOLDOWN` (10) instead of per-product `REACTION_TIME[product]`. OH reactions had a cooldown of 10 instead of 20.
- **runReaction action log**: Both `reaction1` and `reaction2` entries pointed to the left source lab position, causing both visual beams to originate from the same lab.
- **runReaction validation order**: Cooldown check was after target/range checks; moved to match official order.
- **Backend renderer key**: Output key was `reaction` instead of `runReaction`, not matching the official client format.
- **Deprecated mineralAmount getter**: Could index store with `undefined` when no mineral present.

### Validation ordering
All four lab methods now match the official engine's error check ordering. Each method was compared against `screeps/engine` `src/game/structures.js` and reordered to match.

### Test infrastructure
- Fixed test shard state leakage between `simulate()` calls by giving each shard unique `local://` URLs.
- 30-test chemistry suite covering runReaction, boostCreep, reverseReaction, unboostCreep, and boost multiplier effects.

## Divergences from official engine

### Structural
- **Action log format**: The official engine stores reaction visuals as a single `actionLog.runReaction = {x1,y1,x2,y2}`. xxscreeps's action log schema only supports `{type,x,y,time}` per entry, so we use paired entries (`reaction1`/`reaction2` and `reverseReaction1`/`reverseReaction2`) combined in the backend renderer. The rendered output matches the official client format (`runReaction` and `reverseReaction` keys).

### Not included
- **TOUGH damage reduction**: Boosted TOUGH parts should reduce incoming damage via `BOOSTS.tough.*.damage` multipliers. In the official engine this is implemented as a body-part-aware damage distribution pass that iterates front-to-back, computing effective absorption per part based on boost ratios. xxscreeps currently applies damage as a simple `hits -= power` with no body-part-level distribution, so implementing TOUGH reduction requires reworking the damage system rather than adding a multiplier to an existing call site. This is tracked separately.
- **`ERR_RCL_NOT_ENOUGH`**: The official engine checks whether a structure is valid for the current RCL and returns `ERR_RCL_NOT_ENOUGH` if not. xxscreeps's `isActive()` is stubbed to always return `true`, so this check is missing across all structure types, not just labs. This is a broader xxscreeps gap that merits a separate PR.

## Test plan
- [x] All 30 chemistry tests pass
- [x] All pre-existing tests pass (no regressions)
- [x] Verify runReaction visual beams point to correct source labs in browser client
- [x] Verify reverseReaction visual beams appear in browser client
- [x] Test boostCreep/unboostCreep with a running bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)