### PR TITLE
fix: Redirect attack and dismantle damage to ramparts

### DIFF
--- a/packages/xxscreeps/mods/combat/creep.ts
+++ b/packages/xxscreeps/mods/combat/creep.ts
@@ -166,24 +166,24 @@ export function checkDestructible(target: Creep | Structure) {
 }
 
 /**
- * Invokes damage capture callback from top to bottom and returns the remaining power which should
- * be applied to the target.
+ * Walks `objects` descending by `#layer`; `onObject` returns the residual past each one.
+ * `stopAt` ends iteration at that object (throws if absent).
  */
-export function captureDamage(target: RoomObject, initialPower: number, type: number, source: RoomObject | null) {
-	// Sort objects by layer
-	const objects = [ ...Fn.reject(target.room['#lookAt'](target.pos),
-		object => object['#layer'] === undefined || object.hits === undefined) ];
-	objects.sort((left, right) => right['#layer']! - left['#layer']!);
-
-	// Calculate total power, allowing objects on higher layers to deduct damage [ramparts]
+export function walkLayers<T extends RoomObject>(
+	objects: T[],
+	initialPower: number,
+	onObject: (object: T, layerPower: number) => number,
+	stopAt?: T,
+): number {
 	let power = initialPower;
 	let iterationPower = power;
 	let layer: number | undefined;
 	for (const object of objects) {
+		if (object === stopAt) {
+			return iterationPower;
+		}
 		const objectLayer = object['#layer'];
-		if (object === target) {
-			return power;
-		} else if (layer !== objectLayer) {
+		if (layer !== objectLayer) {
 			layer = objectLayer;
 			power = iterationPower;
 			if (power <= 0) {
@@ -193,7 +193,23 @@ export function captureDamage(target: RoomObject, initialPower: number, type: nu
 		// The idea here is that multiple objects on the same layer can capture damage simultaneously,
 		// and whichever one captures more will be used. This doesn't apply to any existing game
 		// objects, but idk maybe it could be interesting.
-		iterationPower = Math.min(iterationPower, target['#captureDamage'](power, C.EVENT_ATTACK_TYPE_MELEE, source));
+		iterationPower = Math.min(iterationPower, onObject(object, power));
 	}
-	throw new Error('Object was never found');
+	if (stopAt !== undefined) {
+		throw new Error('Object was never found');
+	}
+	return iterationPower;
+}
+
+/**
+ * Invokes damage capture callback from top to bottom and returns the remaining power which should
+ * be applied to the target.
+ */
+export function captureDamage(target: RoomObject, initialPower: number, type: number, source: RoomObject | null) {
+	const objects = [ ...Fn.reject(target.room['#lookAt'](target.pos),
+		object => object['#layer'] === undefined || object.hits === undefined) ];
+	objects.sort((left, right) => right['#layer']! - left['#layer']!);
+	return walkLayers(objects, initialPower,
+		(object, layerPower) => object['#captureDamage'](layerPower, type, source),
+		target);
 }

--- a/packages/xxscreeps/mods/combat/processor.ts
+++ b/packages/xxscreeps/mods/combat/processor.ts
@@ -8,7 +8,7 @@ import { RoomPosition } from 'xxscreeps/game/position.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { mapArea } from 'xxscreeps/game/room/look.js';
 import { Creep, calculatePower } from 'xxscreeps/mods/creep/creep.js';
-import { captureDamage, checkAttack, checkHeal, checkRangedAttack, checkRangedHeal, checkRangedMassAttack } from './creep.js';
+import { captureDamage, checkAttack, checkHeal, checkRangedAttack, checkRangedHeal, checkRangedMassAttack, walkLayers } from './creep.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { combat: typeof intents }
@@ -74,35 +74,25 @@ const intents = [
 				(xx, yy) => new RoomPosition(xx, yy, creep.room.name));
 			const basePower = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER, 'rangedMassAttack');
 			for (const pos of area) {
-
-				// Sort objects by layer
 				const objects = [ ...Fn.reject(creep.room['#lookAt'](pos),
 					object => object['#layer'] === undefined || object.hits === undefined || object.my !== false) ];
 				objects.sort((left, right) => right['#layer']! - left['#layer']!);
-
-				// Apply and capture damage
-				let power = basePower * [ 1, 1, 0.4, 0.1 ][creep.pos.getRangeTo(pos)];
-				let iterationPower = power;
-				let layer: number | undefined;
-				for (const object of objects) {
-					const objectLayer = object['#layer'];
-					if (layer !== objectLayer) {
-						layer = objectLayer;
-						power = iterationPower;
-						if (power <= 0) {
-							break;
-						}
+				const power = basePower * [ 1, 1, 0.4, 0.1 ][creep.pos.getRangeTo(pos)];
+				walkLayers(objects, power, (object, layerPower) => {
+					const remaining = object['#captureDamage'](layerPower, C.EVENT_ATTACK_TYPE_RANGED_MASS, creep);
+					const absorbed = layerPower - remaining;
+					if (absorbed === 0) {
+						object['#applyDamage'](layerPower, C.EVENT_ATTACK_TYPE_RANGED_MASS, creep);
 					}
-					iterationPower = Math.min(iterationPower, object['#captureDamage'](power, C.EVENT_ATTACK_TYPE_RANGED_MASS, creep));
-					object['#applyDamage'](power, C.EVENT_ATTACK_TYPE_RANGED_MASS, creep);
 					appendEventLog(object.room, {
 						event: C.EVENT_ATTACK,
 						objectId: creep.id,
 						targetId: object.id,
 						attackType: C.EVENT_ATTACK_TYPE_RANGED_MASS,
-						damage: power,
+						damage: absorbed > 0 ? absorbed : layerPower,
 					});
-				}
+					return remaining;
+				});
 			}
 			saveAction(creep, 'rangedMassAttack', creep.pos);
 			context.didUpdate();

--- a/packages/xxscreeps/mods/construction/processor.ts
+++ b/packages/xxscreeps/mods/construction/processor.ts
@@ -6,6 +6,7 @@ import { Game, me } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
+import { captureDamage } from 'xxscreeps/mods/combat/creep.js';
 import { Creep, calculateBoundedEffect, calculatePower } from 'xxscreeps/mods/creep/creep.js';
 import * as Resource from 'xxscreeps/mods/resource/processor/resource.js';
 import { ConstructionSite, checkRemove, create } from './construction-site.js';
@@ -75,7 +76,8 @@ const intents = [
 				if (overflow > 0) {
 					Resource.drop(creep.pos, 'energy', overflow);
 				}
-				target.hits -= effect;
+				const damage = captureDamage(target, effect, C.EVENT_ATTACK_TYPE_DISMANTLE, creep);
+				target.hits -= damage;
 				if (target.hits <= 0) {
 					target['#destroy']();
 				}

--- a/packages/xxscreeps/mods/defense/rampart.ts
+++ b/packages/xxscreeps/mods/defense/rampart.ts
@@ -25,6 +25,16 @@ export class StructureRampart extends withOverlay(OwnedStructure, shape) {
 
 	override get structureType() { return C.STRUCTURE_RAMPART; }
 
+	override get '#layer'() { return 1; }
+
+	override '#captureDamage'(power: number, type: number, source: RoomObject.RoomObject | null) {
+		const absorbed = Math.min(power, this.hits);
+		if (absorbed > 0) {
+			this['#applyDamage'](absorbed, type, source ?? undefined);
+		}
+		return power - absorbed;
+	}
+
 	/**
 	 * Make this rampart public to allow other players' creeps to pass through.
 	 * @param isPublic Whether this rampart should be public or non-public.


### PR DESCRIPTION
Restore vanilla rampart-shielding so a same-tile rampart absorbs damage before it reaches the underlying creep or structure.

* Fix `captureDamage` typo (`mods/combat/creep.ts`) — the per-object loop called `target['#captureDamage']` instead of `object['#captureDamage']`, so non-target same-tile objects never had their absorb hook invoked. Forward the caller-provided `type` instead of the hardcoded `EVENT_ATTACK_TYPE_MELEE`. Surface the residual (`iterationPower`) when the target-reach early-return fires; the prior code returned `power`, which still held the previous layer's entry value when the target sat on a lower layer.
* Add `#layer` (= 1) and `#captureDamage` overrides on `StructureRampart`. The override deducts hits in place via `#applyDamage` and returns the residual, matching the contract implied by the base no-op (`return power`).
* Extract `walkLayers` helper so `captureDamage` and `rangedMassAttack` share a single layer-walk + parallel-min implementation. The two loops were duplicates of the same algorithm.
* Update `rangedMassAttack` so `#applyDamage(power)` only fires when nothing was absorbed at this layer; the absorbing object handled its own deduction in `#captureDamage`. Event-log damage reflects the actual hits taken.
* Route dismantle damage through `captureDamage` in the construction processor so a rampart over the target absorbs it; preserve the destroy hook from #145.

Verified against ok-screeps (`RAMPART-PROTECT-001/002`, `COMBAT-MELEE-005`, `COMBAT-RANGED-006`, `COMBAT-RMA-004`, `DISMANTLE-004` all pass).