### PR TITLE
Fix Store.getFreeCapacity null propagation and OpenStore pool semantics

### DIFF
--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -384,7 +384,7 @@ export class Creep extends withOverlay(RoomObject, shape) {
 	transfer(this: Creep, target: RoomObject & WithStore, resourceType: ResourceType, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-			amount || Math.min(this.store[resourceType], target.store.getFreeCapacity(resourceType)));
+			amount || Math.min(this.store[resourceType], target.store.getFreeCapacity(resourceType)!));
 		return chainIntentChecks(
 			() => checkTransfer(this, target, resourceType, intentAmount),
 			() => intents.save(this, 'transfer', target.id, resourceType, intentAmount),

--- a/packages/xxscreeps/mods/logistics/link.ts
+++ b/packages/xxscreeps/mods/logistics/link.ts
@@ -35,7 +35,7 @@ export class StructureLink extends withOverlay(OwnedStructure, shape) {
 	transferEnergy(target: StructureLink, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-			amount || Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)));
+			amount || Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
 		return chainIntentChecks(
 			() => checkTransferEnergy(this, target, intentAmount),
 			() => intents.save(this, 'transferEnergy', target.id, intentAmount));

--- a/packages/xxscreeps/mods/resource/store.ts
+++ b/packages/xxscreeps/mods/resource/store.ts
@@ -339,9 +339,10 @@ export function calculateChecked(object1: WithStore | undefined, object2: WithSt
 }
 
 export function checkHasCapacity(target: WithStore, resourceType: ResourceType, amount: number) {
-	if (target.store.getCapacity(resourceType) === null) {
+	const free = target.store.getFreeCapacity(resourceType);
+	if (free === null) {
 		return C.ERR_INVALID_TARGET;
-	} else if (target.store.getFreeCapacity(resourceType)! >= Math.max(1, amount)) {
+	} else if (free >= Math.max(1, amount)) {
 		return C.OK;
 	} else {
 		return C.ERR_FULL;

--- a/packages/xxscreeps/mods/resource/store.ts
+++ b/packages/xxscreeps/mods/resource/store.ts
@@ -70,9 +70,15 @@ export abstract class Store extends BufferObjectWithResourcesType {
 	/**
 	 * A shorthand for `getCapacity(resource) - getUsedCapacity(resource)`.
 	 * @param resourceType The type of resource
+	 * @returns Free capacity, or null when the store cannot hold this resource type.
 	 */
-	getFreeCapacity(resourceType?: ResourceType) {
-		return this.getCapacity(resourceType)! - this.getUsedCapacity(resourceType)!;
+	getFreeCapacity(resourceType?: ResourceType): number | null {
+		const capacity = this.getCapacity(resourceType);
+		const used = this.getUsedCapacity(resourceType);
+		if (capacity === null || used === null) {
+			return null;
+		}
+		return capacity - used;
 	}
 
 	'#entries'(): Iterable<[ ResourceType, number ]> {
@@ -133,6 +139,10 @@ export class OpenStore extends withOverlay(Store, shapeOpen) {
 		} else {
 			return this._sum;
 		}
+	}
+
+	override getFreeCapacity(_resourceType?: ResourceType) {
+		return this['#capacity'] - this._sum;
 	}
 
 	'#add'(type: ResourceType, amount: number) {
@@ -329,7 +339,9 @@ export function calculateChecked(object1: WithStore | undefined, object2: WithSt
 }
 
 export function checkHasCapacity(target: WithStore, resourceType: ResourceType, amount: number) {
-	if (target.store.getFreeCapacity(resourceType) >= Math.max(1, amount)) {
+	if (target.store.getCapacity(resourceType) === null) {
+		return C.ERR_INVALID_TARGET;
+	} else if (target.store.getFreeCapacity(resourceType)! >= Math.max(1, amount)) {
 		return C.OK;
 	} else {
 		return C.ERR_FULL;
@@ -341,6 +353,8 @@ export function checkHasResource(target: WithStore, resourceType: ResourceType |
 		return C.ERR_INVALID_ARGS;
 	} else if (typeof amount !== 'number' || amount < 0) {
 		return C.ERR_INVALID_ARGS;
+	} else if (target.store.getCapacity(resourceType!) === null) {
+		return C.ERR_INVALID_TARGET;
 	} else if (target.store[resourceType!] >= Math.max(1, amount)) {
 		return C.OK;
 	} else {


### PR DESCRIPTION
Three connected bugs in `mods/resource/store.ts`, all keyed off the same invariant: `Store.getCapacity(rt) === null` is the canonical "this store cannot hold this resource type" signal. Three call paths must respect it.

1. **Base `Store.getFreeCapacity`** did `getCapacity(rt)! - getUsedCapacity(rt)!` with non-null assertions. For `LabStore` (and any restricted store) queried with a wrong resource type both operands are `null`; `null - null` coerces to `0`, losing the null signal downstream callers rely on. Short-circuit to `null` when either operand is `null`.

2. **`OpenStore`** inherited the per-type subtraction formula, which is wrong for shared-capacity stores: `#capacity - this[rt]` returns full capacity for any empty slot regardless of what else fills the pool. A creep with `{energy: 45}` in a 50-cap store reported `getFreeCapacity('H') === 50` instead of `5`, so e.g. the mineral overflow check at `mods/mineral/processor.ts:14` absorbed all harvested H instead of dropping it. Override `OpenStore.getFreeCapacity` to return `#capacity - _sum` regardless of `resourceType`.

3. **`checkHasResource` / `checkHasCapacity`** bypassed the store API and tested raw amounts, so a wrong-resource transfer/withdraw to an energy-only structure returned `ERR_FULL` or `ERR_NOT_ENOUGH_RESOURCES` instead of `ERR_INVALID_TARGET`. Gate both helpers on `getCapacity(rt) === null` first.

Verified against ok-screeps.