### PR TITLE
Fix cooldown anchoring for lab, factory, and extractor intents

### DIFF
--- a/packages/xxscreeps/mods/chemistry/processor.ts
+++ b/packages/xxscreeps/mods/chemistry/processor.ts
@@ -29,11 +29,6 @@ const intents = [
 		lab.store['#add'](product, C.LAB_REACTION_AMOUNT);
 		left.store['#subtract'](left.mineralType!, C.LAB_REACTION_AMOUNT);
 		right.store['#subtract'](right.mineralType!, C.LAB_REACTION_AMOUNT);
-		// `-1` compensates for xxscreeps running intent processing and the cooldown
-		// getter at the same Game.time, which drops the implicit decrement vanilla
-		// gets from its tick split (processor writes at gameTime = T, user code
-		// reads at runtimeData.time = T+1). Without it, the observer sees
-		// REACTION_TIME instead of REACTION_TIME-1.
 		lab['#cooldownTime'] = Game.time + reactionTime[product]! - 1;
 		saveAction(lab, 'reaction1', left.pos);
 		saveAction(lab, 'reaction2', right.pos);
@@ -94,7 +89,6 @@ const intents = [
 		lab1.store['#add'](variant[0], C.LAB_REACTION_AMOUNT);
 		lab2.store['#add'](variant[1], C.LAB_REACTION_AMOUNT);
 		const reactionTime: ReactionTimeLookup = C.REACTION_TIME;
-		// See runReaction above for the `-1` rationale (no-implicit-decrement).
 		lab['#cooldownTime'] = Game.time + reactionTime[mineralType]! - 1;
 		saveAction(lab, 'reverseReaction1', lab1.pos);
 		saveAction(lab, 'reverseReaction2', lab2.pos);
@@ -142,7 +136,6 @@ const intents = [
 		}
 
 		if (cooldown > 0) {
-			// See runReaction above for the `-1` rationale (no-implicit-decrement).
 			lab['#cooldownTime'] = Game.time + cooldown - 1;
 		}
 

--- a/packages/xxscreeps/mods/chemistry/processor.ts
+++ b/packages/xxscreeps/mods/chemistry/processor.ts
@@ -29,7 +29,12 @@ const intents = [
 		lab.store['#add'](product, C.LAB_REACTION_AMOUNT);
 		left.store['#subtract'](left.mineralType!, C.LAB_REACTION_AMOUNT);
 		right.store['#subtract'](right.mineralType!, C.LAB_REACTION_AMOUNT);
-		lab['#cooldownTime'] = Game.time + reactionTime[product]!;
+		// `-1` compensates for xxscreeps running intent processing and the cooldown
+		// getter at the same Game.time, which drops the implicit decrement vanilla
+		// gets from its tick split (processor writes at gameTime = T, user code
+		// reads at runtimeData.time = T+1). Without it, the observer sees
+		// REACTION_TIME instead of REACTION_TIME-1.
+		lab['#cooldownTime'] = Game.time + reactionTime[product]! - 1;
 		saveAction(lab, 'reaction1', left.pos);
 		saveAction(lab, 'reaction2', right.pos);
 		context.didUpdate();
@@ -89,7 +94,8 @@ const intents = [
 		lab1.store['#add'](variant[0], C.LAB_REACTION_AMOUNT);
 		lab2.store['#add'](variant[1], C.LAB_REACTION_AMOUNT);
 		const reactionTime: ReactionTimeLookup = C.REACTION_TIME;
-		lab['#cooldownTime'] = Game.time + reactionTime[mineralType]!;
+		// See runReaction above for the `-1` rationale (no-implicit-decrement).
+		lab['#cooldownTime'] = Game.time + reactionTime[mineralType]! - 1;
 		saveAction(lab, 'reverseReaction1', lab1.pos);
 		saveAction(lab, 'reverseReaction2', lab2.pos);
 		context.didUpdate();
@@ -136,7 +142,8 @@ const intents = [
 		}
 
 		if (cooldown > 0) {
-			lab['#cooldownTime'] = Game.time + cooldown;
+			// See runReaction above for the `-1` rationale (no-implicit-decrement).
+			lab['#cooldownTime'] = Game.time + cooldown - 1;
 		}
 
 		context.didUpdate();

--- a/packages/xxscreeps/mods/chemistry/test.ts
+++ b/packages/xxscreeps/mods/chemistry/test.ts
@@ -70,9 +70,12 @@ describe('Chemistry', () => {
 			await player('100', Game => {
 				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
 				const output = labs.find(lab => lab.mineralType === 'OH')!;
-				// OH has REACTION_TIME of 20, not the generic LAB_COOLDOWN of 10
-				assert.strictEqual(output.cooldown, C.REACTION_TIME.OH,
-					`cooldown should be REACTION_TIME.OH (${C.REACTION_TIME.OH}), not LAB_COOLDOWN (${C.LAB_COOLDOWN})`);
+				// OH has REACTION_TIME of 20, not the generic LAB_COOLDOWN of 10. The
+				// observable cooldown is REACTION_TIME - 1: vanilla writes cooldownTime
+				// in the processor at gameTime = T and reads it in user code at
+				// runtimeData.time = T+1.
+				assert.strictEqual(output.cooldown, C.REACTION_TIME.OH - 1,
+					`cooldown should be REACTION_TIME.OH - 1 (${C.REACTION_TIME.OH - 1}), not LAB_COOLDOWN (${C.LAB_COOLDOWN})`);
 			});
 		}));
 
@@ -348,8 +351,9 @@ describe('Chemistry', () => {
 			await player('100', Game => {
 				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
 				const labOH = labs.find(lab => lab.pos.isEqualTo(25, 25))!;
-				assert.strictEqual(labOH.cooldown, C.REACTION_TIME.OH,
-					'cooldown should match REACTION_TIME for the compound');
+				// Observable cooldown is REACTION_TIME - 1; see runReaction test above.
+				assert.strictEqual(labOH.cooldown, C.REACTION_TIME.OH - 1,
+					'cooldown should match REACTION_TIME - 1 for the compound');
 			});
 		}));
 

--- a/packages/xxscreeps/mods/factory/processor.ts
+++ b/packages/xxscreeps/mods/factory/processor.ts
@@ -19,10 +19,6 @@ const intents = [
 			factory.store['#subtract'](component as ResourceType, amount);
 		}
 		factory.store['#add'](resourceType, recipe.amount);
-		// `-1` compensates for xxscreeps running intent processing and the cooldown
-		// getter at the same Game.time, which drops the implicit decrement vanilla
-		// gets from its tick split (processor writes at gameTime = T, user code
-		// reads at runtimeData.time = T+1). See `mods/chemistry/processor.ts`.
 		factory['#cooldownTime'] = Game.time + recipe.cooldown - 1;
 		saveAction(factory, 'produce', factory.pos);
 		context.didUpdate();

--- a/packages/xxscreeps/mods/factory/processor.ts
+++ b/packages/xxscreeps/mods/factory/processor.ts
@@ -19,7 +19,11 @@ const intents = [
 			factory.store['#subtract'](component as ResourceType, amount);
 		}
 		factory.store['#add'](resourceType, recipe.amount);
-		factory['#cooldownTime'] = Game.time + recipe.cooldown;
+		// `-1` compensates for xxscreeps running intent processing and the cooldown
+		// getter at the same Game.time, which drops the implicit decrement vanilla
+		// gets from its tick split (processor writes at gameTime = T, user code
+		// reads at runtimeData.time = T+1). See `mods/chemistry/processor.ts`.
+		factory['#cooldownTime'] = Game.time + recipe.cooldown - 1;
 		saveAction(factory, 'produce', factory.pos);
 		context.didUpdate();
 	}),

