### PR TITLE
Fix Terrain.getRawBuffer Uint8Array destination overload

### DIFF
--- a/packages/xxscreeps/game/terrain.ts
+++ b/packages/xxscreeps/game/terrain.ts
@@ -70,18 +70,16 @@ export class Terrain {
 			const buffer = destinationArray instanceof Uint8Array ? destinationArray : new Uint8Array(625);
 			buffer.set(this.#buffer);
 			return buffer;
-		} else {
-			const buffer = destinationArray ?? new Uint32Array(625);
-			for (let ii = 0; ii < 625; ++ii) {
-				const value = this.#buffer[ii];
-				buffer[ii] =
-					((value >>> ((ii << 3) & 0x06)) & 0x03) |
-					(((value >>> ((ii << 3) + 2 & 0x06)) & 0x03) << 8) |
-					(((value >>> ((ii << 3) + 4 & 0x06)) & 0x03) << 16) |
-					(((value >>> ((ii << 3) + 6 & 0x06)) & 0x03) << 24);
-			}
-			return new Uint8Array(buffer.buffer);
 		}
+		const buffer = destinationArray ?? new Uint8Array(2500);
+		for (let ii = 0, jj = 0; ii < 625; ++ii, jj += 4) {
+			const value = this.#buffer[ii];
+			buffer[jj] = value & 0x03;
+			buffer[jj + 1] = (value >>> 2) & 0x03;
+			buffer[jj + 2] = (value >>> 4) & 0x03;
+			buffer[jj + 3] = (value >>> 6) & 0x03;
+		}
+		return buffer;
 	}
 }
 


### PR DESCRIPTION
## Summary

`Terrain.getRawBuffer` at `packages/xxscreeps/game/terrain.ts:68-85` has two code paths, selected by the second parameter. The `'xxscreeps'` path returns the packed 625-byte buffer and is unchanged. The default path — the Screeps-API-compatible one — builds a 32-bit-packed value per source byte and stores it via `buffer[ii] = <value>`, relying on a final `new Uint8Array(buffer.buffer)` view to unpack the four tile masks into consecutive bytes. That only works when `buffer` is a `Uint32Array(625)`.

The public signature types `destinationArray` as `Uint8Array`, which is what the [Screeps API documents](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer). Given a `Uint8Array(2500)`, `buffer[ii] = <32-bit-value>` truncates to the low byte, so only tile `4·ii + 0` survives at byte `ii`; tiles `4·ii + 1..4·ii + 3` are dropped, and bytes `625..2499` stay zero. `buf[y·50 + x]` is only correct at `(0, 0)` by alignment.

All-plain test rooms mask the bug because zeros truncate to zeros.

## Fix

Byte-wise decode: one mask per byte, 2500 iterations, no packing. Works for both a caller-supplied `Uint8Array(2500)` and the default no-arg call. No internal callers of this path (the schema decomposer at `terrain.ts:122` uses the `'xxscreeps'` variant), and the default `getRawBuffer()` form returns the same 2500-byte Uint8Array as before.

## Testing

- `pnpm build` clean, `pnpm test` 165/165.
- Verified against ok-screeps.