### PR TITLE
Fix structure ownership precedence in checkMyStructure and destroy

### DIFF
--- a/packages/xxscreeps/mods/structure/structure.ts
+++ b/packages/xxscreeps/mods/structure/structure.ts
@@ -203,7 +203,7 @@ export function checkWall(pos: RoomPosition) {
 export function checkMyStructure(structure: Structure, constructor: abstract new(...args: any[]) => any) {
 	if (!(structure instanceof constructor)) {
 		return C.ERR_INVALID_ARGS;
-	} else if (!structure.my && !structure.room.controller?.my) {
+	} else if (!structure.my) {
 		return C.ERR_NOT_OWNER;
 	}
 	return C.OK;
@@ -218,7 +218,8 @@ export function checkIsActive(structure: Structure) {
 
 export function checkDestroy(structure: Structure) {
 	return chainIntentChecks(
-		() => checkMyStructure(structure, Structure),
+		() => structure instanceof Structure ? C.OK : C.ERR_INVALID_ARGS,
+		() => structure.room.controller?.my ? C.OK : C.ERR_NOT_OWNER,
 		() => {
 			if ((structure.hits ?? 0) <= 0) {
 				return C.ERR_INVALID_TARGET;

--- a/packages/xxscreeps/mods/structure/structure.ts
+++ b/packages/xxscreeps/mods/structure/structure.ts
@@ -105,10 +105,7 @@ export class OwnedStructure extends withOverlay(Structure, ownedShape) {
 	/**
 	 * Whether this is your own structure.
 	 */
-	@enumerable override get my() {
-		const user = this['#user'];
-		return user === null ? undefined : user === me;
-	}
+	@enumerable override get my() { return this['#user'] === me; }
 
 	// TODO: This may be invoked each tick until the processor calls isActive. The cache
 	// does not persist from runner into processor, only from processor into runtime.


### PR DESCRIPTION
Two bugs in `mods/structure/structure.ts`:

**1. `checkMyStructure` precedence** (`structure.ts:203`). The `!structure.my && !structure.room.controller?.my` fallback lets another player's structure succeed when the caller owns the room controller. Vanilla's per-intent methods gate on `!this.my` alone — `StructureLab.prototype.runReaction` (`@screeps/engine/src/game/structures.js:318`), `StructureObserver.prototype.observeRoom` (line 549), `StructureFactory.prototype.produce` (line 1093). Require `structure.my`.

**2. `Structure.prototype.destroy`** (vanilla `structures.js:72-78`) checks only `room.controller.my`, never `this.my`. xxscreeps's `checkDestroy` delegated to `checkMyStructure(structure, Structure)`, which accepted self-ownership — a player could destroy their own rampart placed in another player's room. Inline `controller.my` in `checkDestroy`; keep `checkMyStructure` as the structure-ownership path only.

**Intentional divergence on `StructureController.my` for never-claimed controllers.** Vanilla distinguishes never-claimed (`user` field absent → `my === undefined`) from post-unclaim (`user === null` → `my === false`). xxscreeps serializes `#user` as `string | null` with no "absent" representation, so a single-branch getter must collapse one case onto the other. `OwnedStructure.my` is simplified to `this['#user'] === me`, consistent with `Creep.my` and `ConstructionSite.my`, and the never-claimed case returns `false` instead of `undefined`. Post-unclaim (the case player code actually branches on) now matches vanilla.

Verified against ok-screeps.