### PR TITLE
fix: enforce MAX_CONSTRUCTION_SITES limit

### DIFF
--- a/src/mods/construction/room.ts
+++ b/src/mods/construction/room.ts
@@ -40,7 +40,13 @@ declare module 'xxscreeps/game/room/index.js' {
 }
 
 const createdNames = new Set<string>();
-hooks.register('gameInitializer', () => createdNames.clear());
+// Mirrors vanilla's `createdConstructionSites` runtime counter. The processor runs per-room and
+// cannot enforce this shard-level constraint, so it is only checked here in the player runtime.
+let createdConstructionSites = 0;
+hooks.register('gameInitializer', () => {
+	createdNames.clear();
+	createdConstructionSites = 0;
+});
 
 extend(Room, {
 	createConstructionSite(this: Room, ...args: any[]) {
@@ -61,14 +67,18 @@ extend(Room, {
 		}
 
 		// Check global construction site limit
-		if (userGame && Object.keys(userGame.constructionSites).length >= C.MAX_CONSTRUCTION_SITES) {
+		if (userGame && Object.keys(userGame.constructionSites).length + createdConstructionSites >= C.MAX_CONSTRUCTION_SITES) {
 			return C.ERR_FULL;
 		}
 
 		// Send it off
-		return chainIntentChecks(
+		const result = chainIntentChecks(
 			() => checkCreateConstructionSite(this, pos, structureType, name),
 			() => intents.pushLocal(this, 'createConstructionSite', structureType, xx, yy, name));
+		if (result === C.OK) {
+			++createdConstructionSites;
+		}
+		return result;
 	},
 });
 

--- a/src/mods/construction/room.ts
+++ b/src/mods/construction/room.ts
@@ -1,7 +1,7 @@
 import type { ConstructibleStructureType, ConstructionSite } from './construction-site.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { hooks, intents, me } from 'xxscreeps/game/index.js';
+import { hooks, intents, me, userGame } from 'xxscreeps/game/index.js';
 import { makeObstacleChecker } from 'xxscreeps/game/path-finder/obstacle.js';
 import { RoomPosition, fetchArguments } from 'xxscreeps/game/position.js';
 import { Room, registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
@@ -58,6 +58,11 @@ extend(Room, {
 				return C.ERR_NAME_EXISTS;
 			}
 			createdNames.add(name);
+		}
+
+		// Check global construction site limit
+		if (userGame && Object.keys(userGame.constructionSites).length >= C.MAX_CONSTRUCTION_SITES) {
+			return C.ERR_FULL;
 		}
 
 		// Send it off

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -21,9 +21,10 @@ describe('Construction', () => {
 		});
 	}));
 	test('max construction sites', () => construction(async ({ player, tick }) => {
-		// Place 90 sites in tick 1
+		// Place most sites in tick 1
+		const firstBatch = C.MAX_CONSTRUCTION_SITES - 10;
 		await player('100', Game => {
-			for (const pos of Fn.range(90)) {
+			for (const pos of Fn.range(firstBatch)) {
 				const xx = 1 + (pos % 48);
 				const yy = 1 + Math.floor(pos / 48);
 				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
@@ -32,8 +33,8 @@ describe('Construction', () => {
 		await tick();
 		// Try 11 more in tick 2 — first 10 should succeed, 11th should fail
 		await player('100', Game => {
-			assert.strictEqual(Object.keys(Game.constructionSites).length, 90);
-			for (const pos of Fn.range(90, 100)) {
+			assert.strictEqual(Object.keys(Game.constructionSites).length, firstBatch);
+			for (const pos of Fn.range(firstBatch, C.MAX_CONSTRUCTION_SITES)) {
 				const xx = 1 + (pos % 48);
 				const yy = 1 + Math.floor(pos / 48);
 				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -1,5 +1,4 @@
 import * as C from 'xxscreeps/game/constants/index.js';
-import { Fn } from 'xxscreeps/utility/fn.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
 describe('Construction', () => {
@@ -24,7 +23,7 @@ describe('Construction', () => {
 		// Place most sites in tick 1
 		const firstBatch = C.MAX_CONSTRUCTION_SITES - 10;
 		await player('100', Game => {
-			for (const pos of Fn.range(firstBatch)) {
+			for (let pos = 0; pos < firstBatch; ++pos) {
 				const xx = 1 + (pos % 48);
 				const yy = 1 + Math.floor(pos / 48);
 				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
@@ -34,14 +33,14 @@ describe('Construction', () => {
 		// Try 11 more in tick 2 — first 10 should succeed, 11th should fail
 		await player('100', Game => {
 			assert.strictEqual(Object.keys(Game.constructionSites).length, firstBatch);
-			for (const pos of Fn.range(firstBatch, C.MAX_CONSTRUCTION_SITES)) {
+			for (let pos = firstBatch; pos < C.MAX_CONSTRUCTION_SITES; ++pos) {
 				const xx = 1 + (pos % 48);
 				const yy = 1 + Math.floor(pos / 48);
 				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
 			}
 			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(1, 4, 'road'), C.ERR_FULL);
 			// Remove one site, then creating should succeed again
-			Object.values(Game.constructionSites)[0]!.remove();
+			Object.values(Game.constructionSites)[0].remove();
 		});
 		await tick();
 		await player('100', Game => {

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -40,9 +40,7 @@ describe('Construction', () => {
 				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
 			}
 			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(1, 4, 'road'), C.ERR_FULL);
-		});
-		// Remove one site, then creating should succeed again
-		await player('100', Game => {
+			// Remove one site, then creating should succeed again
 			Object.values(Game.constructionSites)[0]!.remove();
 		});
 		await tick();

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -1,4 +1,5 @@
 import * as C from 'xxscreeps/game/constants/index.js';
+import { Fn } from 'xxscreeps/utility/fn.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
 describe('Construction', () => {
@@ -20,20 +21,23 @@ describe('Construction', () => {
 		});
 	}));
 	test('max construction sites', () => construction(async ({ player, tick }) => {
-		// Place MAX_CONSTRUCTION_SITES roads in one tick
+		// Place 90 sites in tick 1
 		await player('100', Game => {
-			for (let ii = 0; ii < C.MAX_CONSTRUCTION_SITES; ++ii) {
-				const x = 1 + (ii % 48);
-				const y = 1 + Math.floor(ii / 48);
-				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(x, y, 'road'), C.OK);
+			for (const pos of Fn.range(90)) {
+				const xx = 1 + (pos % 48);
+				const yy = 1 + Math.floor(pos / 48);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
 			}
 		});
 		await tick();
+		// Try 11 more in tick 2 — first 10 should succeed, 11th should fail
 		await player('100', Game => {
-			assert.strictEqual(Object.keys(Game.constructionSites).length, C.MAX_CONSTRUCTION_SITES);
-		});
-		// 101st should fail with ERR_FULL
-		await player('100', Game => {
+			assert.strictEqual(Object.keys(Game.constructionSites).length, 90);
+			for (const pos of Fn.range(90, 100)) {
+				const xx = 1 + (pos % 48);
+				const yy = 1 + Math.floor(pos / 48);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(xx, yy, 'road'), C.OK);
+			}
 			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(1, 4, 'road'), C.ERR_FULL);
 		});
 		// Remove one site, then creating should succeed again

--- a/src/mods/construction/test.ts
+++ b/src/mods/construction/test.ts
@@ -1,3 +1,4 @@
+import * as C from 'xxscreeps/game/constants/index.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
 describe('Construction', () => {
@@ -18,6 +19,34 @@ describe('Construction', () => {
 			assert(Object.values(Game.constructionSites).length === 1);
 		});
 	}));
+	test('max construction sites', () => construction(async ({ player, tick }) => {
+		// Place MAX_CONSTRUCTION_SITES roads in one tick
+		await player('100', Game => {
+			for (let ii = 0; ii < C.MAX_CONSTRUCTION_SITES; ++ii) {
+				const x = 1 + (ii % 48);
+				const y = 1 + Math.floor(ii / 48);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(x, y, 'road'), C.OK);
+			}
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Object.keys(Game.constructionSites).length, C.MAX_CONSTRUCTION_SITES);
+		});
+		// 101st should fail with ERR_FULL
+		await player('100', Game => {
+			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(1, 4, 'road'), C.ERR_FULL);
+		});
+		// Remove one site, then creating should succeed again
+		await player('100', Game => {
+			Object.values(Game.constructionSites)[0]!.remove();
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Object.keys(Game.constructionSites).length, C.MAX_CONSTRUCTION_SITES - 1);
+			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(1, 4, 'road'), C.OK);
+		});
+	}));
+
 	test('create two sites at same position', () => construction(async ({ player, tick }) => {
 		await player('100', Game => {
 			Game.rooms.W1N1.createConstructionSite(25, 25, 'road');


### PR DESCRIPTION
## Summary
- `MAX_CONSTRUCTION_SITES` (100) was defined as a constant but never enforced
- Add global site count check in `Room.createConstructionSite` using `userGame.constructionSites`, returning `ERR_FULL` when the limit is reached
- Check is in the runner sandbox only, matching official engine behavior

## Verification
- Test creates 100 construction sites, verifies all succeed
- Test verifies the 101st returns `ERR_FULL`
- Test removes a site and verifies creation succeeds again at 99
- All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)