### PR TITLE
Decouple boost output from energy cost for build, repair, and upgradeController

### DIFF
--- a/packages/xxscreeps/mods/construction/processor.ts
+++ b/packages/xxscreeps/mods/construction/processor.ts
@@ -6,7 +6,7 @@ import { Game, me } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
-import { Creep, calculatePower } from 'xxscreeps/mods/creep/creep.js';
+import { Creep, calculateBoundedEffect, calculatePower } from 'xxscreeps/mods/creep/creep.js';
 import * as Resource from 'xxscreeps/mods/resource/processor/resource.js';
 import { ConstructionSite, checkRemove, create } from './construction-site.js';
 import { checkBuild, checkDismantle, checkRepair } from './creep.js';
@@ -43,15 +43,16 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<ConstructionSite>(id)!;
 		if (checkBuild(creep, target) === C.OK) {
-			const power = calculatePower(creep, C.WORK, C.BUILD_POWER, 'build');
-			const energy = Math.min(
-				target.progressTotal - target.progress,
-				creep.store.energy,
-				power,
+			// Vanilla semantics: energy cost derives from unboosted WORK parts,
+			// progress applied uses the boosted output.
+			const buildRemaining = target.progressTotal - target.progress;
+			const { unboosted: energy, boosted } = calculateBoundedEffect(
+				creep, C.WORK, C.BUILD_POWER, 'build',
+				Math.min(buildRemaining, creep.store.energy),
 			);
 			if (energy > 0) {
 				creep.store['#subtract'](C.RESOURCE_ENERGY, energy);
-				target.progress += energy;
+				target.progress += Math.min(boosted, buildRemaining);
 				saveAction(creep, 'build', target.pos);
 				context.didUpdate();
 			}
@@ -86,13 +87,17 @@ const intents = [
 	}, (creep, context, id: string) => {
 		const target = Game.getObjectById<DestructibleStructure>(id)!;
 		if (checkRepair(creep, target) === C.OK) {
-			const effect = Math.min(
-				calculatePower(creep, C.WORK, C.REPAIR_POWER, 'repair'),
-				target.hitsMax - target.hits,
-				creep.store.energy / C.REPAIR_COST);
+			// Vanilla semantics: `repairEffect` (unboosted) caps hits and drives
+			// energy cost; `boostedEffect` is the hits applied to the target.
+			const repairHitsMax = target.hitsMax - target.hits;
+			const { unboosted: effect, boosted } = calculateBoundedEffect(
+				creep, C.WORK, C.REPAIR_POWER, 'repair',
+				Math.min(repairHitsMax, creep.store.energy / C.REPAIR_COST),
+			);
 			if (effect > 0) {
-				creep.store['#subtract'](C.RESOURCE_ENERGY, effect * C.REPAIR_COST);
-				target.hits += effect;
+				const energyCost = Math.min(creep.store.energy, Math.ceil(effect * C.REPAIR_COST));
+				creep.store['#subtract'](C.RESOURCE_ENERGY, energyCost);
+				target.hits += Math.min(boosted, repairHitsMax);
 				saveAction(creep, 'repair', target.pos);
 				context.didUpdate();
 			}

--- a/packages/xxscreeps/mods/controller/processor.ts
+++ b/packages/xxscreeps/mods/controller/processor.ts
@@ -5,7 +5,7 @@ import { registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
-import { Creep, calculatePower } from 'xxscreeps/mods/creep/creep.js';
+import { Creep, calculateBoundedEffect } from 'xxscreeps/mods/creep/creep.js';
 import { checkActiveStructures } from 'xxscreeps/mods/structure/structure.js';
 import { StructureController, checkActivateSafeMode, checkUnclaim } from './controller.js';
 import * as CreepLib from './creep.js';
@@ -168,17 +168,21 @@ const intents = [
 	registerIntentProcessor(Creep, 'upgradeController', { after: 'build' }, (creep, context, id: string) => {
 		const controller = Game.getObjectById<StructureController>(id)!;
 		if (CreepLib.checkUpgradeController(creep, controller) === C.OK) {
-			// Calculate power, deduct energy
+			// Energy cost is driven by unboosted WORK parts (vanilla: `buildEffect`);
+			// progress applied is the boosted output. Level-8 CONTROLLER_MAX_UPGRADE_PER_TICK
+			// caps the unboosted energy spend, matching vanilla's `target._upgraded`.
 			controller.upgradePowerThisTick ??= 0;
-			let power = calculatePower(creep, C.WORK, C.UPGRADE_CONTROLLER_POWER, 'upgradeController');
+			let cap = creep.store.energy;
 			if (controller.level === 8) {
-				power = Math.min(power, C.CONTROLLER_MAX_UPGRADE_PER_TICK - controller.upgradePowerThisTick);
+				cap = Math.min(cap, C.CONTROLLER_MAX_UPGRADE_PER_TICK - controller.upgradePowerThisTick);
 			}
-			const energy = Math.min(power, creep.store.energy);
+			const { unboosted: energy, boosted: progress } = calculateBoundedEffect(
+				creep, C.WORK, C.UPGRADE_CONTROLLER_POWER, 'upgradeController', cap,
+			);
 			creep.store['#subtract'](C.RESOURCE_ENERGY, energy);
 
 			// Update progress
-			controller['#progress'] += energy;
+			controller['#progress'] += progress;
 			controller.upgradePowerThisTick += energy;
 
 			if (controller.level < 8) {

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -554,6 +554,49 @@ export function calculatePower(creep: Creep, part: PartType, power: number, boos
 	});
 }
 
+/**
+ * Split the unboosted (energy-cost-driving) effect from the boosted (output)
+ * effect for per-WORK-part-per-tick actions like build, repair, and
+ * upgradeController. Mirrors vanilla's behavior:
+ *  - unboosted effect = active-part count × `power`, capped by `cap`
+ *  - boosted effect = unboosted + sum(top-k boost deltas), where k = floor(
+ *    unboosted / power) so an energy-limited creep only applies its most-
+ *    boosted parts.
+ *
+ * Callers use `unboosted` as the energy basis (matching vanilla's
+ * `buildEffect`/`repairEffect`/`_upgraded` accounting) and `boosted` as the
+ * progress/hits applied to the target.
+ */
+export function calculateBoundedEffect(
+	creep: Creep, part: PartType, power: number, boostMethod: string, cap: number,
+) {
+	const boosts: BoostsLookup = C.BOOSTS;
+	const deltas: number[] = [];
+	for (const bodyPart of creep.body) {
+		if (bodyPart.type !== part || bodyPart.hits <= 0) continue;
+		let delta = 0;
+		if (bodyPart.boost) {
+			const multiplier = boosts[part]?.[bodyPart.boost]?.[boostMethod];
+			if (multiplier !== undefined && multiplier > 0) {
+				delta = (multiplier - 1) * power;
+			}
+		}
+		deltas.push(delta);
+	}
+	const unboosted = Math.min(deltas.length * power, cap);
+	if (unboosted <= 0) {
+		return { unboosted: 0, boosted: 0 };
+	}
+	deltas.sort((a, b) => b - a);
+	// Vanilla slices by the effect value (in power-units) rather than part
+	// count. Since `deltas.length * power >= unboosted` and `power >= 1` for
+	// all callers, slicing by `unboosted` keeps all parts when energy is
+	// sufficient and the top-k most-boosted parts otherwise.
+	const sliceCount = Math.floor(unboosted);
+	const boostedDelta = deltas.slice(0, sliceCount).reduce((sum, v) => sum + v, 0);
+	return { unboosted, boosted: Math.floor(unboosted + boostedDelta) };
+}
+
 export function calculateWeight(creep: Creep) {
 	let weight = Fn.accumulate(creep.body, part =>
 		part.type === C.CARRY || part.type === C.MOVE ? 0 : 1);


### PR DESCRIPTION
## Summary

`calculatePower` at `packages/xxscreeps/mods/creep/creep.ts:541` returns the boosted per-tick output (`power × boost multiplier`), and three intent processors reuse that same value as the energy charge. A 1-WORK creep with XGH2O (2× upgrade) is charged 2 energy per tick instead of 1; XLH2O repair (2× repair) charges 2 energy for 200 hits instead of 1 for 200; XLH2O build (2× build) charges 2 energy per boosted progress unit.

Affected call sites:

- `mods/controller/processor.ts:173-182` (upgradeController)
- `mods/construction/processor.ts:46-51` (build)
- `mods/construction/processor.ts:89-94` (repair)

Vanilla (`@screeps/engine/src/processor/intents/creeps/{upgradeController,build,repair}.js`) keeps the two separate: an unboosted `buildEffect`/`repairEffect` drives the energy cost and the level-8 `_upgraded` cap, while a `boostedEffect` is applied to progress/hits. When energy is low, only the top-boosted parts contribute — vanilla sorts boost deltas descending and slices to `buildEffect` parts so a mixed-boost creep uses its most-boosted WORK parts first.

## Fix

Add `calculateBoundedEffect` next to `calculatePower`, returning `{ unboosted, boosted }`. Mirrors vanilla's sort-and-slice pattern.

Rewire:

- `upgradeController`: energy = unboosted, progress = boosted. `CONTROLLER_MAX_UPGRADE_PER_TICK` now caps unboosted spend, matching vanilla's `target._upgraded` accounting.
- `build`: energy = unboosted, `target.progress += min(boosted, progressTotal − progress)`.
- `repair`: energy = `min(store.energy, ceil(unboosted × REPAIR_COST))`, `target.hits += min(boosted, hitsMax − hits)`.

Dismantle, harvest, and combat intents keep `calculatePower` — their output and any derived yield are both meant to scale with the boost.

## Testing

- `pnpm build` clean, `pnpm test` 165/165.
- Verified against ok-screeps.