### PR TITLE
fix(creep): use Fn.take in calculateBoundedEffect to handle sliceCount > deltas.length

### DIFF
--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -606,7 +606,7 @@ export function calculateBoundedEffect(
 	// all callers, slicing by `unboosted` keeps all parts when energy is
 	// sufficient and the top-k most-boosted parts otherwise.
 	const sliceCount = Math.floor(unboosted);
-	const boostedDelta = Fn.accumulate(Fn.slice(deltas, 0, sliceCount));
+	const boostedDelta = Fn.accumulate(Fn.take(deltas, sliceCount));
 	return { unboosted, boosted: Math.floor(unboosted + boostedDelta) };
 }
 


### PR DESCRIPTION
`sliceCount = floor(unboosted) = activeParts × power` but `deltas.length = activeParts`. When `power > 1` (repair, build, upgrade), `Fn.slice(deltas, 0, sliceCount)` iterates `deltas[i]` past the array end and yields `undefined`, which poisons `Fn.accumulate` to `NaN` and propagates to `target.hits` in the consuming intents. `Fn.take` short-circuits at iterable end — sibling of `Fn.takeWhile` introduced alongside `iterateActiveParts`.

Verified against ok-screeps.