### PR TITLE
Reclaim body energy and divert into containers on creep death

### DIFF
--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -84,8 +84,9 @@ function recalculateBody(creep: Creep) {
 		hits += 100;
 		part.hits = clamp(0, 100, hits);
 	}
-	// Drop excess resources
+	// Dying creeps: leave the store intact so buryCreep can transfer it.
 	const capacity = creep.store['#capacity'] = calculateCarry(creep.body);
+	if (creep.hits <= 0) return;
 	let overflow = creep.store.getUsedCapacity() - capacity;
 	if (overflow > 0) {
 		for (const [ type, amount ] of creep.store['#entries']()) {

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -297,6 +297,53 @@ describe('Movement', () => {
 		}));
 	});
 
+	describe('Tombstone store', () => {
+		const boostedSuicide = simulate({
+			W7N7: room => {
+				const creep = create(new RoomPosition(25, 25, 'W7N7'), [ C.ATTACK ], 'boosted', '100');
+				creep.body[0].boost = C.RESOURCE_UTRIUM_HYDRIDE;
+				room['#insertObject'](creep);
+			},
+		});
+
+		test('suicide reclaims body energy and boost mineral', () => boostedSuicide(async ({ player, tick, peekRoom }) => {
+			await player('100', Game => {
+				Game.creeps.boosted.suicide();
+			});
+			await tick();
+			await peekRoom('W7N7', room => {
+				const tombs = room['#lookFor'](C.LOOK_TOMBSTONES);
+				assert.strictEqual(tombs.length, 1);
+				const tomb = tombs[0];
+				assert.strictEqual(tomb.store[C.RESOURCE_ENERGY], 19);
+				assert.strictEqual(tomb.store[C.RESOURCE_UTRIUM_HYDRIDE], 5);
+			});
+		}));
+
+		const claimSuicide = simulate({
+			W8N8: room => {
+				const creep = create(new RoomPosition(25, 25, 'W8N8'), [ C.CLAIM ], 'claimer', '100');
+				// Spawn code seats CLAIM creeps at CREEP_CLAIM_LIFE_TIME; create() only knows
+				// CREEP_LIFE_TIME. Retarget #ageTime so the reclaim rate picks the CLAIM branch.
+				creep['#ageTime'] = creep['#ageTime'] - C.CREEP_LIFE_TIME + C.CREEP_CLAIM_LIFE_TIME;
+				room['#insertObject'](creep);
+			},
+		});
+
+		test('CLAIM body uses CREEP_CLAIM_LIFE_TIME for the reclaim rate', () => claimSuicide(async ({ player, tick, peekRoom }) => {
+			await player('100', Game => {
+				Game.creeps.claimer.suicide();
+			});
+			await tick();
+			await peekRoom('W8N8', room => {
+				const tombs = room['#lookFor'](C.LOOK_TOMBSTONES);
+				assert.strictEqual(tombs.length, 1);
+				// Using CREEP_LIFE_TIME instead would yield floor(600 * 0.2 * (599/1500)) = 47.
+				assert.strictEqual(tombs[0].store[C.RESOURCE_ENERGY], 119);
+			});
+		}));
+	});
+
 	describe('Room', () => {
 		const sim = simulate({
 			W0N0: room => {

--- a/packages/xxscreeps/mods/creep/tombstone.ts
+++ b/packages/xxscreeps/mods/creep/tombstone.ts
@@ -1,8 +1,10 @@
+import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomObject, create as createObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
 import { OpenStore, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
+import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { Creep } from './creep.js';
@@ -69,9 +71,41 @@ export function buryCreep(creep: Creep, rate = C.CREEP_CORPSE_RATE) {
 	const tombstone = createObject(new Tombstone(), creep.pos);
 	tombstone.deathTime = Game.time;
 	tombstone.store = new OpenStore();
-	for (const [ resourceType, amount ] of creep.store['#entries']()) {
-		tombstone.store['#add'](resourceType, Math.floor(amount * rate));
+
+	if (rate > 0) {
+		const lifeTime = creep.body.some(part => part.type === C.CLAIM)
+			? C.CREEP_CLAIM_LIFE_TIME : C.CREEP_LIFE_TIME;
+		const lifeRate = rate * (creep.ticksToLive ?? 0) / lifeTime;
+		let bodyEnergy = 0;
+		const bodyBoosts = new Map<ResourceType, number>();
+		for (const part of creep.body) {
+			if (part.boost !== undefined) {
+				bodyBoosts.set(part.boost,
+					(bodyBoosts.get(part.boost) ?? 0) + C.LAB_BOOST_MINERAL * lifeRate);
+				bodyEnergy += C.LAB_BOOST_ENERGY * lifeRate;
+			}
+			bodyEnergy += Math.min(C.CREEP_PART_MAX_ENERGY, C.BODYPART_COST[part.type] * lifeRate);
+		}
+		// Same-tile container absorbs resources before the tombstone, matching vanilla.
+		const container = lookForStructureAt(creep.room, creep.pos, C.STRUCTURE_CONTAINER);
+		const deposit = (type: ResourceType, amount: number) => {
+			if (amount <= 0) return;
+			if (container !== undefined && container.hits > 0) {
+				const toContainer = Math.min(amount, container.store.getFreeCapacity(type));
+				if (toContainer > 0) {
+					container.store['#add'](type, toContainer);
+					const remaining = amount - toContainer;
+					if (remaining > 0) tombstone.store['#add'](type, remaining);
+					return;
+				}
+			}
+			tombstone.store['#add'](type, amount);
+		};
+		deposit(C.RESOURCE_ENERGY, Math.floor(bodyEnergy));
+		for (const [ mineral, amount ] of bodyBoosts) deposit(mineral, Math.floor(amount));
+		for (const [ type, amount ] of creep.store['#entries']()) deposit(type, amount);
 	}
+
 	tombstone['#creep'] = {
 		body: creep.body.map(bodyPart => bodyPart.type),
 		id: creep.id,


### PR DESCRIPTION
buryCreep previously scaled the creep's carried store by dropRate and reclaimed no body energy, diverging from vanilla _die. Rewrite to mirror vanilla: body energy at rate * ticksToLive / lifeTime (CLAIM-aware, CREEP_PART_MAX_ENERGY-capped) plus LAB_BOOST_MINERAL and LAB_BOOST_ENERGY refunds per boosted part, carried store at full amount, and route every deposit through a same-tile container before tombstone remainder. The chemistry constants are read through the ambient C aggregator (same pattern as the existing C.BOOSTS consumption in creep.ts), so no new mod import edge.

Also fix a race in recalculateBody: when a creep's hits reach zero this tick, skip the capacity-shrink overflow drop so the store survives for buryCreep to transfer.

Adds a Tombstone-store test exercising suicide with a boosted body part.

Verified against ok-screeps.