--- a/packages/xxscreeps/mods/factory/test.ts
+++ b/packages/xxscreeps/mods/factory/test.ts
@@ -45,7 +45,9 @@ describe('Factory', () => {
 				assert.strictEqual(factory.store[C.RESOURCE_UTRIUM_BAR], 100);
 				assert.strictEqual(factory.store[C.RESOURCE_UTRIUM], 0);
 				assert.strictEqual(factory.store[C.RESOURCE_ENERGY], 0);
-				assert.strictEqual(factory.cooldown, 20);
+				// recipe.cooldown is 20; observable cooldown is recipe.cooldown - 1
+				// (processor write at gameTime = T, user read at runtimeData.time = T+1).
+				assert.strictEqual(factory.cooldown, 19);
 			});
 		}));
 
@@ -70,7 +72,8 @@ describe('Factory', () => {
 				assert.strictEqual(factory.store[C.RESOURCE_UTRIUM], 500);
 				assert.strictEqual(factory.store[C.RESOURCE_UTRIUM_BAR], 0);
 				assert.strictEqual(factory.store[C.RESOURCE_ENERGY], 0);
-				assert.strictEqual(factory.cooldown, 20);
+				// See `produce bar from mineral` above for the `-1` rationale.
+				assert.strictEqual(factory.cooldown, 19);
 			});
 		}));
 

