### PR TITLE
Guard link.transferEnergy, persist cooldown, restore legacy getters

### DIFF
--- a/packages/xxscreeps/mods/logistics/link.ts
+++ b/packages/xxscreeps/mods/logistics/link.ts
@@ -27,6 +27,11 @@ export class StructureLink extends withOverlay(OwnedStructure, shape) {
 	 */
 	@enumerable get cooldown() { return Math.max(0, this['#cooldownTime'] - Game.time); }
 
+	/** @deprecated */
+	@enumerable get energy() { return this.store[C.RESOURCE_ENERGY]; }
+	/** @deprecated */
+	@enumerable get energyCapacity() { return this.store.getCapacity(C.RESOURCE_ENERGY); }
+
 	/**
 	 * Remotely transfer energy to another link at any location in the same room.
 	 * @param target The target object.
@@ -68,6 +73,12 @@ export function checkTransferEnergy(link: StructureLink, target: StructureLink, 
 		() => checkMyStructure(link, StructureLink),
 		() => checkIsActive(link),
 		() => checkTarget(target, StructureLink),
+		() => target === link ? C.ERR_INVALID_TARGET : C.OK,
+		() => {
+			if (!target.my) {
+				return C.ERR_NOT_OWNER;
+			}
+		},
 		() => checkHasResource(link, C.RESOURCE_ENERGY, amount),
 		() => checkHasCapacity(target, C.RESOURCE_ENERGY, amount),
 		() => checkSameRoom(link, target),

--- a/packages/xxscreeps/mods/logistics/processor.ts
+++ b/packages/xxscreeps/mods/logistics/processor.ts
@@ -16,6 +16,7 @@ const intents = [
 			target.store['#add'](C.RESOURCE_ENERGY, Math.floor(amount * (1 - C.LINK_LOSS_RATIO)));
 			link['#cooldownTime'] = Game.time + C.LINK_COOLDOWN * link.pos.getRangeTo(target) - 1;
 			saveAction(link, 'transferEnergy', target.pos);
+			context.didUpdate();
 		}
 	}),
 ];


### PR DESCRIPTION
## Summary

Four related bugs in `mods/logistics/`:

1. **Self-transfer accepted.** `checkTransferEnergy` (`link.ts:66`) had no
   `target === link` check; vanilla's `StructureLink.prototype.transferEnergy`
   (`@screeps/engine/src/game/structures.js:493`) returns `ERR_INVALID_TARGET`
   in that case. Added `target === link` → `ERR_INVALID_TARGET`.

2. **Cross-owner transfer accepted.** Same function had no ownership test on
   the target. Vanilla's `!target.my` check (line 497) returns `ERR_NOT_OWNER`;
   added the same here, matching the existing `checkUnboostCreep` pattern in
   `mods/chemistry/lab.ts:196-198`.

3. **Cooldown not persisted.** The `transferEnergy` intent processor mutates
   serialized state (`store`, `#cooldownTime`, action log) but doesn't call
   `context.didUpdate()`. Every other state-mutating intent processor in
   the codebase does — link is the outlier. Without the call, `finalize()`
   falls through to `copyRoomFromPreviousTick` instead of `saveRoom` and
   the mutations are dropped; in mixed rooms another processor's
   `didUpdate()` usually covers for it. Added the call to bring link in
   line with the rest.

4. **Missing legacy getters.** `StructureLink` lacked the `energy` and
   `energyCapacity` compat aliases that vanilla exposes (and that
   `StructureLab` already provides at `mods/chemistry/lab.ts:36-38`). Added
   both delegating to `store`.

## Verification

Verified against ok-screeps: LINK-002, LINK-004, LINK-006, and
SHAPE-STRUCT-001:link all now pass; full parity run shows zero
regressions versus the pin.