### PR TITLE
fix: Node 24 compatibility — import.meta.resolve and circular dependency TDZ

### DIFF
--- a/src/config/entry.ts
+++ b/src/config/entry.ts
@@ -94,14 +94,14 @@ if (missingFlags.length) {
 				const command = commands[specifier];
 				if (command) {
 					// Found run alias
-					return await import.meta.resolve!(`${new URL(command, new URL('../..', import.meta.url))}`);
+					return import.meta.resolve(`${new URL(command, new URL('../..', import.meta.url))}`);
 				} else {
 					// Try to parse as file:// URL, probably a self-invoking worker
 					try {
 						return `${new URL(specifier)}`;
 					} catch (err) {}
 					// Resolve as file from cwd
-					return await import.meta.resolve!(join(process.cwd(), specifier), import.meta.url);
+					return import.meta.resolve(join(process.cwd(), specifier));
 				}
 			} catch (error: any) {
 				if (error.code !== 'ERR_MODULE_NOT_FOUND') {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,7 +11,7 @@ import './mods/index.js';
 if (isTopThread) {
 	const schema = await async function() {
 		try {
-			const path = await import.meta.resolve!('./mods.static/config.schema.json', import.meta.url);
+			const path = import.meta.resolve('./mods.static/config.schema.json');
 			return JSON.parse(await fs.readFile(new URL(path), 'utf8'));
 		} catch (err) {}
 	}();

--- a/src/config/mods/index.ts
+++ b/src/config/mods/index.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../declarations.d.ts" />
 import fs from 'node:fs/promises';
 import { configDefaults } from 'xxscreeps/config/config.js';
-import config, { configPath } from 'xxscreeps/config/raw.js';
+import config from 'xxscreeps/config/raw.js';
 
 type Provide = 'backend' | 'config' | 'constants' | 'driver' | 'game' | 'processor' | 'storage' | 'test';
 export type Manifest = {
@@ -17,18 +17,21 @@ const mods: {
 }[] = [];
 const stack: string[] = [];
 const resolved = new Set<string>();
-const baseUrl = configPath;
 const version = 5;
 async function resolve(specifiers: string[]) {
 	const imports = await Promise.all([ ...specifiers ].sort().map(async specifier => {
+		// Node 24 ignores the second argument to import.meta.resolve, so bare
+		// specifiers always resolve from *this* file's package scope. That
+		// happens to work for built-in xxscreeps/* mods but would break for
+		// third-party mods installed outside this package tree.
 		const url = await async function() {
 			try {
-				return import.meta.resolve!(`${specifier}/index.js`, `${baseUrl}`);
+				return import.meta.resolve(`${specifier}/index.js`);
 			} catch {
 				try {
-					return import.meta.resolve!(`${specifier}.js`, `${baseUrl}`);
+					return import.meta.resolve(`${specifier}.js`);
 				} catch {
-					return import.meta.resolve!(specifier, `${baseUrl}`);
+					return import.meta.resolve(specifier);
 				}
 			}
 		}();
@@ -69,14 +72,19 @@ const cached = await async function() {
 	} catch (err) {}
 }();
 if (cached?.json !== JSON.stringify(mods) || cached.version !== version) {
-	// Given a specifier fragment this return all mods which export it
+	// Given a specifier fragment this return all mods which export it.
+	// Uses new URL() instead of import.meta.resolve because these are
+	// relative paths against each mod's URL — import.meta.resolve's
+	// second argument is ignored on Node 24.
 	const resolveWithinMods = async (specifier: string) => {
 		const resolved = await Promise.all(mods.map(async ({ provides, url }) => {
 			if (provides.includes(specifier as never)) {
+				const primary = new URL(`./${specifier}.js`, url);
 				try {
-					return import.meta.resolve!(`./${specifier}.js`, `${url}`);
+					await fs.access(primary);
+					return `${primary}`;
 				} catch {
-					return import.meta.resolve!(`./${specifier}/index.js`, `${url}`);
+					return `${new URL(`./${specifier}/index.js`, url)}`;
 				}
 			}
 		}));
@@ -109,7 +117,7 @@ if (cached?.json !== JSON.stringify(mods) || cached.version !== version) {
 			// Merge JSON schema
 			const schemaOutput = new URL('config.schema.json', outDir);
 			const inputs = [
-				await import.meta.resolve!('xxscreeps/config/config.js'),
+				import.meta.resolve('xxscreeps/config/config.js'),
 				...await resolveWithinMods('config'),
 			];
 			const json = (await Promise.all(inputs.map(async path => {
@@ -147,9 +155,9 @@ export async function importMods(provides: Provide) {
 	for (const mod of mods) {
 		if (mod.provides.includes(provides)) {
 			try {
-				await import(await import.meta.resolve!(`./${provides}.js`, `${mod.url}`));
+				await import(new URL(`./${provides}.js`, mod.url).href);
 			} catch (e) {
-				await import(await import.meta.resolve!(`./${provides}/index.js`, `${mod.url}`));
+				await import(new URL(`./${provides}/index.js`, mod.url).href);
 			}
 		}
 	}

--- a/src/engine/db/storage/local/keyval.ts
+++ b/src/engine/db/storage/local/keyval.ts
@@ -7,7 +7,7 @@ import { Fn } from 'xxscreeps/utility/fn.js';
 import { latin1ToBuffer, typedArrayToString } from 'xxscreeps/utility/string.js';
 import { connect, makeClient, makeHost } from './responder.js';
 import { SortedSet } from './sorted-set.js';
-import { registerStorageProvider } from 'xxscreeps/engine/db/storage/index.js';
+import { registerStorageProvider } from 'xxscreeps/engine/db/storage/register.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
 import { BlobStorage } from './blob.js';
 

--- a/src/engine/db/storage/local/pubsub.ts
+++ b/src/engine/db/storage/local/pubsub.ts
@@ -4,7 +4,7 @@ import { MessageChannel, parentPort } from 'node:worker_threads';
 import { Deferred, listen } from 'xxscreeps/utility/async.js';
 import { getOrSet, staticCast } from 'xxscreeps/utility/utility.js';
 import { isTopThread } from 'xxscreeps/utility/worker.js';
-import { registerStorageProvider } from '../index.js';
+import { registerStorageProvider } from '../register.js';
 
 type Listener = (message: string) => void;
 

--- a/src/scripts/scrape-world.ts
+++ b/src/scripts/scrape-world.ts
@@ -47,7 +47,7 @@ const argv = checkArguments({
 const dontOverwrite = argv['dont-overwrite'];
 const shardOnly = argv['shard-only'];
 const jsonSource = argv.argv[0] ??
-	new URL('../init_dist/db.json', await import.meta.resolve!('@screeps/launcher', import.meta.url));
+	new URL('../init_dist/db.json', import.meta.resolve('@screeps/launcher'));
 
 function forUser(userId: string | null) {
 	return userId === 'f4b532d08c3952a' ? '1' : userId;
@@ -89,7 +89,7 @@ if ((rcInfo?.size ?? 0) === 0) {
 		fetched.add(specifier);
 		try {
 			// Find `package.json` for this specifier
-			const indexPath = new URL(await import.meta.resolve!(specifier, `${configPath}`));
+			const indexPath = new URL(import.meta.resolve(specifier));
 			const packagePath = await async function() {
 				let path = indexPath;
 				while (true) {


### PR DESCRIPTION
## Summary
Discovered while running the test suite to verify an unrelated fix (laverdet/xxscreeps#84). Tests immediately crashed with two errors:

1. `ReferenceError: Cannot access 'providers' before initialization` — circular dependency TDZ in local storage providers
2. `Error: Cannot find module 'dist/config/mods/test/index.js'` — `importMods` resolving relative paths against the wrong base

Tracing the root cause revealed that Node 24 silently ignores the second argument to `import.meta.resolve`, breaking all call sites that relied on it for base URL resolution. The remaining call sites were not immediately apparent because:

- **`resolve()`**: bare `xxscreeps/*` specifiers happen to resolve correctly from the package's own scope (the default), masking the lost `baseUrl`
- **`resolveWithinMods()`**: only runs when the manifest cache is stale — existing caches generated on older Node versions continued to work

### Changes
- `resolveWithinMods`: use `new URL()` for relative path construction and `fs.access()` for file existence probing (replaces `import.meta.resolve` try/catch which no longer throws for wrong base)
- `importMods`: use `new URL().href` for relative mod path resolution
- `resolve()`: drop ignored second arg and document the remaining limitation for third-party mods outside the xxscreeps package tree
- Remove redundant `import.meta.url` second args from `config/index.ts`, `entry.ts`, and `scrape-world.ts`
- Drop non-null assertions (`!`) on `import.meta.resolve` — always defined under nodenext module resolution
- Import `registerStorageProvider` from `register.js` instead of barrel `index.js` to fix circular-dependency TDZ crash in local storage providers

## Test plan
- `npm run build` — clean compilation
- `npm test` — all existing tests pass
- Deleted `manifest.cached.js` and verified `resolveWithinMods` regenerates correct mod bundles via `fs.access()` fallback
- Server starts and runs correctly on Node 24.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)