### PR TITLE
fix: Destroy dismantled structures, spill container contents on decay

### DIFF
--- a/packages/xxscreeps/mods/construction/processor.ts
+++ b/packages/xxscreeps/mods/construction/processor.ts
@@ -76,7 +76,10 @@ const intents = [
 					Resource.drop(creep.pos, 'energy', overflow);
 				}
 				target.hits -= effect;
-				// TODO: dismantle event + destroy hook
+				if (target.hits <= 0) {
+					target['#destroy']();
+				}
+				// TODO: dismantle event
 				// saveAction(creep, 'dismantle', target.pos.x, target.pos.y);
 				context.didUpdate();
 			}

--- a/packages/xxscreeps/mods/resource/processor/container.ts
+++ b/packages/xxscreeps/mods/resource/processor/container.ts
@@ -2,12 +2,16 @@ import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { StructureContainer } from '../container.js';
+import { drop } from './resource.js';
 
 registerObjectTickProcessor(StructureContainer, (container, context) => {
 	if (container.ticksToDecay === 0) {
 		const ownedController = (container.room.controller?.level ?? 0) > 0;
 		container.hits -= C.CONTAINER_DECAY;
 		if (container.hits <= 0) {
+			for (const [ resourceType, amount ] of container.store['#entries']()) {
+				drop(container.pos, resourceType, amount);
+			}
 			container.room['#removeObject'](container);
 		}
 		container['#nextDecayTime'] = Game.time + (ownedController

--- a/packages/xxscreeps/mods/resource/processor/resource.ts
+++ b/packages/xxscreeps/mods/resource/processor/resource.ts
@@ -13,9 +13,10 @@ export function drop(pos: RoomPosition, resourceType: ResourceType, amount: numb
 	const room = Game.rooms[pos.roomName];
 	let remaining = amount;
 
-	// Is there a container to catch the resource?
+	// Skip a container that is being destroyed so it doesn't catch its own
+	// spill. Matches vanilla _create-energy.
 	const container = lookForStructureAt(room, pos, C.STRUCTURE_CONTAINER);
-	if (container) {
+	if (container && container.hits > 0) {
 		const capacity = container.store.getFreeCapacity(resourceType);
 		if (capacity > 0) {
 			const amount = Math.min(remaining, capacity);


### PR DESCRIPTION
Three fixes tying structure destruction to vanilla's observable behavior.

1. `mods/construction/processor.ts` — dismantle left a target at `hits=0` in place. Vanilla's `dismantle.js:52` routes through `_damage.js:46-49`, which invokes `structures/_destroy.js` on any non-creep that reaches zero hits — creating a ruin and removing the object. Added `target['#destroy']()` when `target.hits <= 0`; the existing `Structure['#destroy']()` override at `mods/structure/structure.ts:82` already handles ruin creation and removal.

2. `mods/resource/processor/container.ts` — container decay removed the container without spilling its store. Vanilla's `containers/tick.js:14-20` iterates `object.store` and routes each resource through `_create-energy` before `bulk.remove`. Mirror that: iterate `container.store['#entries']()` and call `drop()` per entry, then `#removeObject`.

3. `mods/resource/processor/resource.ts` — `drop()`'s container-catch was not gated on `container.hits > 0`. Vanilla's `_create-energy.js:22` already has the gate. Without it, the container-spill loop above routes resources back into the same container that's being removed, because `#removeObject` only queues removal for a later flush — `lookForStructureAt` still finds the dead container within the same tick.

The one thing that I wonder about is the use of drop and then checking for a dead container inside drop. We could have a dropOnGround that drop uses to make the code a bit cleaner?

Verified against ok-screeps.