### PR TITLE
Fix RawMemory.set guards: eager 2 MB throw + preserve in-tick Memory mutations

### DIFF
--- a/.changeset/raw-memory-set-guards.md
+++ b/.changeset/raw-memory-set-guards.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `RawMemory.set` guards: eager 2 MB throw, in-tick `Memory` mutation preservation, cross-tick parse refresh

--- a/packages/xxscreeps/mods/memory/game.ts
+++ b/packages/xxscreeps/mods/memory/game.ts
@@ -44,11 +44,19 @@ hooks.register('runtimeConnector', {
 	receive(payload) {
 		loadSegments(payload.memorySegments);
 		loadForeignSegment(payload.foreignSegment);
-		// Redefine memory each tick, expected behavior from vanilla server
+		// Self-replacing getter — first access pins Memory to a value descriptor (vanilla parity).
 		Object.defineProperty(globalThis, 'Memory', {
 			configurable: true,
 			enumerable: true,
-			get,
+			get() {
+				const value: unknown = get();
+				Object.defineProperty(globalThis, 'Memory', {
+					configurable: true,
+					enumerable: true,
+					value,
+				});
+				return value;
+			},
 		});
 	},
 

--- a/packages/xxscreeps/mods/memory/memory.ts
+++ b/packages/xxscreeps/mods/memory/memory.ts
@@ -17,8 +17,8 @@ let requestedPublicSegments: number[] | undefined;
 let memory: Uint16Array;
 let memoryLength = 0;
 let string: string | undefined;
-let accessedJson = false;
 let json: object | undefined;
+let setCalled = false;
 let isBufferOutOfDate = false;
 
 function align(address: number) {
@@ -92,7 +92,12 @@ export const RawMemory = {
 		if (typeof value !== 'string') {
 			throw new TypeError('Memory value must be a string');
 		}
-		RawMemory._parsed = json = undefined;
+		if (value.length > kMaxMemoryLength) {
+			throw new Error(`Reached maximum \`Memory\` limit. Requested: ${value.length} out of ${kMaxMemoryLength}`);
+		}
+		// Keep `json` so in-tick `Memory` reads stay pinned. `setCalled` separates this from a `delete _parsed` memhack-skip.
+		RawMemory._parsed = undefined;
+		setCalled = true;
 		string = value;
 		isBufferOutOfDate = true;
 	},
@@ -171,7 +176,6 @@ export const RawMemory = {
  * `Game.memory` getter
  */
 export function get(): any {
-	accessedJson = true;
 	if (json) {
 		return json;
 	}
@@ -198,21 +202,15 @@ export function flush() {
 		return { size: 0 };
 	}
 
-	// Check for JSON-based `Memory` object
-	if (json) {
-		// "Memhack" - https://wiki.screepspl.us/index.php/MemHack
-		const memhack = RawMemory._parsed;
-		const accessedJsonThisTick = accessedJson;
-		accessedJson = false;
-		if (!memhack) {
-			// User wants to skip saving memory this tick
-			RawMemory._parsed = json;
-			return { size: memoryLength };
-		} else if (accessedJsonThisTick && json === memhack) {
-			// User did not mess with `Memory`, simulate vanilla reconstruction
+	// Vanilla precedence: `_parsed` > setCalled-saves-string > memhack-skip > fall-through.
+	const memhack = RawMemory._parsed;
+	const wasSet = setCalled;
+	setCalled = false;
+	if (memhack) {
+		if (json === memhack) {
 			crunch(json);
 		} else {
-			// User wants to reuse memory object
+			// "Memhack" - https://wiki.screepspl.us/index.php/MemHack
 			json = memhack;
 		}
 		try {
@@ -221,6 +219,17 @@ export function flush() {
 		} catch (err) {
 			console.error(err);
 		}
+		// Drop the cache; next tick re-parses from `string` so JSON-coerced values (functions, NaN, Infinity) match vanilla.
+		json = undefined;
+	} else if (!wasSet && json) {
+		// Memhack-skip: don't save, restore `_parsed` for next tick. Drop the cache —
+		// in-tick mutations live in `json` but never reached raw.
+		RawMemory._parsed = json;
+		json = undefined;
+		return { size: memoryLength };
+	} else if (wasSet) {
+		// `set()` replaced raw; the cached parse is now stale. Next tick re-reads.
+		json = undefined;
 	}
 
 	// Update the uint16 buffer
@@ -253,6 +262,8 @@ export function flush() {
 export function initialize(value: Readonly<Uint8Array> | null) {
 	json = undefined;
 	string = undefined;
+	setCalled = false;
+	isBufferOutOfDate = false;
 	if (value) {
 		memoryLength = value.length >>> 1;
 		memory = new Uint16Array(new SharedArrayBuffer(align(value.length)));


### PR DESCRIPTION
Split from #131 per review. Three narrow `RawMemory.set` / `Memory` correctness fixes in `mods/memory/`.

## Changes

1. **Eager 2 MB throw.** Length check moves from `flush()` into `set()` so a user-code `try/catch` actually sees it.

2. **Self-replacing `Memory` + in-tick mutation preservation.** `runtimeConnector.receive` installs `Memory` as a self-replacing lazy getter — first access flips the descriptor to a value property, matching `@screeps/engine/src/game/game.js`. `set()` clears `_parsed` only and sets a `setCalled` flag; cached `json` survives the call so per-object `.memory` reads (which go through `get()`, not `globalThis.Memory`) stay pinned to the originally-parsed object in-tick.

   `flush()` precedence matches vanilla: `_parsed` > `setCalled`-saves-string > memhack-skip > fall-through. Per-object `.memory` accessors continue to call the module-level `get()` directly (no `declare global`).

3. **Cross-tick parse refresh.** Drop cached `json` after every `flush()` save path so the next tick's first `Memory` access re-parses raw — values that `JSON.stringify` coerces (functions stripped, `NaN`/`Infinity` → `null`) round-trip to those coerced forms instead of surviving in the live object across ticks.

## Validation

Verified against screeps-ok: `MEMORY-002`/`004`/`005`/`006`, `UNDOC-MEMHACK-007`/`008`/`009`/`010`/`011`/`012`, and `UNDOC-MEMJSON-001`/`003`/`004`. xxscreeps `pnpm run test` 177/177.