### PR TITLE
Match vanilla corner-exit branch order in creep room transition

### DIFF
--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -310,10 +310,10 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 		const next = function() {
 			if (creep.pos.x === 0) {
 				return new RoomPosition(49, creep.pos.y, generateRoomName(rx - 1, ry));
-			} else if (creep.pos.x === 49) {
-				return new RoomPosition(0, creep.pos.y, generateRoomName(rx + 1, ry));
 			} else if (creep.pos.y === 0) {
 				return new RoomPosition(creep.pos.x, 49, generateRoomName(rx, ry - 1));
+			} else if (creep.pos.x === 49) {
+				return new RoomPosition(0, creep.pos.y, generateRoomName(rx + 1, ry));
 			} else {
 				return new RoomPosition(creep.pos.x, 0, generateRoomName(rx, ry + 1));
 			}


### PR DESCRIPTION
## Summary

When a creep ends its move on a border tile, xxscreeps transitions it to the adjacent room at `mods/creep/processor.ts:311-319`. The four-branch sequence is `x=0 → x=49 → y=0 → y=49`. Vanilla's equivalent at [`@screeps/engine/src/processor/intents/creeps/tick.js:58-73`](https://github.com/screeps/engine/blob/master/src/processor/intents/creeps/tick.js#L58-L73) uses `x=0 → y=0 → x=49 → y=49`. The two only diverge at one tile.

## The diverging case

Corner `(49, 0)`:

| Engine | First true branch | Exit | New pos |
|---|---|---|---|
| Vanilla (tick.js:62-65) | `y == 0` | north | `(49, 49)` of `rx, ry-1` |
| xxscreeps (processor.ts:313-314) | `x === 49` | east | `(0, 0)` of `rx+1, ry` |

The other three corners agree in both orderings:
- `(0, 0)`: `x == 0` wins in both → west
- `(0, 49)`: `x == 0` wins in both → west
- `(49, 49)`: falls through to `x == 49` in both → east

Non-corner border tiles trigger a single branch, so order is irrelevant there.

## Fix

Swap branches 2 and 3 in `mods/creep/processor.ts` so xxscreeps matches vanilla's precedence:

```diff
 if (creep.pos.x === 0) {
     return new RoomPosition(49, creep.pos.y, generateRoomName(rx - 1, ry));
-} else if (creep.pos.x === 49) {
-    return new RoomPosition(0, creep.pos.y, generateRoomName(rx + 1, ry));
 } else if (creep.pos.y === 0) {
     return new RoomPosition(creep.pos.x, 49, generateRoomName(rx, ry - 1));
+} else if (creep.pos.x === 49) {
+    return new RoomPosition(0, creep.pos.y, generateRoomName(rx + 1, ry));
 } else {
```

## Testing

Verified against ok-screeps: a creep arriving at `(49, 0)` now exits north (matching vanilla) instead of east. All other room-transition tests still pass unchanged.