### PR TITLE
fix: register Room.getEventLog at import time

### DIFF
--- a/src/game/room/event-log.ts
+++ b/src/game/room/event-log.ts
@@ -24,7 +24,7 @@ declare module './room.js' {
 	}
 }
 
-export default () => extend(Room, {
+extend(Room, {
 	getEventLog(raw = false) {
 		if (raw) {
 			return JSON.stringify(this['#eventLog']);

--- a/src/mods/combat/test.ts
+++ b/src/mods/combat/test.ts
@@ -43,3 +43,55 @@ describe('Combat', () => {
 		});
 	}));
 });
+
+describe('getEventLog', () => {
+	const sim = simulate({
+		W1N1: room => {
+			room['#level'] = 7;
+			room['#user'] = room.controller!['#user'] = '100';
+			room['#insertObject'](createLab(new RoomPosition(25, 25, 'W1N1'), '100'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 24, 'W1N1'),
+				[ C.ATTACK ],
+				'attacker',
+				'100',
+			));
+		},
+	});
+
+	test('returns an array', () => sim(async ({ player }) => {
+		await player('100', Game => {
+			const log = Game.rooms.W1N1.getEventLog();
+			assert.ok(Array.isArray(log));
+		});
+	}));
+
+	test('records attack events after processing', () => sim(async ({ player, tick }) => {
+		await player('100', Game => {
+			const lab = Game.rooms.W1N1.find(C.FIND_STRUCTURES)
+				.find((s: any) => s.structureType === C.STRUCTURE_LAB)!;
+			assert.strictEqual(Game.creeps.attacker.attack(lab), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const log = Game.rooms.W1N1.getEventLog() as any[];
+			const attackEvent = log.find(e => e.event === C.EVENT_ATTACK);
+			assert.ok(attackEvent, 'expected an attack event in the event log');
+		});
+	}));
+
+	test('raw mode returns JSON string', () => sim(async ({ player, tick }) => {
+		await player('100', Game => {
+			const lab = Game.rooms.W1N1.find(C.FIND_STRUCTURES)
+				.find((s: any) => s.structureType === C.STRUCTURE_LAB)!;
+			Game.creeps.attacker.attack(lab);
+		});
+		await tick();
+		await player('100', Game => {
+			const raw = Game.rooms.W1N1.getEventLog(true);
+			assert.strictEqual(typeof raw, 'string');
+			const parsed = JSON.parse(raw as string);
+			assert.ok(Array.isArray(parsed));
+		});
+	}));
+});


### PR DESCRIPTION
## Summary
- `Room.getEventLog` was wrapped in an `export default () =>` factory function that was never called, so the `extend(Room, ...)` never executed and `getEventLog` was never added to the Room prototype
- Removed the factory wrapper to match every other `extend()` call in the codebase (e.g. `path.ts`, `look.ts`)

## Verification
- Replicated the reported error: calling `room.getEventLog()` throws `TypeError: Game.rooms.W1N1.getEventLog is not a function`
- `returns an array` — confirms `getEventLog` exists and returns an array with no prior events
- `records attack events after processing` — triggers an attack, advances a tick, verifies the event log contains an `EVENT_ATTACK` entry
- `raw mode returns JSON string` — verifies `getEventLog(true)` returns a parseable JSON string

Closes #39