### PR TITLE
Fix Game.map.findRoute: routeCallback arg order and null-exit guard

### DIFF
--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -159,9 +159,9 @@ export class GameMap {
 			[ origin ],
 			pos => Math.abs(destination.rx - pos.rx) + Math.abs(destination.ry - pos.ry),
 			routeCallback
-				? (to, from) => routeCallback(generateRoomName(from.rx, from.ry), generateRoomName(to.rx, to.ry)) :
+				? (to, from) => routeCallback(generateRoomName(to.rx, to.ry), generateRoomName(from.rx, from.ry)) :
 				() => 1,
-			pos => Fn.map(Object.values(this.describeExits(generateRoomName(pos.rx, pos.ry))), parseRoomName));
+			pos => Fn.map(Object.values(this.describeExits(generateRoomName(pos.rx, pos.ry)) ?? {}), parseRoomName));
 		if (route) {
 			return Fn.pipe(
 				route,

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -161,6 +161,9 @@ export class GameMap {
 			routeCallback
 				? (to, from) => routeCallback(generateRoomName(to.rx, to.ry), generateRoomName(from.rx, from.ry)) :
 				() => 1,
+			// describeExits is typed `null as never` for player-facing ergonomics but
+			// can genuinely return null at runtime; `Object.values(null)` would throw.
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 			pos => Fn.map(Object.values(this.describeExits(generateRoomName(pos.rx, pos.ry)) ?? {}), parseRoomName));
 		if (route) {
 			return Fn.pipe(


### PR DESCRIPTION
## Summary

Two issues in `Game.map.findRoute` at `packages/xxscreeps/game/map.ts:156-164`, both in how the callbacks are passed to `astar`. The first is the bug; the second is a latent issue that surfaces as soon as the first is fixed, so they ship together.

## Issue 1: routeCallback args reversed

**Vanilla** ([`@screeps/engine/src/game/map.js:164`](https://github.com/screeps/engine/blob/master/src/game/map.js#L164)):
```js
let cost = Number(routeCallback(roomName, fromRoomName)) || 1;
```
where `roomName` is the neighbor being examined and `fromRoomName` is the current node — i.e. the destination room is the **first** argument. The public doc string on `Game.map.findRoute` agrees: `"function(roomName, fromRoomName)"`.

**xxscreeps (current):**
```ts
(to, from) => routeCallback(generateRoomName(from.rx, from.ry), generateRoomName(to.rx, to.ry))
```
The wrapper passes `from` first and `to` second — reversed. A routeCallback that blocks a target room by name (the common pattern) never sees that room as its first argument.

## Issue 2: `describeExits` can return null

`describeExits` returns `null` when the requested room has no terrain data (`packages/xxscreeps/game/map.ts:89`). The astar visit callback at line 164 does `Object.values(this.describeExits(...))` which throws `Cannot convert undefined or null to object` for such rooms.

Vanilla's equivalent loop uses `for (let dir in exits)` ([map.js:154](https://github.com/screeps/engine/blob/master/src/game/map.js#L154)) which no-ops on null/undefined — effectively treating an unknown room as having zero exits.

This doesn't surface today because the broken routeCallback (issue 1) means astar finds the destination on its first visit and never explores far enough to hit a room with no terrain data. Fixing issue 1 alone causes the search to expand outward until it crashes on the first unknown neighbor — so both fixes land together.

## Fix

```diff
 routeCallback
-    ? (to, from) => routeCallback(generateRoomName(from.rx, from.ry), generateRoomName(to.rx, to.ry)) :
+    ? (to, from) => routeCallback(generateRoomName(to.rx, to.ry), generateRoomName(from.rx, from.ry)) :
     () => 1,
-pos => Fn.map(Object.values(this.describeExits(generateRoomName(pos.rx, pos.ry))), parseRoomName));
+pos => Fn.map(Object.values(this.describeExits(generateRoomName(pos.rx, pos.ry)) ?? {}), parseRoomName));
```

## Testing

Verified against ok-screeps: a routeCallback returning `Infinity` for the destination room now correctly yields `ERR_NO_PATH`, matching vanilla. All other map tests still pass.