### PR TITLE
Serialize concurrent save() in local blob and keyval storage

### DIFF
--- a/.changeset/savechain-serialize-saves.md
+++ b/.changeset/savechain-serialize-saves.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Serialize concurrent `save()` in local blob and keyval storage

--- a/packages/xxscreeps/engine/db/storage/local/blob.ts
+++ b/packages/xxscreeps/engine/db/storage/local/blob.ts
@@ -15,6 +15,7 @@ export class BlobStorage {
 
 	private saveId = 0;
 	private readonly knownPaths = new Set<string>();
+	private saveChain: Promise<void> = Promise.resolve();
 	private readonly path;
 
 	constructor(path: string | null) {
@@ -215,7 +216,13 @@ export class BlobStorage {
 		}
 	}
 
-	async save() {
+	save() {
+		const promise = this.saveChain.then(() => this.performSave());
+		this.saveChain = promise.catch(() => {});
+		return promise;
+	}
+
+	private async performSave() {
 		// Get changes since last save
 		if (this.path === null) {
 			return;

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -21,6 +21,7 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 	private readonly data = new Map<string, any>();
 	private readonly expires = new Set<string>();
 	private readonly scripts = new Map<string, (instance: LocalKeyValResponder, keys: string[], argv: P.Value[]) => any>();
+	private saveChain: Promise<void> = Promise.resolve();
 	private readonly url;
 	private readonly blob;
 
@@ -614,7 +615,13 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 		this.data.clear();
 	}
 
-	async save() {
+	save() {
+		const promise = this.saveChain.then(() => this.performSave());
+		this.saveChain = promise.catch(() => {});
+		return promise;
+	}
+
+	private async performSave() {
 		if (this.url) {
 			const payload = JSON.stringify(this.data, (key, value) => {
 				if (value === this.data) {

--- a/packages/xxscreeps/engine/db/storage/local/test.ts
+++ b/packages/xxscreeps/engine/db/storage/local/test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as Path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { BlobStorage } from './blob.js';
+import { LocalKeyValResponder } from './keyval.js';
+
+type SaveSpy = { performSave: () => Promise<void> };
+
+async function withTempDir<Type>(body: (dir: string) => Promise<Type>): Promise<Type> {
+	const dir = await fs.mkdtemp(Path.join(os.tmpdir(), 'xxscreeps-savechain-'));
+	try {
+		return await body(dir);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+describe('Local storage save() serialization', () => {
+
+	test('blob save() serializes overlapping invocations', () => withTempDir(async dir => {
+		const url = pathToFileURL(`${dir}/`);
+		const [ effect, blob ] = await BlobStorage.create(url);
+		try {
+			const order: string[] = [];
+			const spy = blob as unknown as SaveSpy;
+			const original = spy.performSave.bind(blob);
+			let counter = 0;
+			spy.performSave = async function() {
+				const id = ++counter;
+				order.push(`enter-${id}`);
+				try {
+					await original();
+				} finally {
+					order.push(`exit-${id}`);
+				}
+			};
+
+			blob.set('a', new Uint8Array([ 1 ]));
+			const first = blob.save();
+			blob.set('b', new Uint8Array([ 2 ]));
+			const second = blob.save();
+			await Promise.all([ first, second ]);
+
+			assert.deepStrictEqual(order, [ 'enter-1', 'exit-1', 'enter-2', 'exit-2' ]);
+		} finally {
+			effect();
+		}
+	}));
+
+	test('blob save() persists last write for overlapping keys', () => withTempDir(async dir => {
+		const url = pathToFileURL(`${dir}/`);
+		const [ effect, blob ] = await BlobStorage.create(url);
+		try {
+			blob.set('k', new Uint8Array([ 1, 2, 3 ]));
+			const first = blob.save();
+			blob.set('k', new Uint8Array([ 4, 5, 6 ]));
+			const second = blob.save();
+			await Promise.all([ first, second ]);
+
+			const persisted = await fs.readFile(Path.join(dir, 'k'));
+			assert.deepStrictEqual([ ...persisted ], [ 4, 5, 6 ]);
+		} finally {
+			effect();
+		}
+	}));
+
+	test('keyval save() serializes overlapping invocations', () => withTempDir(async dir => {
+		const url = new URL(`${pathToFileURL(dir)}/`);
+		const [ effect, host ] = await LocalKeyValResponder.create(url);
+		try {
+			const order: string[] = [];
+			const spy = host as unknown as SaveSpy;
+			const original = spy.performSave.bind(host);
+			let counter = 0;
+			spy.performSave = async function() {
+				const id = ++counter;
+				order.push(`enter-${id}`);
+				try {
+					await original();
+				} finally {
+					order.push(`exit-${id}`);
+				}
+			};
+
+			host.set('a', '1');
+			const first = host.save();
+			host.set('b', '2');
+			const second = host.save();
+			await Promise.all([ first, second ]);
+
+			assert.deepStrictEqual(order, [ 'enter-1', 'exit-1', 'enter-2', 'exit-2' ]);
+		} finally {
+			effect();
+		}
+	}));
+
+	test('keyval save() persists last write for overlapping keys', () => withTempDir(async dir => {
+		const url = new URL(`${pathToFileURL(dir)}/`);
+		const [ effect, host ] = await LocalKeyValResponder.create(url);
+		try {
+			host.set('k', 'first');
+			const first = host.save();
+			host.set('k', 'second');
+			const second = host.save();
+			await Promise.all([ first, second ]);
+
+			const payload = JSON.parse(await fs.readFile(Path.join(dir, 'data.json'), 'utf8')) as { $: Record<string, string> };
+			assert.strictEqual(payload.$.k, 'second');
+		} finally {
+			effect();
+		}
+	}));
+});

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -1,6 +1,7 @@
 import { importMods } from 'xxscreeps/config/mods/index.js';
 import { flush, summary } from './context.js';
 import './import.js';
+import 'xxscreeps/engine/db/storage/local/test.js';
 
 await importMods('test');
 try {


### PR DESCRIPTION
Both `BlobStorage.save()` and `LocalKeyValResponder.save()` write to a fixed `.<basename>.swp` tmp path and then `rename()` it over the live file. Two overlapping `save()` calls race on that single tmp path: the second writeFile clobbers the first's tmp content, the first rename moves the wrong bytes to the live file, and the second rename then fails with `ENOENT` because the tmp is already gone.

The fix is a per-instance `saveChain: Promise<void>` that serializes callers — each `save()` chains its `performSave()` body onto the chain and replaces the chain with an error-swallowed copy so a transient failure doesn't poison subsequent saves. The caller-returned promise still rejects normally; only the chain itself catches.

This race isn't reachable today because only the shutdown path calls `save()`. The first overlapping caller is the upcoming CLI `system.importWorld` command, which calls `save()` after wiping and re-importing the world while shutdown's `backendContext.close()` also triggers a final `save()`. Without this guard, one of the two writes silently disappears.

Includes a regression test at
`engine/db/storage/local/test.ts` covering both providers with two designs:
- a behavior test that wraps `performSave` to record enter/exit timestamps and asserts strict serialization across two concurrent `save()` calls;
- an outcome test that issues two overlapping `set` + `save` pairs and reads the persisted file back from disk to verify last-save-wins. Without `saveChain` the outcome test reproducibly fails with the ENOENT rename error described above.