### PR TITLE
fix: return error response instead of throwing on respawn without rooms

### DIFF
--- a/src/mods/spawn/backend.ts
+++ b/src/mods/spawn/backend.ts
@@ -159,7 +159,7 @@ hooks.register('route', {
 		}
 		const roomNames = await context.shard.scratch.smembers(userToPresenceRoomsSetKey(userId));
 		if (roomNames.length === 0) {
-			return { error: 'not spawned' };
+			return { error: 'invalid status' };
 		}
 		await Promise.all(roomNames.map(roomName => pushIntentsForRoomNextTick(context.shard, roomName, userId, {
 			local: { unspawn: [ [] ] },

--- a/src/mods/spawn/backend.ts
+++ b/src/mods/spawn/backend.ts
@@ -159,7 +159,7 @@ hooks.register('route', {
 		}
 		const roomNames = await context.shard.scratch.smembers(userToPresenceRoomsSetKey(userId));
 		if (roomNames.length === 0) {
-			throw new Error('Invalid status');
+			return { error: 'not spawned' };
 		}
 		await Promise.all(roomNames.map(roomName => pushIntentsForRoomNextTick(context.shard, roomName, userId, {
 			local: { unspawn: [ [] ] },


### PR DESCRIPTION
## Summary
- The `/api/user/respawn` endpoint threw an unhandled error when called by a user with no rooms (e.g. clicking "Respawn" in the Steam client before spawning), causing a 500 response
- Changed to return `{ error: 'not spawned' }`, matching the error response convention used by other endpoints in the same file (e.g. `check-unique-object-name` returns `{ error: 'exists' }`)

Closes #12