### PR TITLE
Fix renewCreep busy/boost guards and spawnCreep check order

### DIFF
--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -77,14 +77,7 @@ function calculateEffectiveDamage(creep: Creep, totalDamage: number) {
 	return hitsLost;
 }
 
-function recalculateBody(creep: Creep) {
-	// Apply damage to body parts
-	let hits = creep.hits - creep.hitsMax;
-	for (const part of creep.body) {
-		hits += 100;
-		part.hits = clamp(0, 100, hits);
-	}
-	// Dying creeps: leave the store intact so buryCreep can transfer it.
+export function dropOverflowResources(creep: Creep) {
 	const capacity = creep.store['#capacity'] = calculateCarry(creep.body);
 	if (creep.hits <= 0) return;
 	let overflow = creep.store.getUsedCapacity() - capacity;
@@ -98,6 +91,16 @@ function recalculateBody(creep: Creep) {
 			}
 		}
 	}
+}
+
+function recalculateBody(creep: Creep) {
+	// Apply damage to body parts
+	let hits = creep.hits - creep.hitsMax;
+	for (const part of creep.body) {
+		hits += 100;
+		part.hits = clamp(0, 100, hits);
+	}
+	dropOverflowResources(creep);
 }
 
 declare module 'xxscreeps/engine/processor/index.js' {

--- a/packages/xxscreeps/mods/spawn/processor.ts
+++ b/packages/xxscreeps/mods/spawn/processor.ts
@@ -12,6 +12,7 @@ import { Room } from 'xxscreeps/game/room/index.js';
 import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import * as ControllerProc from 'xxscreeps/mods/controller/processor.js';
 import { Creep, create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { dropOverflowResources } from 'xxscreeps/mods/creep/processor.js';
 import { buryCreep } from 'xxscreeps/mods/creep/tombstone.js';
 import { createRuin } from 'xxscreeps/mods/structure/ruin.js';
 import { OwnedStructure, checkMyStructure, lookForStructures } from 'xxscreeps/mods/structure/structure.js';
@@ -136,6 +137,12 @@ const intents = [
 			if (consumeEnergy(spawn, cost)) {
 				saveAction(creep, 'healed', spawn.pos);
 				creep['#ageTime'] += calculateRenewAmount(creep);
+				if (creep.body.some(part => part.boost)) {
+					for (const part of creep.body) {
+						part.boost = undefined;
+					}
+					dropOverflowResources(creep);
+				}
 				context.didUpdate();
 			}
 		}

--- a/packages/xxscreeps/mods/spawn/spawn.ts
+++ b/packages/xxscreeps/mods/spawn/spawn.ts
@@ -144,8 +144,10 @@ export class StructureSpawn extends withOverlay(OwnedStructure, shape) {
 	 * square. The target should not have CLAIM body parts. The spawn should not be busy with the
 	 * spawning process. Each execution increases the creep's timer by amount of ticks according to
 	 * this formula: `floor(600 / body.length)`. Energy required for each execution is determined
-	 * using this formula: `ceil(creepCost / 2.5 / body.length)`. Renewing a creep removes all of its
-	 * boosts.
+	 * using this formula: `ceil(creepCost / 2.5 / body.length)`.
+	 *
+	 * Renewing a creep removes all of its boosts. Calling this on a boosted creep is deprecated
+	 * in the official API — prefer `StructureLab.unboostCreep` first.
 	 * @param creep The target creep object.
 	 */
 	renewCreep(creep: Creep) {
@@ -270,6 +272,7 @@ export function checkRecycleCreep(spawn: StructureSpawn, creep: Creep) {
 export function checkRenewCreep(spawn: StructureSpawn, creep: Creep) {
 	return chainIntentChecks(
 		() => checkMyStructure(spawn, StructureSpawn),
+		() => spawn.spawning ? C.ERR_BUSY : C.OK,
 		() => checkIsActive(spawn),
 		() => checkTarget(creep, Creep),
 		() => checkCommon(creep),
@@ -277,10 +280,7 @@ export function checkRenewCreep(spawn: StructureSpawn, creep: Creep) {
 		() => {
 			if (spawn.room.energyAvailable < calculateRenewCost(creep)) {
 				return C.ERR_NOT_ENOUGH_RESOURCES;
-			} else if (
-				creep.body.some(bodyPart => bodyPart.type === C.CLAIM) ||
-				creep.body.some(bodyPart => bodyPart.boost !== undefined)
-			) {
+			} else if (creep.body.some(bodyPart => bodyPart.type === C.CLAIM)) {
 				return C.ERR_NO_BODYPART;
 			} else if (creep.ticksToLive! + calculateRenewAmount(creep) > C.CREEP_LIFE_TIME) {
 				return C.ERR_FULL;
@@ -306,7 +306,6 @@ export function checkSpawnCreep(
 ) {
 	return chainIntentChecks(
 		() => checkMyStructure(spawn, StructureSpawn),
-		() => checkIsActive(spawn),
 		() => checkString(name, 100, true),
 		() => {
 			if (userGame?.creeps[name] !== undefined) {
@@ -318,7 +317,9 @@ export function checkSpawnCreep(
 			if (spawn.spawning) {
 				return C.ERR_BUSY;
 			}
-
+		},
+		() => checkIsActive(spawn),
+		() => {
 			if (
 				!Array.isArray(body) ||
 				body.length === 0 ||


### PR DESCRIPTION
Three independent mismatches in mods/spawn/ with the canonical engine.

checkRenewCreep was missing ERR_BUSY. Vanilla's user-side renewCreep short-circuits on this.spawning before any target validation. xxscreeps went straight to checkIsActive and target checks, so renewing through a mid-spawn returned whatever downstream check produced first instead of ERR_BUSY.

checkRenewCreep rejected boosted creeps with ERR_NO_BODYPART. Vanilla accepts them and the processor strips the boosts. Removed the boost-presence branch from the check and moved the strip into the renewCreep processor: clear each part.boost and call the new shared helper (see below) to reconcile store capacity.

checkSpawnCreep ran checkIsActive before the name-collision check. With a duplicate name against an RCL-inactive spawn, vanilla returns ERR_NAME_EXISTS (in structures.js the name branch sits above the off branch). xxscreeps was returning ERR_RCL_NOT_ENOUGH. Moved checkIsActive after the name / directions / busy closure.

While here, extracted the overflow-drop half of recalculateBody (mods/creep/processor.ts) as a new exported helper dropOverflowResources. It already did exactly what renewCreep needed after a boost strip — capacity recompute via calculateCarry and drop excess resources at the creep's position — and was duplicated inline in the first pass of this PR. Both call sites now share it. Stripping boosts off of a creep on renew is deprecated but still functional behaviour in vanilla so left a deprecation note as well.

Verified against ok-screeps.