### PR TITLE
Fix Flag.setPosition to use parsed position id

### DIFF
--- a/packages/xxscreeps/mods/flag/flag.ts
+++ b/packages/xxscreeps/mods/flag/flag.ts
@@ -78,7 +78,7 @@ export class Flag extends withOverlay(RoomObject, shape) {
 			() => checkFlagPosition(pos!),
 			() => {
 				intents.push({ type: 'create', params: [
-					this.name, this.pos['#id'],
+					this.name, pos!['#id'],
 					this.color, this.secondaryColor,
 				] });
 			},


### PR DESCRIPTION
## Summary

`Flag.setPosition` parses a new `pos` from its arguments via `fetchPositionArgument`, but the `create` intent it pushes still references `this.pos['#id']` — the flag's *current* position id — so the flag never relocates. One-character semantic fix: use `pos!['#id']` in the intent payload, matching the variable that was just computed and validated a line above.

## Repro

```js
Game.rooms['W1N1'].createFlag(10, 10, 'movable');
// next tick:
Game.flags.movable.setPosition(30, 35);   // returns OK
// next tick:
Game.flags.movable.pos  // → still (10, 10) on current main; (30, 35) with this patch
```

## Why it's safe

- `pos` is already computed at the top of `setPosition` and validated by `checkFlagPosition(pos!)` before the intent block runs, so the non-null assertion is warranted.
- The engine-side handler (`mods/flag/game.ts`, `createFlag`) already relocates on mismatch via `flag.pos = pos; flag['#posId'] = pos['#id']` — it just needs to be told the new id.
- `setColor` (same file, a few lines up) legitimately pushes `this.pos['#id']`; only the `setPosition` copy is wrong.

## Testing

Verified against ok-screeps, an external canonical-behavior test suite that runs the same specs against vanilla and xxscreeps: the `setPosition` test goes from failing to passing, with no regressions in the rest of the flag suite.