### PR TITLE
Short-circuit Room.findPath when origin === goal

### DIFF
--- a/packages/xxscreeps/game/room/path.ts
+++ b/packages/xxscreeps/game/room/path.ts
@@ -126,6 +126,10 @@ extend(Room, {
 
 	findPath(origin: RoomPosition, goal: RoomPosition, options: FindPathOptions & { serialize?: boolean } = {}) {
 
+		if (origin.isEqualTo(goal)) {
+			return options.serialize ? '' : [];
+		}
+
 		// Delegate to `PathFinder` for main search
 		const result = PathFinder.roomSearch(origin, [ goal ], options);
 


### PR DESCRIPTION
## Summary

`Room.findPath` at `packages/xxscreeps/game/room/path.ts:127` delegates to `PathFinder.roomSearch`, which correctly returns an empty path for a same-position query. But the auto-append branch at lines 132-140 falls through to `origin.isNearTo(goal)` — which is `true` for range 0 — and pushes `goal` onto the empty path, yielding a spurious 1-step result with `dx = dy = 0`.

## Vanilla behavior

Both pathfinder paths in vanilla short-circuit before any search:

- Legacy pathfinder: [`@screeps/engine/src/game/rooms.js:914-916`](https://github.com/screeps/engine/blob/master/src/game/rooms.js#L914-L916)
  ```js
  if (fromX == toX && fromY == toY) {
      return opts.serialize ? '' : [];
  }
  ```

- New pathfinder (`_findPath2`): [`@screeps/engine/src/game/rooms.js:227-229`](https://github.com/screeps/engine/blob/master/src/game/rooms.js#L227-L229)
  ```js
  if (fromPos.isEqualTo(toPos)) {
      return opts.serialize ? '' : [];
  }
  ```

xxscreeps' `findPath` has no upfront cross-room guard and delegates straight to the pathfinder, structurally mirroring `_findPath2`, so `isEqualTo` is the right match.

## Fix

```diff
 findPath(origin: RoomPosition, goal: RoomPosition, options: ... = {}) {

+    if (origin.isEqualTo(goal)) {
+        return options.serialize ? '' : [];
+    }
+
     // Delegate to `PathFinder` for main search
     const result = PathFinder.roomSearch(origin, [ goal ], options);
```

## Testing

Verified against ok-screeps: `creep.pos.findPathTo(creep.pos)` now returns `[]` (or `''` when `serialize: true`), matching vanilla. All other pathfinding tests still pass.