### PR TITLE
fix: renewCreep/recycleCreep throw on undefined instead of returning ERR_INVALID_TARGET

### DIFF
--- a/src/mods/spawn/spawn.ts
+++ b/src/mods/spawn/spawn.ts
@@ -265,14 +265,15 @@ registerBuildableStructure(C.STRUCTURE_SPAWN, {
 export function checkRecycleCreep(spawn: StructureSpawn, creep: Creep) {
 	return chainIntentChecks(
 		() => checkMyStructure(spawn, StructureSpawn),
-		() => checkCommon(creep),
 		() => checkTarget(creep, Creep),
+		() => checkCommon(creep),
 		() => checkRange(spawn, creep, 1));
 }
 
 export function checkRenewCreep(spawn: StructureSpawn, creep: Creep) {
 	return chainIntentChecks(
 		() => checkMyStructure(spawn, StructureSpawn),
+		() => checkTarget(creep, Creep),
 		() => checkCommon(creep),
 		() => checkRange(spawn, creep, 1),
 		() => {

--- a/src/mods/spawn/test.ts
+++ b/src/mods/spawn/test.ts
@@ -100,6 +100,18 @@ describe('Spawn', () => {
 		});
 	}));
 
+	test('renewCreep undefined', () => simulation(async ({ player }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.spawns.Spawn1.renewCreep(undefined as any), C.ERR_INVALID_TARGET);
+		});
+	}));
+
+	test('recycleCreep undefined', () => simulation(async ({ player }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.spawns.Spawn1.recycleCreep(undefined as any), C.ERR_INVALID_TARGET);
+		});
+	}));
+
 	test('destroy + unclaim', () => simulation(async ({ player, tick }) => {
 		await player('100', Game => {
 			assert.strictEqual(Game.spawns.Spawn1.spawnCreep([ C.MOVE ], 'creep'), C.OK);


### PR DESCRIPTION
## Summary
- `StructureSpawn.renewCreep(undefined)` and `recycleCreep(undefined)` throw `TypeError: Cannot read properties of undefined (reading 'my')` instead of returning `ERR_INVALID_TARGET`
- Root cause: `checkCommon` (which accesses `creep.my`) runs before `checkTarget` (which guards against null/undefined) in both `checkRenewCreep` and `checkRecycleCreep`
- Fix: reorder checks so `checkTarget(creep, Creep)` runs before `checkCommon(creep)`, matching the guard ordering used in combat/heal check functions
- Adds two test cases verifying both methods return `ERR_INVALID_TARGET` for undefined input

Closes #57

## Verification
- New tests reproduce the bug against unfixed code (TypeError thrown)
- New tests pass after fix (ERR_INVALID_TARGET returned)
- Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)