### PR TITLE
fix: construction sites should not block creep movement

### DIFF
--- a/src/game/path-finder/index.ts
+++ b/src/game/path-finder/index.ts
@@ -69,6 +69,7 @@ export function roomSearch(origin: RoomPosition, goals: RoomPosition[], options:
 				const check = makeObstacleChecker({
 					ignoreCreeps,
 					ignoreDestructibleStructures,
+					pathing: true,
 					room,
 					user: me,
 				});

--- a/src/game/path-finder/obstacle.ts
+++ b/src/game/path-finder/obstacle.ts
@@ -7,6 +7,7 @@ type MovementParameters = {
 	checkTerrain?: boolean | undefined;
 	ignoreCreeps?: boolean | undefined;
 	ignoreDestructibleStructures?: boolean | undefined;
+	pathing?: boolean | undefined;
 	room: Room;
 	user: string;
 };

--- a/src/mods/construction/construction-site.ts
+++ b/src/mods/construction/construction-site.ts
@@ -68,8 +68,11 @@ export function checkRemove(site: ConstructionSite) {
 	return C.OK;
 }
 
-// Register path finder logic
+// Construction sites are only obstacles during pathfinding, never during movement
 registerObstacleChecker(params => {
+	if (!params.pathing) {
+		return null;
+	}
 	const { user } = params;
 	return object => object instanceof ConstructionSite &&
 		object['#user'] === user &&

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -1,3 +1,7 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createConstructionSite } from './construction-site.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
 describe('Construction', () => {
@@ -30,6 +34,41 @@ describe('Construction', () => {
 				Object.values(Game.constructionSites).length === 1 &&
                 Object.values(Game.constructionSites)[0]?.structureType === 'road',
 			);
+		});
+	}));
+});
+
+describe('Construction site movement', () => {
+	const roomWithSpawnSite = simulate({
+		W0N0: room => {
+			room['#level'] = 3;
+			room['#user'] = '100';
+			room['#insertObject'](createCreep(new RoomPosition(24, 25, 'W0N0'), [ C.MOVE ], 'spawn_movement', '100'));
+			room['#insertObject'](createConstructionSite(new RoomPosition(25, 25, 'W0N0'), 'spawn', '100'));
+		},
+	});
+
+	test('move should pass through obstacle-type csite', () => roomWithSpawnSite(async ({ player, tick }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.spawn_movement.move(C.RIGHT), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const { x, y } = Game.creeps.spawn_movement.pos;
+			assert.strictEqual(x, 25);
+			assert.strictEqual(y, 25);
+		});
+	}));
+
+	test('moveTo should pass through obstacle-type csite', () => roomWithSpawnSite(async ({ player, tick }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.spawn_movement.moveTo(25, 25), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const { x, y } = Game.creeps.spawn_movement.pos;
+			assert.strictEqual(x, 25);
+			assert.strictEqual(y, 25);
 		});
 	}));
 });


### PR DESCRIPTION
## Summary

Construction sites of obstacle types (spawn, extension, wall, etc.) incorrectly block creep movement. In official Screeps, construction sites never block movement — they only influence pathfinding cost matrices.

The root cause is that the refactored obstacle checker system uses `makeObstacleChecker()` for both pathfinding and movement resolution, with no way to distinguish the two contexts. The construction site checker unconditionally treats the owner's obstacle-type sites as obstacles, but should only do so during pathfinding.

The original design (visible in the commented-out code in `obstacle.ts`) had a `pathing` flag for exactly this distinction — construction sites were only obstacles when `pathing` was true.

## Changes

- Add `pathing` flag to `MovementParameters` (defaults to `undefined`, so all existing callers are unaffected)
- Gate the construction site obstacle checker on `params.pathing` — returns `null` when not pathfinding
- Pass `pathing: true` only from the pathfinding cost matrix builder in `roomSearch()`

This also subsumes the earlier rampart-specific fix (f92550c), which changed rampart's `obstacle: undefined` to `false` as a narrower workaround for the same underlying issue.

Closes #50

## Verification

- Added `move()` and `moveTo()` tests for creep movement through a spawn construction site (obstacle type)
- Tests confirmed to fail without the fix (creep blocked at x=24) and pass with it (creep reaches x=25)
- All existing tests pass, including rampart csite movement tests from #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)