### PR TITLE
Add Game.cpuLimit, Game.powerCreeps, Room.survivalInfo

### DIFF
--- a/packages/xxscreeps/game/game.ts
+++ b/packages/xxscreeps/game/game.ts
@@ -75,6 +75,18 @@ export class Game extends GameBase {
 	declare cpu: CPU;
 
 	/**
+	 * Your assigned CPU limit for the current shard.
+	 * @deprecated
+	 */
+	get cpuLimit(): number { return this.cpu.limit; }
+
+	/**
+	 * A hash containing all your power creeps with their names as hash keys. xxscreeps does not
+	 * implement power creeps yet, so this is always an empty object.
+	 */
+	powerCreeps: Record<string, unknown> = Object.create(null);
+
+	/**
 	 * An object describing the world shard where your script is currently being executed in.
 	 */
 	shard: { name: string; type: string; ptr: boolean };

--- a/packages/xxscreeps/game/room/room.ts
+++ b/packages/xxscreeps/game/room/room.ts
@@ -31,6 +31,13 @@ export class Room extends withOverlay(BufferObject, shape) {
 	#removeObjects = new Set<RoomObject>();
 
 	/**
+	 * A [survival game](https://docs.screeps.com/survival.html) info, if the current game is
+	 * running in the Survival Mode. xxscreeps has no survival mode, so this is always `null`.
+	 */
+	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
+	@enumerable get survivalInfo(): null { return null; }
+
+	/**
 	 * Find all objects of the specified type in the room. Results are cached automatically for the
 	 * specified room and type before applying any custom filters. This automatic cache lasts until
 	 * the end of the tick.


### PR DESCRIPTION
xxscreeps was missing three data-properties vanilla exposes on `Game` and `Room`:

- **`Game.cpuLimit`** — now a getter deriving from `this.cpu.limit`.
- **`Game.powerCreeps`** — always `{}` and marked `@deprecated` in line with xxscreeps' existing deprecation markers on other legacy-compat surfaces.
- **`Room.survivalInfo`** — always `null` (xxscreeps has no survival mode).

Scope trimmed from the earlier version of this PR:

- The `id`-on-Flag restructure is deferred pending a separate discussion (per your note that flags are already architecturally separate from room state, so the id special-case should stay narrow to Flag).
- The `hits`/`hitsMax`/`my` base-leak cleanup is split into its own focused PR, which removes the getters rather than widening the base type via interface merge.

Verified against ok-screeps.