### PR TITLE
fix: RawMemory.segments data lost after global reset

### DIFF
--- a/src/mods/memory/driver.ts
+++ b/src/mods/memory/driver.ts
@@ -31,6 +31,10 @@ hooks.register('runnerConnector', player => {
 	let foreignSegmentRequest: TickResult['foreignSegmentRequest'] = null;
 	return [ undefined, {
 		async initialize(payload) {
+			// Reset state that mirrors the runtime sandbox
+			activeSegments = new Set<number>();
+			nextSegments = undefined;
+			foreignSegmentRequest = null;
 			// Get current memory payload
 			payload.memoryBlob = await loadUserMemoryBlob(shard, userId);
 		},

--- a/src/mods/memory/driver.ts
+++ b/src/mods/memory/driver.ts
@@ -26,13 +26,13 @@ declare module 'xxscreeps/engine/runner/index.js' {
 
 hooks.register('runnerConnector', player => {
 	const { shard, userId } = player;
-	let activeSegments = new Set<number>();
+	let activeSegments: Set<number>;
 	let nextSegments: Set<number> | undefined;
 	let foreignSegmentRequest: TickResult['foreignSegmentRequest'] = null;
 	return [ undefined, {
 		async initialize(payload) {
 			// Reset state that mirrors the runtime sandbox
-			activeSegments = new Set<number>();
+			activeSegments = new Set();
 			nextSegments = undefined;
 			foreignSegmentRequest = null;
 			// Get current memory payload


### PR DESCRIPTION
## Summary

Fixes #56. `RawMemory.segments` data is lost after a global reset (code push or server restart) even though the data remains in the database.

- The runner connector's closure-scoped `activeSegments` Set persists across sandbox resets while the runtime-side state is wiped (new V8 isolate)
- When user code re-requests the same segments via `setActiveSegments`, the driver's `refresh()` skips the DB read because `activeSegments.has(id)` still returns true for the old IDs
- Reset all three mirror-state variables (`activeSegments`, `nextSegments`, `foreignSegmentRequest`) to their initial values in `initialize()`, which runs on every sandbox creation

## Reproduction

1. Write data to a segment and call `setActiveSegments`
2. Push code (triggers global reset)
3. Call `setActiveSegments` with the same IDs
4. Wait a tick — segments are empty despite data being in the DB

## Verification

Tested on a live xxscreeps server:

| Scenario | Segment after reset |
|---|---|
| Without fix | `"EMPTY"` |
| With fix | Original data preserved |