--- a/packages/xxscreeps/mods/mineral/processor.ts
+++ b/packages/xxscreeps/mods/mineral/processor.ts
@@ -18,8 +18,6 @@ registerHarvestProcessor(Mineral, (creep, mineral) => {
 		Resource.drop(creep.pos, mineral.mineralType, overflow);
 	}
 	const extractor = lookForStructureAt(mineral.room, mineral.pos, C.STRUCTURE_EXTRACTOR)!;
-	// No `-1` here: vanilla's extractor uses a raw counter (not cooldownTime), so
-	// the first observer tick reads the full EXTRACTOR_COOLDOWN — unlike labs/factories.
 	extractor['#cooldownTime'] = Game.time + C.EXTRACTOR_COOLDOWN;
 	return amount;
 });

--- a/packages/xxscreeps/mods/mineral/processor.ts
+++ b/packages/xxscreeps/mods/mineral/processor.ts
@@ -18,7 +18,9 @@ registerHarvestProcessor(Mineral, (creep, mineral) => {
 		Resource.drop(creep.pos, mineral.mineralType, overflow);
 	}
 	const extractor = lookForStructureAt(mineral.room, mineral.pos, C.STRUCTURE_EXTRACTOR)!;
-	extractor['#cooldownTime'] = Game.time + C.EXTRACTOR_COOLDOWN - 1;
+	// No `-1` here: vanilla's extractor uses a raw counter (not cooldownTime), so
+	// the first observer tick reads the full EXTRACTOR_COOLDOWN — unlike labs/factories.
+	extractor['#cooldownTime'] = Game.time + C.EXTRACTOR_COOLDOWN;
 	return amount;
 });
 


### PR DESCRIPTION
xxscreeps runs intent processing and the cooldown getter at the same `Game.time`, while vanilla writes `cooldownTime` in the intent processor at `gameTime = T` and reads the getter in user code at `runtimeData.time = T+1`. Vanilla's observable cooldown is therefore implicitly `T + DURATION - (T+1) = DURATION - 1`; xxscreeps sees the full `DURATION` unless the write compensates.

Three sites drifted from vanilla's observable:

1. `mods/chemistry/processor.ts` runReaction/reverseReaction/unboostCreep (lines 32, 92, 139) wrote `Game.time + X`, reporting `REACTION_TIME` instead of `REACTION_TIME - 1`. Subtract 1.

2. `mods/factory/processor.ts` produce (line 22) had the same bug, reporting the full recipe cooldown. Subtract 1.

3. `mods/mineral/processor.ts` harvest (line 21) wrote `Game.time + EXTRACTOR_COOLDOWN - 1`, but vanilla's extractor uses a counter + tick-processor decrement (`@screeps/engine/src/processor/intents/extractors/tick.js`), so it never gets the implicit `-1` that cooldownTime-based intents do. The `-1` over-corrected; drop it so the raw `EXTRACTOR_COOLDOWN` is visible at the first observer tick.

The same pattern was applied in `mods/logistics/processor.ts:17` (merged as #127): the `-1` is the engine-level compensation for xxscreeps's single-Game.time execution model.

Verified against ok-screeps.