### PR TITLE
Remove hits/hitsMax/my leak from RoomObject base

### DIFF
--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -57,13 +57,9 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
 	get '#providesVision'() { return false; }
 	get '#user'(): string | null { return null; }
-	get hits(): number | undefined { return undefined; }
-	get hitsMax(): number | undefined { return undefined; }
-	get my(): boolean | undefined { return undefined; }
 	abstract get ['#lookType'](): string | null;
 
 	set '#user'(_user: string | null) { throw new Error('Setting `#user` on unownable object'); }
-	set hits(_hits: number | undefined) { throw new Error('Setting `hits` on indestructible object'); }
 
 	'#addToMyGame'(_game: GameConstructor) {}
 	'#afterInsert'(room: Room) {
@@ -95,6 +91,14 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 			return `${options.stylize(`[${this.constructor.name}]`, 'special')} ${options.stylize('{released}', 'null')}`;
 		}
 	}
+}
+
+// Type-only merge: exposes `hits`/`hitsMax`/`my` at the base type without installing getters on the prototype.
+export declare interface RoomObject {
+	get hits(): number | undefined;
+	set hits(hits: number);
+	get hitsMax(): number | undefined;
+	get my(): boolean | undefined;
 }
 
 export function create<Type extends RoomObject>(instance: Type, pos: RoomPosition): Type {


### PR DESCRIPTION
xxscreeps' `RoomObject` base defines `hits`/`hitsMax`/`my` as getters returning `undefined`. Vanilla installs these selectively on `Creep`/`Structure`/`ConstructionSite` only. The result is a prototype-shape divergence: `Source`, `Mineral`, `Resource`, `Tombstone`, `Ruin`, and `Flag` all expose those three entries on their prototypes in xxscreeps but not in vanilla. Invisible to value reads, observable via `'hits' in obj`, prototype walking, and any player-side type guards that rely on the property being genuinely absent.

The base getters existed only to let shared code like `#applyDamage` type-check `this.hits`. Rather than leave them on the prototype or introduce runtime scaffolding to compensate for their removal, this PR keeps them visible at the *type* level via a declaration-merged `export declare interface RoomObject` block placed after the class. The merge has zero runtime footprint, so consumer sites (`object.hits === undefined`, `structure.my`) keep their natural form — property access on non-destructible / non-ownable objects resolves to `undefined` naturally.

**Change:** `packages/xxscreeps/game/object.ts` only.

- Delete the base `hits`/`hitsMax`/`my` getters and the `hits` setter.
- Add a type-only `export declare interface RoomObject { get hits(); set hits(); get hitsMax(); get my(); }` merge after the class. No runtime effect; destructible/ownable subclasses continue to supply the real getters.

Split out from #133. Verified against ok-screeps.
