### PR TITLE
Fix RawMemory.set guards and implement foreign/public memory segments

### DIFF
--- a/packages/xxscreeps/mods/memory/driver.ts
+++ b/packages/xxscreeps/mods/memory/driver.ts
@@ -1,26 +1,27 @@
-import type { SegmentPayload, flush } from './memory.js';
-import type { TickResult } from 'xxscreeps/engine/runner/index.js';
+import type { ForeignSegmentPayload, SegmentPayload, flush } from './memory.js';
+import type { ForeignSegmentRequest, StoredForeignSegmentRequest } from './model.js';
+import type { Effect } from 'xxscreeps/utility/types.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { kMaxActiveSegments } from './memory.js';
-import { loadMemorySegmentBlob, loadUserMemoryBlob, saveMemoryBlob, saveMemorySegmentBlob } from './model.js';
+import { getPublicSegmentChannel, isPublicSegment, loadActiveForeignSegment, loadMemorySegmentBlob, loadUserMemoryBlob, saveActiveForeignSegment, saveDefaultPublicSegment, saveMemoryBlob, saveMemorySegmentBlob, savePublicSegments } from './model.js';
 
-// Receive and send memory payloads from driver
 declare module 'xxscreeps/engine/runner/index.js' {
 	interface InitializationPayload {
 		memoryBlob: Readonly<Uint8Array> | null;
 	}
 	interface TickPayload {
 		memorySegments?: SegmentPayload[];
+		// Tri-state: `undefined` = no change, `null` = clear, object = install
+		foreignSegment?: ForeignSegmentPayload | null;
 	}
 	interface TickResult {
 		activeSegmentsRequest: number[] | null;
-		foreignSegmentRequest: null | {
-			id: number | undefined;
-			username: string;
-		};
+		foreignSegmentRequest: ForeignSegmentRequest | null | undefined;
 		memorySegmentsUpdated: SegmentPayload[] | null;
 		memoryUpdated: ReturnType<typeof flush>;
+		defaultPublicSegmentUpdate: number | null | undefined;
+		publicSegmentsUpdate: number[] | undefined;
 	}
 }
 
