### PR TITLE
Fix controller safe-mode guards and generateSafeMode intent

### DIFF
--- a/packages/xxscreeps/mods/controller/controller.ts
+++ b/packages/xxscreeps/mods/controller/controller.ts
@@ -1,7 +1,7 @@
 import type { Room } from 'xxscreeps/game/room/index.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { Game, intents, userInfo } from 'xxscreeps/game/index.js';
+import { Game, hooks, intents, userInfo } from 'xxscreeps/game/index.js';
 import { OwnedStructure, checkMyStructure, ownedStructureFormat } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
 
@@ -65,7 +65,26 @@ export class StructureController extends withOverlay(OwnedStructure, shape) {
 	activateSafeMode() {
 		return chainIntentChecks(
 			() => checkActivateSafeMode(this),
-			() => intents.save(this, 'activateSafeMode'));
+			() => {
+				// Runtime-only world-wide scan; the processor's Game.rooms has only the target room.
+				for (const room of Object.values(Game.rooms)) {
+					const other = room.controller;
+					if (other?.my && other.safeMode !== undefined) {
+						return C.ERR_BUSY;
+					}
+				}
+			},
+			() => {
+				// Cap to one activateSafeMode intent per tick; safeMode only flips in the processor.
+				if (lastActivateSafeModeId !== undefined && lastActivateSafeModeId !== this.id) {
+					const previous = Game.getObjectById<StructureController>(lastActivateSafeModeId);
+					if (previous) {
+						intents.remove(previous, 'activateSafeMode');
+					}
+				}
+				lastActivateSafeModeId = this.id;
+				return intents.save(this, 'activateSafeMode');
+			});
 	}
 
 	/**
@@ -100,6 +119,11 @@ declare module 'xxscreeps/game/room/index.js' {
 	}
 }
 
+let lastActivateSafeModeId: string | undefined;
+hooks.register('gameInitializer', () => {
+	lastActivateSafeModeId = undefined;
+});
+
 export function checkActivateSafeMode(controller: StructureController) {
 	return chainIntentChecks(
 		() => checkMyStructure(controller, StructureController),
@@ -111,16 +135,13 @@ export function checkActivateSafeMode(controller: StructureController) {
 				- C.CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD;
 			if (
 				controller.safeModeCooldown ||
-				(controller.upgradeBlocked ?? 0) > 0 ||
+				controller.upgradeBlocked !== undefined ||
 				(controller.ticksToDowngrade ?? Infinity) < downgradeThreshold
 			) {
 				return C.ERR_TIRED;
 			}
-			for (const room of Object.values(Game.rooms)) {
-				const other = room.controller;
-				if (other?.my && other.safeMode) {
-					return C.ERR_BUSY;
-				}
+			if (controller.safeMode !== undefined) {
+				return C.ERR_BUSY;
 			}
 		});
 }

--- a/packages/xxscreeps/mods/controller/controller.ts
+++ b/packages/xxscreeps/mods/controller/controller.ts
@@ -106,10 +106,21 @@ export function checkActivateSafeMode(controller: StructureController) {
 		() => {
 			if (controller.safeModeAvailable <= 0) {
 				return C.ERR_NOT_ENOUGH_RESOURCES;
-			} else if (controller.safeModeCooldown) {
+			}
+			const downgradeThreshold = C.CONTROLLER_DOWNGRADE[controller.level]! / 2
+				- C.CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD;
+			if (
+				controller.safeModeCooldown ||
+				(controller.upgradeBlocked ?? 0) > 0 ||
+				(controller.ticksToDowngrade ?? Infinity) < downgradeThreshold
+			) {
 				return C.ERR_TIRED;
-			} else if (controller.safeMode) {
-				return C.ERR_BUSY;
+			}
+			for (const room of Object.values(Game.rooms)) {
+				const other = room.controller;
+				if (other?.my && other.safeMode) {
+					return C.ERR_BUSY;
+				}
 			}
 		});
 }

--- a/packages/xxscreeps/mods/controller/creep.ts
+++ b/packages/xxscreeps/mods/controller/creep.ts
@@ -152,7 +152,7 @@ export function checkClaimController(creep: Creep, target: StructureController) 
 
 export function checkGenerateSafeMode(creep: Creep, target: StructureController) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.WORK),
+		() => checkCommon(creep),
 		() => checkHasResource(creep, C.RESOURCE_GHODIUM, C.SAFE_MODE_COST),
 		() => checkTarget(target, StructureController),
 		() => checkRange(creep, target, 1));

--- a/packages/xxscreeps/mods/controller/processor.ts
+++ b/packages/xxscreeps/mods/controller/processor.ts
@@ -123,7 +123,7 @@ const intents = [
 	registerIntentProcessor(Creep, 'generateSafeMode', {}, (creep, context, id: string) => {
 		const controller = Game.getObjectById<StructureController>(id)!;
 		if (CreepLib.checkGenerateSafeMode(creep, controller) === C.OK) {
-			creep.store[C.RESOURCE_GHODIUM] -= C.SAFE_MODE_COST;
+			creep.store['#subtract'](C.RESOURCE_GHODIUM, C.SAFE_MODE_COST);
 			++controller.safeModeAvailable;
 			saveAction(creep, 'upgradeController', controller.pos);
 			context.didUpdate();

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -63,4 +63,32 @@ describe('Controller', () => {
 			});
 		}));
 	});
+
+	describe('activateSafeMode', () => {
+
+		const ownedTwoRooms = simulate({
+			W1N1: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				room.controller!.safeModeAvailable = 1;
+			},
+			W3N3: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				room.controller!.safeModeAvailable = 1;
+			},
+		});
+
+		test('caps at one activation per tick across controllers', () => ownedTwoRooms(async ({ player, tick }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.controller!.activateSafeMode(), C.OK);
+				assert.strictEqual(Game.rooms.W3N3.controller!.activateSafeMode(), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.controller!.safeMode, undefined);
+				assert.notStrictEqual(Game.rooms.W3N3.controller!.safeMode, undefined);
+			});
+		}));
+	});
 });


### PR DESCRIPTION
Three related bugs in `mods/controller/` surface when a player drives a
safe-mode lifecycle through a CARRY/MOVE ghodium-ferry creep.

## `checkActivateSafeMode` (`controller.ts:103-115`)

Vanilla's `StructureController.activateSafeMode` (see
[`@screeps/engine/src/game/structures.js:211-234`](https://github.com/screeps/engine/blob/master/src/game/structures.js#L211-L234))
returns:

- `ERR_TIRED` when `ticksToDowngrade < CONTROLLER_DOWNGRADE[level]/2 - CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD`
  **or** when the controller is `upgradeBlocked`
- `ERR_BUSY` when any of the player's owned controllers already has an active safe mode

xxscreeps was missing the downgrade-threshold and `upgradeBlocked`
guards, and the `safeMode → ERR_BUSY` check was scoped to the single
target controller rather than the player's whole portfolio. Add all
three. The cross-room scan subsumes the old single-target `safeMode`
branch — safe mode on the target room satisfies the scan.

## `checkGenerateSafeMode` (`creep.ts:153`)

Required a `WORK` body part via `checkCommon(creep, C.WORK)`. Vanilla's
[`Creep.prototype.generateSafeMode`](https://github.com/screeps/engine/blob/master/src/game/creeps.js#L1049-L1070)
requires only `my`, `!spawning`, `SAFE_MODE_COST` ghodium, and range —
no body-part requirement, consistent with the pattern that
resource-sacrifice intents (transfer/withdraw/pickup/drop) don't need
WORK. Drop the `WORK` argument.

## `generateSafeMode` processor (`processor.ts:126`)

Once the user-side WORK guard is gone and the processor actually runs,
it surfaces a latent bug: the ghodium decrement was written as
`creep.store[C.RESOURCE_GHODIUM] -= C.SAFE_MODE_COST`, which is a
no-op on the schema-backed Store proxy. `safeModeAvailable` incremented
but the creep kept its ghodium — free safe-mode charges. Use
`store['#subtract']`, matching the pattern in `upgradeController` a
few lines down.

Verified against ok-screeps.