### PR TITLE
fix: Improve test runner output and reliability

### DIFF
--- a/src/mods/chemistry/test.ts
+++ b/src/mods/chemistry/test.ts
@@ -420,13 +420,10 @@ describe('Chemistry', () => {
 				assert.strictEqual(labGO.boostCreep(Game.creeps.unboosted), C.OK);
 			});
 			await tick();
-			// Verify boost was applied
+			// Verify boost was applied, then unboost
 			await player('100', Game => {
 				const creep = Game.creeps.unboosted;
 				assert.ok(creep.body.some(part => part.boost === 'GO'), 'creep should be boosted');
-			});
-			// Now unboost
-			await player('100', Game => {
 				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
 				const unboostLab = labs.find(lab => !lab.mineralType)!;
 				assert.strictEqual(unboostLab.unboostCreep(Game.creeps.unboosted), C.OK);

--- a/src/test/context.ts
+++ b/src/test/context.ts
@@ -25,9 +25,9 @@ let failed = 0;
 const testTimeout = 10000;
 
 // Catch unhandled rejections so async failures don't vanish silently
-process.on('unhandledRejection', (err: any) => {
+process.on('unhandledRejection', reason => {
 	++failed;
-	console.error('\nUnhandled rejection:', err?.stack ?? err);
+	console.log('\nUnhandled rejection:', reason);
 });
 
 export async function flush() {
@@ -86,7 +86,7 @@ export function test(name: string, fn: Callback) {
 			let timer: NodeJS.Timeout;
 			await Promise.race([
 				Promise.resolve(fn()).finally(() => clearTimeout(timer)),
-				new Promise((_, reject) => {
+				new Promise((_resolve, reject) => {
 					timer = setTimeout(() => reject(new Error(`Test "${name}" timed out after ${testTimeout}ms`)), testTimeout);
 				}),
 			]);
@@ -94,14 +94,14 @@ export function test(name: string, fn: Callback) {
 			if (argv.length === 0) {
 				process.stdout.write('.');
 			}
-		} catch (err: any) {
+		} catch (err) {
 			++failed;
 			const names = [ ...stack.map(frame => frame.name), context?.name, name ].filter(nonNullPredicate);
 			if (argv.length === 0) {
 				console.log(`\n  FAIL: ${name}`);
-				console.log(`  Isolate with: npx xxscreeps test ${names.map(name => `"${name}"`).join(' ')}`);
+				console.log(`  Isolate with: npx xxscreeps test ${names.map(nn => `"${nn}"`).join(' ')}`);
 			}
-			console.log(err.stack);
+			console.log(err);
 		}
 	});
 }

--- a/src/test/context.ts
+++ b/src/test/context.ts
@@ -20,6 +20,15 @@ const checkFilter = (name: string) => {
 
 let context: Context | undefined = makeFrame();
 const stack: Context[] = [];
+let passed = 0;
+let failed = 0;
+const testTimeout = 10000;
+
+// Catch unhandled rejections so async failures don't vanish silently
+process.on('unhandledRejection', (err: any) => {
+	++failed;
+	console.error('\nUnhandled rejection:', err?.stack ?? err);
+});
 
 export async function flush() {
 	if (!context) {
@@ -28,11 +37,20 @@ export async function flush() {
 	for (const test of context.tests) {
 		await test();
 	}
-	console.log();
+	if (argv.length === 0 && context.tests.length > 0) {
+		process.stdout.write('\n');
+	}
 	for (const child of context.children) {
 		await child();
 	}
 	context = undefined;
+}
+
+export function summary() {
+	console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+	if (failed > 0) {
+		process.exitCode = 1;
+	}
 }
 
 export function describe(name: string, fn: Callback): void {
@@ -43,7 +61,7 @@ export function describe(name: string, fn: Callback): void {
 	}
 	context.children.push(async () => {
 		if (argv.length === 0) {
-			process.stdout.write('  '.repeat(stack.length) + name);
+			process.stdout.write('  '.repeat(stack.length) + name + ' ');
 		}
 		const frame = makeFrame(name);
 		stack.push(context!);
@@ -65,14 +83,23 @@ export function test(name: string, fn: Callback) {
 	}
 	context.tests.push(async () => {
 		try {
-			await fn();
+			let timer: NodeJS.Timeout;
+			await Promise.race([
+				Promise.resolve(fn()).finally(() => clearTimeout(timer)),
+				new Promise((_, reject) => {
+					timer = setTimeout(() => reject(new Error(`Test "${name}" timed out after ${testTimeout}ms`)), testTimeout);
+				}),
+			]);
+			++passed;
 			if (argv.length === 0) {
 				process.stdout.write('.');
 			}
 		} catch (err: any) {
+			++failed;
 			const names = [ ...stack.map(frame => frame.name), context?.name, name ].filter(nonNullPredicate);
 			if (argv.length === 0) {
-				console.log(`\nTest "${name}" failed. Isolate with: npx xxscreeps test ${names.map(name => `"${name}"`).join(' ')}`);
+				console.log(`\n  FAIL: ${name}`);
+				console.log(`  Isolate with: npx xxscreeps test ${names.map(name => `"${name}"`).join(' ')}`);
 			}
 			console.log(err.stack);
 		}

--- a/src/test/run.ts
+++ b/src/test/run.ts
@@ -1,5 +1,5 @@
 import { importMods } from 'xxscreeps/config/mods/index.js';
-import { flush } from './context.js';
+import { flush, summary } from './context.js';
 import './import.js';
 
 await importMods('test');
@@ -8,3 +8,6 @@ try {
 } catch (err) {
 	console.log(err);
 }
+summary();
+// Force exit — test modules hold db/shard connections that keep the event loop alive
+process.exit();

--- a/src/test/run.ts
+++ b/src/test/run.ts
@@ -7,6 +7,7 @@ try {
 	await flush();
 } catch (err) {
 	console.log(err);
+	process.exitCode = 1;
 }
 summary();
 // Force exit — test modules hold db/shard connections that keep the event loop alive


### PR DESCRIPTION
## Summary
- Add pass/fail counters and summary line (always printed, including filtered runs)
- Add 10-second per-test timeout to catch hung tests (timer properly cleared on success)
- Catch `unhandledRejection` — logs and counts as failure instead of silently vanishing; remaining tests still run
- Set `process.exitCode = 1` on any failure; `process.exit()` after summary to drain db/shard connections that keep the event loop alive
- Cleaner failure output: `FAIL:` prefix with isolate command on a separate line

### Note on `process.exit()`
Test modules hold db/shard connections that prevent the event loop from draining naturally. The test framework has no teardown mechanism to close these, so `process.exit()` is used as a pragmatic solution. If a proper cleanup path is preferred, happy to add an `afterAll`-style hook instead.

## Verified
- `npx xxscreeps test` —  all tests pass, dots and summary displayed
- `npx xxscreeps test Observer observer_range` — filtered run shows summary confirming test ran
- Exit code 0 on success, 1 on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)