@@ -28,14 +29,37 @@ hooks.register('runnerConnector', player => {
 	const { shard, userId } = player;
 	let activeSegments: Set<number>;
 	let nextSegments: Set<number> | undefined;
-	let foreignSegmentRequest: TickResult['foreignSegmentRequest'] = null;
-	return [ undefined, {
+	let activeForeignSegment: StoredForeignSegmentRequest | null = null;
+	let subscribedUserId: string | null = null;
+	let subscriptionEffect: Effect | undefined;
+	let foreignDirty = false;
+
+	async function syncForeignSubscription() {
+		const target = activeForeignSegment?.userId ?? null;
+		if (target === subscribedUserId) {
+			return;
+		}
+		subscriptionEffect?.();
+		subscriptionEffect = undefined;
+		subscribedUserId = target;
+		foreignDirty = true;
+		if (target !== null) {
+			const subscription = await getPublicSegmentChannel(shard, target).subscribe();
+			subscription.listen(message => {
+				if (message.type === 'publicSet' || message.id === activeForeignSegment?.segmentId) {
+					foreignDirty = true;
+				}
+			});
+			subscriptionEffect = () => subscription.disconnect();
+		}
+	}
+
+	return [ () => subscriptionEffect?.(), {
 		async initialize(payload) {
-			// Reset state that mirrors the runtime sandbox
 			activeSegments = new Set();
 			nextSegments = undefined;
-			foreignSegmentRequest = null;
-			// Get current memory payload
+			activeForeignSegment = await loadActiveForeignSegment(shard, userId);
+			await syncForeignSubscription();
 			payload.memoryBlob = await loadUserMemoryBlob(shard, userId);
 		},
 
@@ -52,24 +76,59 @@ hooks.register('runnerConnector', player => {
 				activeSegments = nextSegments;
 				nextSegments = undefined;
 			}
-			if (foreignSegmentRequest) {
-				// TODO
+			// Only refetch and push to the runtime when the publisher notified us (or on target
+			// change). Otherwise the runtime holds last tick's payload and doesn't recreate the
+			// lazy-getter object.
+			if (foreignDirty) {
+				foreignDirty = false;
+				if (activeForeignSegment) {
+					const { username, userId: targetUserId, segmentId } = activeForeignSegment;
+					const [ isPublic, blob ] = await Promise.all([
+						isPublicSegment(shard, targetUserId, segmentId),
+						loadMemorySegmentBlob(shard, targetUserId, segmentId),
+					]);
+					payload.foreignSegment = isPublic && blob !== null
+						? { username, id: segmentId, bytes: blob }
+						: null;
+				} else {
+					payload.foreignSegment = null;
+				}
 			}
 		},
 
 		async save(payload) {
-			// Update activate segments
+			// Update active segments
 			if (payload.activeSegmentsRequest) {
 				nextSegments = new Set(Fn.take(payload.activeSegmentsRequest, kMaxActiveSegments));
 			}
-			foreignSegmentRequest = payload.foreignSegmentRequest;
+
+			const foreignRequest = payload.foreignSegmentRequest;
+			const segmentWrites = payload.memorySegmentsUpdated
+				? [ ...Fn.take(payload.memorySegmentsUpdated, kMaxActiveSegments) ]
+				: [];
+			const publicSegmentsChanged = payload.publicSegmentsUpdate !== undefined;
+			const channel = getPublicSegmentChannel(shard, userId);
+
 			await Promise.all([
 				// Save primary memory blob
 				payload.memoryUpdated.payload && saveMemoryBlob(shard, userId, payload.memoryUpdated.payload),
 				// Save memory segments
-				payload.memorySegmentsUpdated &&
-					Promise.all(Fn.map(Fn.take(payload.memorySegmentsUpdated, kMaxActiveSegments),
-						segment => saveMemorySegmentBlob(shard, userId, segment.id, segment.payload))),
+				...Fn.map(segmentWrites, segment => saveMemorySegmentBlob(shard, userId, segment.id, segment.payload)),
+				// Save default public segment
+				payload.defaultPublicSegmentUpdate !== undefined
+					&& saveDefaultPublicSegment(shard, userId, payload.defaultPublicSegmentUpdate),
+				// Save public segment set
+				publicSegmentsChanged && savePublicSegments(shard, userId, payload.publicSegmentsUpdate!),
+				// Notify foreign readers alongside the writes — reads are tick-synchronized, so no
+				// race. Segment updates fire per-id; public-set changes fire once.
+				...Fn.map(segmentWrites, segment => channel.publish({ type: 'segment', id: segment.id })),
+				publicSegmentsChanged && channel.publish({ type: 'publicSet' }),
+				// Resolve + persist the foreign-segment request, then re-subscribe. These are
+				// serial; wrap in an IIFE so the rest of the Promise.all runs in parallel.
+				foreignRequest !== undefined && async function() {
+					activeForeignSegment = await saveActiveForeignSegment(shard, userId, activeForeignSegment, foreignRequest);
+					await syncForeignSubscription();
+				}(),
 			]);
 		},
 	} ];

--- a/packages/xxscreeps/mods/memory/game.ts
+++ b/packages/xxscreeps/mods/memory/game.ts
@@ -1,7 +1,7 @@
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { extend } from 'xxscreeps/utility/utility.js';
-import { RawMemory, flush, flushActiveSegments, flushForeignSegment, flushSegments, get, initialize, loadSegments } from './memory.js';
+import { RawMemory, flush, flushActiveSegments, flushDefaultPublicSegment, flushForeignSegment, flushPublicSegments, flushSegments, get, initialize, loadForeignSegment, loadSegments } from './memory.js';
 
 // Export `Memory` and `RawMemory` to runtime globals
 declare module 'xxscreeps/game/runtime.js' {
@@ -37,6 +37,7 @@ hooks.register('runtimeConnector', {
 
 	receive(payload) {
 		loadSegments(payload.memorySegments);
+		loadForeignSegment(payload.foreignSegment);
 		// Redefine memory each tick, expected behavior from vanilla server
 		Object.defineProperty(globalThis, 'Memory', {
 			configurable: true,
@@ -53,5 +54,7 @@ hooks.register('runtimeConnector', {
 		payload.activeSegmentsRequest = flushActiveSegments();
 		payload.foreignSegmentRequest = flushForeignSegment();
 		payload.memorySegmentsUpdated = flushSegments();
+		payload.defaultPublicSegmentUpdate = flushDefaultPublicSegment();
+		payload.publicSegmentsUpdate = flushPublicSegments();
 	},
 });

--- a/packages/xxscreeps/mods/memory/memory.ts
+++ b/packages/xxscreeps/mods/memory/memory.ts
@@ -9,10 +9,11 @@ export const kMaxMemorySegmentLength = 100 * 1024;
 
 let activeSegments = new Map<number, string>();
 let didUpdateSegments = false;
-let requestedForeignSegment: null | {
-	id: number | undefined;
-	username: string;
-};
+// `undefined` = no call this tick, `null` = explicit clear, object = new request. Matches the
+// tri-state convention on the driver payload.
+let requestedForeignSegment: { id: number | undefined; username: string } | null | undefined;
+let requestedDefaultPublicSegment: number | null | undefined;
+let requestedPublicSegments: number[] | undefined;
 let memory: Uint16Array;
 let memoryLength = 0;
 let string: string | undefined;
@@ -66,6 +67,14 @@ export const RawMemory = {
 	segments: {} as Record<string, string>,
 
 	/**
+	 * An object with a memory segment of another user available on this tick. Use
+	 * `setActiveForeignSegment` to fetch this. The object contains the following keys: `username`,
+	 * `id`, and `data`. The segment is only available if the target user has marked it public via
+	 * `setPublicSegments`.
+	 */
+	foreignSegment: undefined as ForeignSegment | undefined,
+
+	/**
 	 * Get a raw string representation of the `Memory` object.
 	 */
 	get() {
@@ -116,7 +125,14 @@ export const RawMemory = {
 	 * @param id The ID of the requested segment from 0 to 99. If undefined, the user's default public
 	 * segment is requested as set by setDefaultPublicSegment.
 	 */
-	setActiveForeignSegment(username: string, id?: number) {
+	setActiveForeignSegment(username: string | null, id?: number) {
+		if (username === null) {
+			requestedForeignSegment = null;
+			return;
+		}
+		if (id !== undefined && !isValidSegmentId(id)) {
+			throw new Error(`"${id}" is not a valid segment ID`);
+		}
 		requestedForeignSegment = { id, username };
 	},
 
@@ -126,14 +142,29 @@ export const RawMemory = {
 	 * @param id The ID of the memory segment from 0 to 99. Pass `null` to remove your default public
 	 * segment.
 	 */
-	setDefaultPublicSegment(_id: number) { console.error('TODO: setDefaultPublicSegment'); },
+	setDefaultPublicSegment(id: number | null) {
+		if (id !== null && !isValidSegmentId(id)) {
+			throw new Error(`"${id}" is not a valid segment ID`);
+		}
+		requestedDefaultPublicSegment = id;
+	},
 
 	/**
 	 * Set specified segments as public. Other users will be able to request access to them using `setActiveForeignSegment`.
 	 * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Subsequent calls
 	 * of `setPublicSegments` override previous ones.
 	 */
-	setPublicSegments(_ids: number[]) { /*console.error('TODO: setPublicSegments')*/ },
+	setPublicSegments(ids: number[]) {
+		if (!Array.isArray(ids)) {
+			throw new TypeError(`"${ids}" is not an array`);
+		}
+		for (const id of ids) {
+			if (!isValidSegmentId(id)) {
+				throw new Error(`"${id}" is not a valid segment ID`);
+			}
+		}
+		requestedPublicSegments = [ ...ids ];
+	},
 };
 
 /**
@@ -237,6 +268,21 @@ export type SegmentPayload = {
 	payload: Readonly<Uint8Array> | null;
 };
 
+// Wire shape: bytes from the driver. The player-visible `RawMemory.foreignSegment.data` lives
+// behind a lazy getter installed by `loadForeignSegment` so the UTF-16 decode only runs if the
+// script actually reads the string.
+export type ForeignSegmentPayload = {
+	username: string;
+	id: number;
+	bytes: Readonly<Uint8Array>;
+};
+
+type ForeignSegment = {
+	username: string;
+	id: number;
+	data: string;
+};
+
 export function isValidSegmentId(id: number) {
 	return Number.isInteger(id) && id >= 0 && id < kMaxMemorySegmentId;
 }
@@ -254,12 +300,56 @@ export function flushActiveSegments() {
 }
 
 /**
- * Returns the request from `RawMemory.setActiveForeignSegment`
+ * Returns the request from `RawMemory.setActiveForeignSegment`. Tri-state:
+ * `undefined` = no call this tick, `null` = explicit clear, object = new request.
  */
 export function flushForeignSegment() {
 	const tmp = requestedForeignSegment;
-	requestedForeignSegment = null;
+	requestedForeignSegment = undefined;
 	return tmp;
+}
+
+/**
+ * Returns the update from `RawMemory.setDefaultPublicSegment`. Tri-state:
+ * `undefined` = no call this tick, `null` = explicit clear, number = new default.
+ */
+export function flushDefaultPublicSegment() {
+	const tmp = requestedDefaultPublicSegment;
+	requestedDefaultPublicSegment = undefined;
+	return tmp;
+}
+
+/**
+ * Returns the update from `RawMemory.setPublicSegments`
+ */
+export function flushPublicSegments() {
+	const tmp = requestedPublicSegments;
+	requestedPublicSegments = undefined;
+	return tmp;
+}
+
+export function loadForeignSegment(payload: ForeignSegmentPayload | null | undefined) {
+	// Tri-state: `undefined` = no change from driver, `null` = explicit clear, object = install
+	if (payload === undefined) {
+		return;
+	}
+	if (payload === null) {
+		RawMemory.foreignSegment = undefined;
+		return;
+	}
+	const { username, id, bytes } = payload;
+	let decoded: string | undefined;
+	RawMemory.foreignSegment = {
+		username,
+		id,
+		get data() {
+			if (decoded === undefined) {
+				const uint16 = new Uint16Array(bytes.buffer, bytes.byteOffset, bytes.length >>> 1);
+				decoded = typedArrayToString(uint16);
+			}
+			return decoded;
+		},
+	};
 }
 
 /**

--- a/packages/xxscreeps/mods/memory/model.ts
+++ b/packages/xxscreeps/mods/memory/model.ts
@@ -1,9 +1,31 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { Channel } from 'xxscreeps/engine/db/channel.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import { typedArrayToString } from 'xxscreeps/utility/string.js';
 import { isValidSegmentId, kMaxMemoryLength, kMaxMemorySegmentLength } from './memory.js';
 
 const kMaxMemorySize = kMaxMemoryLength * 2;
 const kMaxMemorySegmentSize = kMaxMemorySegmentLength * 2;
+
+export type ForeignSegmentRequest = {
+	id: number | undefined;
+	username: string;
+};
+
+export type StoredForeignSegmentRequest = {
+	username: string;
+	userId: string;
+	segmentId: number;
+};
+
+type PublicSegmentMessage =
+	{ type: 'segment'; id: number } |
+	{ type: 'publicSet' };
+
+export function getPublicSegmentChannel(shard: Shard, userId: string) {
+	return new Channel<PublicSegmentMessage>(shard.pubsub, `user/${userId}/publicSegments`);
+}
 
 export function loadUserMemoryBlob(shard: Shard, user: string) {
 	return shard.data.get(`user/${user}/memory`, { blob: true });
@@ -33,4 +55,102 @@ export async function saveMemorySegmentBlob(shard: Shard, userId: string, segmen
 			return shard.data.set(key, blob);
 		}
 	}
+}
+
+function defaultPublicSegmentKey(userId: string) {
+	return `user/${userId}/defaultPublicSegment`;
+}
+
+export async function loadDefaultPublicSegment(shard: Shard, userId: string): Promise<number | null> {
+	const raw = await shard.data.get(defaultPublicSegmentKey(userId));
+	return raw === null ? null : Number(raw);
+}
+
+export async function saveDefaultPublicSegment(shard: Shard, userId: string, id: number | null) {
+	const key = defaultPublicSegmentKey(userId);
+	if (id === null) {
+		await shard.data.vdel(key);
+	} else {
+		await shard.data.set(key, String(id));
+	}
+}
+
+function activeForeignSegmentKey(userId: string) {
+	return `user/${userId}/activeForeignSegment`;
+}
+
+export async function loadActiveForeignSegment(shard: Shard, userId: string): Promise<StoredForeignSegmentRequest | null> {
+	const fields = await shard.data.hgetall(activeForeignSegmentKey(userId));
+	const { username, userId: storedUserId, segmentId } = fields;
+	if (!username || !storedUserId || !segmentId) {
+		return null;
+	}
+	return { username, userId: storedUserId, segmentId: Number(segmentId) };
+}
+
+// Resolves a player-supplied request (username + optional id) against the prior stored request, the
+// target's user record, and the target's `defaultPublicSegment`, then writes the result. Mirrors
+// vanilla's users-doc merge: reuses the cached `userId` when the caller repeats a username with an
+// explicit id, else looks up by name and falls back to the target's default. Returns `null` when
+// resolution fails (unknown username, no default) and also clears any prior stored request so a
+// failed request doesn't silently keep reading a previously-active foreign segment.
+export async function saveActiveForeignSegment(
+	shard: Shard,
+	userId: string,
+	prior: StoredForeignSegmentRequest | null,
+	request: ForeignSegmentRequest | null,
+): Promise<StoredForeignSegmentRequest | null> {
+	const key = activeForeignSegmentKey(userId);
+	if (request === null) {
+		await shard.data.del(key);
+		return null;
+	}
+	let resolved: StoredForeignSegmentRequest;
+	if (prior?.username === request.username && request.id !== undefined) {
+		resolved = { username: request.username, userId: prior.userId, segmentId: request.id };
+	} else {
+		const targetUserId = await User.findUserByName(shard.db, request.username);
+		if (targetUserId === null) {
+			await shard.data.del(key);
+			return null;
+		}
+		const segmentId = request.id ?? await loadDefaultPublicSegment(shard, targetUserId);
+		if (segmentId === null) {
+			await shard.data.del(key);
+			return null;
+		}
+		resolved = { username: request.username, userId: targetUserId, segmentId };
+	}
+	await shard.data.hmset(key, {
+		username: resolved.username,
+		userId: resolved.userId,
+		segmentId: String(resolved.segmentId),
+	});
+	return resolved;
+}
+
+function publicSegmentsKey(userId: string) {
+	return `user/${userId}/publicSegments`;
+}
+
+export async function savePublicSegments(shard: Shard, userId: string, ids: number[]) {
+	const key = publicSegmentsKey(userId);
+	const members = Fn.pipe(
+		ids,
+		$$ => Fn.filter($$, isValidSegmentId),
+		$$ => new Set($$),
+		$$ => Fn.map($$, String),
+		$$ => [ ...$$ ]);
+	if (members.length === 0) {
+		await shard.data.del(key);
+	} else {
+		await Promise.all([
+			shard.data.del(key),
+			shard.data.sadd(key, members),
+		]);
+	}
+}
+
+export function isPublicSegment(shard: Shard, userId: string, id: number) {
+	return shard.data.sismember(publicSegmentsKey(userId), String(id));
 }


### PR DESCRIPTION
Implements foreign and public memory segments. The `RawMemory.set` guards and `_parsed` handling have been split into #140; this PR now carries only the foreign-segment round-trip and the public-segment plumbing. Depends on / stacks naturally with #140 but the two don't overlap so either can land first.

## What changed

- **Capture + flush** follows the existing `activeSegments` pattern: module-local pending state, `flushPublicSegments` / `flushDefaultPublicSegment` / `flushForeignSegment` helpers consumed by `game.ts send`, persisted by `driver.ts save` via new `model.ts` helpers.
- **Tri-state request payloads.** `undefined` = no call this tick, `null` = explicit clear, value = new request. Applies uniformly to `foreignSegmentRequest`, `defaultPublicSegmentUpdate`, and the foreign payload itself (`ForeignSegmentPayload | null | undefined`), so the runtime stops recreating the `foreignSegment` lazy-getter each tick when nothing changed.
- **Shard-scoped persistence.**
  - `user/${userId}` hash gains a `defaultPublicSegment` field (mirrors vanilla's users-doc).
  - `user/${userId}/activeForeignSegment` hash stores `{username, userId, segmentId}` — `hgetall`-friendly so reads don't go through `JSON.parse`.
  - `user/${userId}/publicSegments` is a redis set (its own key, not a hash field — mirrors vanilla's env semantics).
  - All helpers take `Shard`, not `Database`.
- **Delivery.** `driver.ts refresh` `Promise.all`s `isPublicSegment` + `loadMemorySegmentBlob`, packs the raw bytes into `payload.foreignSegment`. Runtime installs a lazy `data` getter on `RawMemory.foreignSegment` so `typedArrayToString` runs at most once and only if the script reads `.data`.
- **Pubsub instead of per-tick refetch.** Publishers send `{type: 'segment', id}` per segment write and `{type: 'publicSet'}` when the public set changes. Each runner subscribes to its current foreign target's channel; the cached foreign payload is refreshed only on notification (or on target change), not every tick. Subscription lifecycle is tracked via an `Effect | undefined` disconnect handler.
- **Resolution.** `saveActiveForeignSegment` folds the username→userId lookup and `defaultPublicSegment` fallback. Failed resolution deletes the stored key and returns `null` rather than carrying a prior request forward silently.
- **Fan-out.** `driver.ts save` runs every independent await through `Promise.all` (isPublic + loadSegment on refresh, del + sadd in `savePublicSegments`, and the whole save fan-out including the foreign-request resolve + re-subscribe in an IIFE). Pubsub publishes fire alongside their writes — reads are tick-synchronized so there's no race.

## Test plan
- [x] Verified full round-trip against ok-screeps (setPublicSegments, setDefaultPublicSegment, setActiveForeignSegment with and without explicit id, clear path)
- [x] Zero new lint warnings on the four changed files