### PR TITLE
fix: clean shutdown of backend WebSocket subscriptions

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -33,7 +33,7 @@ const router = new Router<State, Context>();
 const httpServer = http.createServer(koa.callback());
 const unlistenServer = setupGracefulShutdown(httpServer);
 installUpgradeHandlers(koa, httpServer);
-installSocketHandlers(koa, backendContext);
+const socketHandler = installSocketHandlers(koa, backendContext);
 koa.use(ConditionalGet());
 koa.use(async (context, next) => {
 	try {
@@ -82,5 +82,6 @@ for await (const message of Async.breakable(serviceChannel.iterable(), breaker =
 
 // Start graceful exit
 serviceChannel.disconnect();
-backendContext.disconnect();
 await unlistenServer();
+await socketHandler.flush();
+backendContext.disconnect();

--- a/src/backend/socket.ts
+++ b/src/backend/socket.ts
@@ -82,6 +82,9 @@ export function installUpgradeHandlers(koa: Koa<State, Context>, httpServer: Ser
 }
 
 export function installSocketHandlers(koa: Koa<State, Context>, context: BackendContext) {
+	// Track pending subscription teardowns for graceful shutdown
+	const pendingTeardowns = new Set<Promise<void>>();
+
 	// SockJS aggressively injects its listeners at the front of the queue, so we pass it a fake HTTP
 	// server to have better control over the event flow.
 	const httpDelegate = new EventEmitter() as Server;
@@ -129,7 +132,9 @@ export function installSocketHandlers(koa: Koa<State, Context>, context: Backend
 		function close() {
 			for (const [ name, unlistener ] of subscriptions) {
 				subscriptions.delete(name);
-				unlistener.then(unlistener => unlistener(), () => {});
+				const teardown = unlistener.then(unlistener => unlistener(), () => {});
+				pendingTeardowns.add(teardown);
+				teardown.finally(() => pendingTeardowns.delete(teardown));
 			}
 			connection.close();
 		}
@@ -216,5 +221,7 @@ export function installSocketHandlers(koa: Koa<State, Context>, context: Backend
 
 		connection.on('close', close);
 	});
-	return socketServer;
+	return {
+		flush: () => Promise.all(pendingTeardowns),
+	};
 }

--- a/src/engine/db/storage/local/responder.ts
+++ b/src/engine/db/storage/local/responder.ts
@@ -117,6 +117,11 @@ abstract class ResponderClient {
 			throw new Error('Already disconnected responder client');
 		}
 		this.#disconnected = true;
+		const error = new Error('Disconnected from responder');
+		for (const deferred of this.#requests.values()) {
+			deferred.reject(error);
+			deferred.promise.catch(() => {});
+		}
 		this.#requests.clear();
 		this.#port.close();
 	}


### PR DESCRIPTION
## Summary
Shutting down the server while a room was open in the client threw a `Disconnected from responder` error and crashed — this resolves that so the server shuts down cleanly.

- `unlistenServer()` closes raw sockets during shutdown, which triggers sockjs connection close and subscription teardown — but the teardowns are fire-and-forget (`.then()` chains) so in-flight `loadRoom` calls can race with `backendContext.disconnect()` killing the responder
- Track pending subscription teardowns and await them before disconnecting the shard, so `mustNotReject` safety is preserved for genuine failures during normal operation
- Also reject pending responder requests on disconnect instead of silently dropping them, preventing hanging awaits from unsettled promises
- Tested on a live server before and after to confirm this resolves the issue

**Changes:**
- `server.ts` — Reorder shutdown: drain connections before disconnect, await subscription teardown flush
- `socket.ts` — Track teardown promises in a self-cleaning Set, expose `flush()` for the shutdown sequence
- `responder.ts` — Reject (not drop) pending requests on disconnect