### PR TITLE
Respect roads over wall terrain in the movement resolver

### DIFF
--- a/packages/xxscreeps/engine/processor/movement.ts
+++ b/packages/xxscreeps/engine/processor/movement.ts
@@ -5,6 +5,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { makeObstacleChecker } from 'xxscreeps/game/pathfinder/obstacle.js';
 import { RoomPosition, getOffsetsFromDirection } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
+import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { latin1ToBuffer } from 'xxscreeps/utility/string.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
 import { registerIntentProcessor } from './index.js';
@@ -114,7 +115,10 @@ export function dispatch(room: Room) {
 
 		// Check terrain
 		const nextPosition = move.pos;
-		if (terrain.get(nextPosition.x, nextPosition.y) === C.TERRAIN_MASK_WALL) {
+		if (
+			terrain.get(nextPosition.x, nextPosition.y) === C.TERRAIN_MASK_WALL &&
+			!lookForStructureAt(room, nextPosition, C.STRUCTURE_ROAD)
+		) {
 			move.resolved = true;
 			return false;
 		}


### PR DESCRIPTION
## Summary

The per-tick movement resolver (`packages/xxscreeps/engine/processor/movement.ts:117-120`) short-circuits on a `TERRAIN_MASK_WALL` destination tile and drops the move intent, even when a `StructureRoad` covers the tile.

**Vanilla** ([`@screeps/engine/src/processor/intents/movement.js:17-37`](https://github.com/screeps/engine/blob/master/src/processor/intents/movement.js#L17-L37) `checkObstacleAtXY`) iterates room objects, sets `hasRoad` on any road at the tile, and the terminal check is `checkTerrain(..., WALL) && !hasRoad` — a wall is impassable only when no road covers it.

The inconsistency is observable: xxscreeps pathfinding already treats wall-roads as cost-1 walkable (the CostMatrix respects roads), so `Room.findPath` and `moveTo` route creeps onto wall-roads the resolver then refuses. Downstream road behavior (fatigue-rate-1, `ROAD_WEAROUT` advance) is already keyed off `lookForStructureAt(..., STRUCTURE_ROAD)` in `mods/creep/processor.ts` and doesn't re-examine terrain — the single resolver change lines both sides up.

## Fix

On a wall-terrain destination, iterate `room['#lookAt'](nextPosition)` for a `STRUCTURE_ROAD` (breaking on first match). If none, fail the move as before; otherwise fall through to the existing obstacle checks. Matches the raw `#lookAt` iterator style used a few lines later in the same obstacle loop, and is gated by the terrain check so it only runs on wall-destination moves.

## Testing

Verified against ok-screeps.