### PR TITLE
Add hdel to KeyValProvider

### DIFF
--- a/packages/redis/keyval.ts
+++ b/packages/redis/keyval.ts
@@ -114,6 +114,10 @@ export class RedisProvider implements P.KeyValProvider {
 
 	//
 	// hashes
+	async hdel(key: string, fields: string[]) {
+		return this.redis.invoke<number>(cb => this.redis.batch(key).hdel(key, fields, cb));
+	}
+
 	async hget(key: string, field: string) {
 		return send(await this.redis.invoke<string | null>(cb => this.redis.batch(key).hget(key, field, cb)));
 	}

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -170,6 +170,14 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 		return value;
 	}
 
+	hdel(key: string, fields: string[]) {
+		const map = this.data.get(key) as Map<string, string> | undefined;
+		if (!map) return 0;
+		const removed = Fn.accumulate(fields, field => map.delete(field) ? 1 : 0);
+		if (map.size === 0) this.remove(key);
+		return removed;
+	}
+
 	hget(key: string, field: string) {
 		const map: Map<string, string> | undefined = this.data.get(key);
 		return map?.get(field) ?? null;

--- a/packages/xxscreeps/engine/db/storage/provider.ts
+++ b/packages/xxscreeps/engine/db/storage/provider.ts
@@ -46,6 +46,7 @@ export type KeyValProvider = {
 	incr: (key: string) => Promise<number>;
 	incrBy: (key: string, value: number) => Promise<number>;
 	// hashes
+	hdel: (key: string, fields: string[]) => Promise<number>;
 	hget: (key: string, field: string) => Promise<string | null>;
 	hgetall: (key: string) => Promise<Record<string, string>>;
 	hincrBy: (key: string, field: string, value: number) => Promise<number>;


### PR DESCRIPTION
## Summary

Adds `hdel(key, fields)` to `KeyValProvider`, with local and redis implementations. Closes an interface gap — local previously had no public `hdel` path, so polymorphic callers had to either reach into the responder's internal `Map` or skip removal.

## Verification

- `pnpm run build` clean.
- `pnpm run test` 177/177 passing.

## Future consumer

This is the first of a series of small PRs splitting up an admin-CLI feature branch I'd previously opened too large (#137). The sibling `users.remove` command in a later PR is the first polymorphic `hdel` caller.