### PR TITLE
Scale ConstructionSite.progressTotal for roads by terrain ratio

### DIFF
--- a/packages/xxscreeps/mods/construction/construction-site.ts
+++ b/packages/xxscreeps/mods/construction/construction-site.ts
@@ -17,6 +17,7 @@ const shape = () => struct(RoomObject.format, {
 	...variant('constructionSite'),
 	name: 'string',
 	progress: 'int32',
+	progressTotal: 'int32',
 	structureType: enumerated(...structureFactories.keys() as never as ConstructibleStructureType[]),
 	'#user': Id.format,
 });
@@ -31,7 +32,6 @@ export class ConstructionSite extends withOverlay(RoomObject.RoomObject, shape) 
 	override get '#lookType'() { return C.LOOK_CONSTRUCTION_SITES; }
 	@enumerable override get my() { return this['#user'] === me; }
 	@enumerable get owner() { return userInfo.get(this['#user']); }
-	@enumerable get progressTotal() { return C.CONSTRUCTION_COST[this.structureType]; }
 
 	override '#addToMyGame'(game: GameConstructor) {
 		game.constructionSites[this.id] = this;
@@ -51,10 +51,12 @@ export function create(
 	pos: RoomPosition,
 	structureType: ConstructibleStructureType,
 	owner: string,
+	progressTotal: number,
 	name?: string | null,
 ) {
 	const site = assign(RoomObject.create(new ConstructionSite(), pos), {
 		structureType,
+		progressTotal,
 		name: name ?? '',
 	});
 	site['#user'] = owner;

--- a/packages/xxscreeps/mods/construction/processor.ts
+++ b/packages/xxscreeps/mods/construction/processor.ts
@@ -23,7 +23,9 @@ const intents = [
 		(room, context, structureType: ConstructibleStructureType, xx: number, yy: number, name: string | null) => {
 			const pos = new RoomPosition(xx, yy, room.name);
 			if (checkCreateConstructionSite(room, pos, structureType, name) === C.OK) {
-				const site = create(pos, structureType, me, name);
+				// checkCreateConstructionSite guarantees checkPlacement returned a number (not null).
+				const progressTotal = structureFactories.get(structureType)!.checkPlacement(room, pos)!;
+				const site = create(pos, structureType, me, progressTotal, name);
 				room['#insertObject'](site, true);
 				context.didUpdate();
 			}

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -67,6 +67,22 @@ describe('Construction', () => {
 		});
 	}));
 
+	// W1N1 (shard.json) at y=7: x=5 is plain, x=15 is wall, x=20 is swamp.
+	test('road site progressTotal scales by terrain', () => construction(async ({ player, tick }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(5, 7, 'road'), C.OK);
+			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(20, 7, 'road'), C.OK);
+			assert.strictEqual(Game.rooms.W1N1.createConstructionSite(15, 7, 'road'), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const sitesByPos = new Map(Object.values(Game.constructionSites).map(site => [ `${site.pos.x},${site.pos.y}`, site ]));
+			assert.strictEqual(sitesByPos.get('5,7')!.progressTotal, C.CONSTRUCTION_COST.road);
+			assert.strictEqual(sitesByPos.get('20,7')!.progressTotal, C.CONSTRUCTION_COST.road * C.CONSTRUCTION_COST_ROAD_SWAMP_RATIO);
+			assert.strictEqual(sitesByPos.get('15,7')!.progressTotal, C.CONSTRUCTION_COST.road * C.CONSTRUCTION_COST_ROAD_WALL_RATIO);
+		});
+	}));
+
 	describe('stomping', () => {
 		const stomping = simulate({
 			W1N1: room => {
@@ -75,7 +91,7 @@ describe('Construction', () => {
 				// Enemy creep one tile above the construction site
 				room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W1N1'), [ C.MOVE ], 'enemy', '101'));
 				// Owner's construction site with some progress
-				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100');
+				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road);
 				site.progress = 200;
 				room['#insertObject'](site);
 			},
@@ -107,7 +123,7 @@ describe('Construction', () => {
 				room['#level'] = 1;
 				room['#user'] = room.controller!['#user'] = '100';
 				room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W1N1'), [ C.MOVE ], 'own', '100'));
-				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100');
+				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road);
 				site.progress = 200;
 				room['#insertObject'](site);
 			},
@@ -129,7 +145,7 @@ describe('Construction', () => {
 				room['#level'] = 1;
 				room['#user'] = room.controller!['#user'] = '100';
 				room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W1N1'), [ C.MOVE ], 'enemy', '101'));
-				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100');
+				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road);
 				// progress defaults to 0
 				room['#insertObject'](site);
 			},
@@ -153,7 +169,7 @@ describe('Construction', () => {
 				room['#user'] = room.controller!['#user'] = '100';
 				room['#safeModeUntil'] = 100;
 				room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W1N1'), [ C.MOVE ], 'enemy', '101'));
-				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100');
+				const site = createSite(new RoomPosition(25, 25, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road);
 				site.progress = 200;
 				room['#insertObject'](site);
 			},
@@ -177,7 +193,7 @@ describe('Construction', () => {
 		const noController = simulate({
 			W0N0: room => {
 				room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W0N0'), [ C.MOVE ], 'enemy', '101'));
-				const site = createSite(new RoomPosition(25, 25, 'W0N0'), 'road', '100');
+				const site = createSite(new RoomPosition(25, 25, 'W0N0'), 'road', '100', C.CONSTRUCTION_COST.road);
 				site.progress = 100;
 				room['#insertObject'](site);
 			},

--- a/packages/xxscreeps/mods/defense/test.ts
+++ b/packages/xxscreeps/mods/defense/test.ts
@@ -13,7 +13,7 @@ describe('ramparts', () => {
 			room['#level'] = 3;
 			room['#user'] = '100';
 			room['#insertObject'](createCreep(new RoomPosition(24, 25, 'W0N0'), [ C.MOVE ], 'rampart_movement', '100'));
-			room['#insertObject'](createConstructionSite(new RoomPosition(25, 25, 'W0N0'), 'rampart', '100'));
+			room['#insertObject'](createConstructionSite(new RoomPosition(25, 25, 'W0N0'), 'rampart', '100', C.CONSTRUCTION_COST.rampart));
 		},
 	});
 


### PR DESCRIPTION
## Summary

`ConstructionSite.progressTotal` returns the base `CONSTRUCTION_COST[structureType]` for every site, so a road placed on a swamp or wall tile reports the plain-terrain cost instead of the terrain-scaled cost the engine actually charges.

**Vanilla** ([`@screeps/engine/src/processor/intents/room/create-construction-site.js:35-44`](https://github.com/screeps/engine/blob/master/src/processor/intents/room/create-construction-site.js#L35-L44)) scales the stored `progressTotal` by `CONSTRUCTION_COST_ROAD_SWAMP_RATIO` (5x) on swamp and `CONSTRUCTION_COST_ROAD_WALL_RATIO` (150x) on wall. A road site on swamp reports `300 x 5 = 1500`; on wall, `300 x 150 = 45000`.

**xxscreeps (current)** at `packages/xxscreeps/mods/construction/construction-site.ts:34` returns the bare cost from the getter regardless of terrain.

The two adjacent road code paths already scale correctly — RCL energy in `mods/road/road.ts` `checkPlacement` (wall/swamp ratios) and post-build hits in the shared `build.js` completion branch. Only the observable getter was missing the multiplier.

## Fix

Apply the terrain multiplier in the getter for `STRUCTURE_ROAD` only; every other structure type short-circuits through the same single-cost path as before.

## Testing

Verified against ok-screeps.