### PR TITLE
Wire up missing Room.getEventLog() events; match vanilla data shape

### DIFF
--- a/.changeset/wire-event-log-events.md
+++ b/.changeset/wire-event-log-events.md
@@ -1,0 +1,11 @@
+---
+"xxscreeps": patch
+---
+
+Wire up missing `Room.getEventLog()` events and reshape the player-facing payload to vanilla's `{event, objectId, data?}` shape.
+
+Newly emitted: `EVENT_BUILD`, `EVENT_REPAIR`, `EVENT_TRANSFER`, `EVENT_EXIT`, `EVENT_ATTACK_CONTROLLER`, `EVENT_RESERVE_CONTROLLER`, `EVENT_UPGRADE_CONTROLLER`, `EVENT_OBJECT_DESTROYED` (on creep death, structure destruction by attack/dismantle, and container decay), and `EVENT_ATTACK` for the previously-unwired `DISMANTLE` and `HIT_BACK` `attackType` variants. Each event is emitted exactly once at the intent processor that performs the action; `Creep.prototype['#applyDamage']` no longer emits, keeping damage application and event recording decoupled. `EVENT_OBJECT_DESTROYED` is gated on the alive→dead transition so multi-attacker ticks don't duplicate it.
+
+`EVENT_BUILD` carries `structureType`, `x`, `y`, and `incomplete` to match vanilla's payload.
+
+Closes #107. Verified against screeps-ok.

--- a/.changeset/wire-event-log-events.md
+++ b/.changeset/wire-event-log-events.md
@@ -2,10 +2,4 @@
 "xxscreeps": patch
 ---
 
-Wire up missing `Room.getEventLog()` events and reshape the player-facing payload to vanilla's `{event, objectId, data?}` shape.
-
-Newly emitted: `EVENT_BUILD`, `EVENT_REPAIR`, `EVENT_TRANSFER`, `EVENT_EXIT`, `EVENT_ATTACK_CONTROLLER`, `EVENT_RESERVE_CONTROLLER`, `EVENT_UPGRADE_CONTROLLER`, `EVENT_OBJECT_DESTROYED` (on creep death, structure destruction by attack/dismantle, and container decay), and `EVENT_ATTACK` for the previously-unwired `DISMANTLE` and `HIT_BACK` `attackType` variants. Each event is emitted exactly once at the intent processor that performs the action; `Creep.prototype['#applyDamage']` no longer emits, keeping damage application and event recording decoupled. `EVENT_OBJECT_DESTROYED` is gated on the alive→dead transition so multi-attacker ticks don't duplicate it.
-
-`EVENT_BUILD` carries `structureType`, `x`, `y`, and `incomplete` to match vanilla's payload.
-
-Closes #107. Verified against screeps-ok.
+Emit missing `Room.getEventLog()` events with vanilla-shaped payloads.

--- a/packages/xxscreeps/game/room/event-log.ts
+++ b/packages/xxscreeps/game/room/event-log.ts
@@ -6,22 +6,18 @@ import { Room } from './room.js';
 type RemoveVariant<T> = T extends any ? Omit<T, typeof Variant> : never;
 export type AnyEventLog = RemoveVariant<Room['#eventLog'][number]>;
 
-// Vanilla shape: `{event, objectId, data?}`, with `data` omitted when there are no
-// extra fields. Distributes over the union so per-variant payloads stay narrowable.
-type EventToPlayer<E> = E extends { event: infer Ev; objectId: infer Id }
-	? Omit<E, 'event' | 'objectId'> extends infer D
-		? keyof D extends never
-			? { event: Ev; objectId: Id }
-			: { event: Ev; objectId: Id; data: D }
-		: never
-	: never;
-export type PlayerEventLog = EventToPlayer<AnyEventLog>;
+export interface GameEvent {
+	event: number;
+	objectId: string;
+	data?: Record<string, unknown>;
+	[key: string]: unknown;
+}
 
-function toPlayerShape(entry: AnyEventLog): PlayerEventLog {
+function toPlayerShape(entry: AnyEventLog): GameEvent {
 	const { event, objectId, ...data } = entry;
-	return (Object.keys(data).length === 0
+	return Object.keys(data).length === 0
 		? { event, objectId }
-		: { event, objectId, data }) as PlayerEventLog;
+		: { event, objectId, data };
 }
 
 // Event log mutator
@@ -41,7 +37,7 @@ declare module './room.js' {
 		// eslint-disable-next-line @typescript-eslint/method-signature-style
 		getEventLog(raw: true): string;
 		// eslint-disable-next-line @typescript-eslint/method-signature-style
-		getEventLog(raw?: false): PlayerEventLog[];
+		getEventLog(raw?: false): GameEvent[];
 	}
 }
 

--- a/packages/xxscreeps/game/room/event-log.ts
+++ b/packages/xxscreeps/game/room/event-log.ts
@@ -6,6 +6,24 @@ import { Room } from './room.js';
 type RemoveVariant<T> = T extends any ? Omit<T, typeof Variant> : never;
 export type AnyEventLog = RemoveVariant<Room['#eventLog'][number]>;
 
+// Vanilla shape: `{event, objectId, data?}`, with `data` omitted when there are no
+// extra fields. Distributes over the union so per-variant payloads stay narrowable.
+type EventToPlayer<E> = E extends { event: infer Ev; objectId: infer Id }
+	? Omit<E, 'event' | 'objectId'> extends infer D
+		? keyof D extends never
+			? { event: Ev; objectId: Id }
+			: { event: Ev; objectId: Id; data: D }
+		: never
+	: never;
+export type PlayerEventLog = EventToPlayer<AnyEventLog>;
+
+function toPlayerShape(entry: AnyEventLog): PlayerEventLog {
+	const { event, objectId, ...data } = entry;
+	return (Object.keys(data).length === 0
+		? { event, objectId }
+		: { event, objectId, data }) as PlayerEventLog;
+}
+
 // Event log mutator
 export function appendEventLog(room: Room, event: AnyEventLog) {
 	room['#eventLog'].push({
@@ -23,18 +41,15 @@ declare module './room.js' {
 		// eslint-disable-next-line @typescript-eslint/method-signature-style
 		getEventLog(raw: true): string;
 		// eslint-disable-next-line @typescript-eslint/method-signature-style
-		getEventLog(raw?: false): AnyEventLog[];
+		getEventLog(raw?: false): PlayerEventLog[];
 	}
 }
 
 extend(Room, {
 	// @ts-expect-error
 	getEventLog(raw = false) {
+		const translated = (this['#eventLog'] as AnyEventLog[]).map(toPlayerShape);
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (raw) {
-			return JSON.stringify(this['#eventLog']);
-		} else {
-			return this['#eventLog'];
-		}
+		return raw ? JSON.stringify(translated) : translated;
 	},
 });

--- a/packages/xxscreeps/mods/combat/creep.ts
+++ b/packages/xxscreeps/mods/combat/creep.ts
@@ -3,6 +3,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import { chainIntentChecks, checkRange, checkSafeMode, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { intents } from 'xxscreeps/game/index.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Creep, calculatePower, checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { Structure } from 'xxscreeps/mods/structure/structure.js';
 import { extend } from 'xxscreeps/utility/utility.js';
@@ -105,6 +106,13 @@ Creep.prototype['#applyDamage'] = function(this: Creep, power, type, source) {
 		if (counterAttack) {
 			const damage = captureDamage(source, counterAttack, C.EVENT_ATTACK_TYPE_HIT_BACK, null);
 			if (damage > 0) {
+				appendEventLog(this.room, {
+					event: C.EVENT_ATTACK,
+					objectId: this.id,
+					targetId: source.id,
+					attackType: C.EVENT_ATTACK_TYPE_HIT_BACK,
+					damage,
+				});
 				source['#applyDamage'](damage, C.EVENT_ATTACK_TYPE_HIT_BACK, this);
 			}
 		}

--- a/packages/xxscreeps/mods/combat/processor.ts
+++ b/packages/xxscreeps/mods/combat/processor.ts
@@ -45,9 +45,9 @@ const intents = [
 		const target = Game.getObjectById<Creep | DestructibleStructure>(id)!;
 		if (checkRangedAttack(creep, target) === C.OK) {
 			const power = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER, 'rangedAttack');
-			const damage = captureDamage(target, power, C.RANGED_ATTACK_POWER, creep);
+			const damage = captureDamage(target, power, C.EVENT_ATTACK_TYPE_RANGED, creep);
 			if (damage > 0) {
-				target['#applyDamage'](damage, C.RANGED_ATTACK_POWER, creep);
+				target['#applyDamage'](damage, C.EVENT_ATTACK_TYPE_RANGED, creep);
 				appendEventLog(target.room, {
 					event: C.EVENT_ATTACK,
 					objectId: creep.id,

--- a/packages/xxscreeps/mods/combat/test.ts
+++ b/packages/xxscreeps/mods/combat/test.ts
@@ -78,12 +78,16 @@ describe('getEventLog', () => {
 		await tick();
 		await player('100', Game => {
 			const log = Game.rooms.W1N1.getEventLog();
-			const attackEvent: unknown = log.find(event => event.event === C.EVENT_ATTACK);
+			const attackEvent = log.find(event => event.event === C.EVENT_ATTACK);
 			assert.ok(attackEvent, 'expected an attack event in the event log');
+			assert.strictEqual(attackEvent.objectId, Game.creeps.attacker.id);
+			assert.ok(attackEvent.data, 'expected nested data payload');
+			assert.strictEqual(attackEvent.data.attackType, C.EVENT_ATTACK_TYPE_MELEE);
+			assert.ok(typeof attackEvent.data.damage === 'number');
 		});
 	}));
 
-	test('raw mode returns JSON string', () => sim(async ({ player, tick }) => {
+	test('raw mode returns vanilla-shaped JSON string', () => sim(async ({ player, tick }) => {
 		await player('100', Game => {
 			const lab = Game.rooms.W1N1.find(C.FIND_STRUCTURES)
 				.find(structure => structure.structureType === C.STRUCTURE_LAB)!;
@@ -93,8 +97,79 @@ describe('getEventLog', () => {
 		await player('100', Game => {
 			const raw = Game.rooms.W1N1.getEventLog(true);
 			assert.ok(typeof raw === 'string');
-			const parsed: unknown = JSON.parse(raw);
+			const parsed = JSON.parse(raw) as { event: number; objectId: string; data?: Record<string, unknown> }[];
 			assert.ok(Array.isArray(parsed));
+			const attack = parsed.find(event => event.event === C.EVENT_ATTACK);
+			assert.ok(attack, 'attack event missing from raw log');
+			assert.ok(attack.data && typeof attack.data === 'object', 'attack event data must be an object');
+		});
+	}));
+});
+
+describe('getEventLog missing events', () => {
+	// Structure destruction (EVENT_OBJECT_DESTROYED) from damage.
+	const structureKill = simulate({
+		W1N1: room => {
+			room['#level'] = 7;
+			room['#user'] = room.controller!['#user'] = '100';
+			room['#insertObject'](createLab(new RoomPosition(25, 25, 'W1N1'), '100'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 24, 'W1N1'),
+				[ ...Fn.map(Fn.range(17), () => C.ATTACK) ],
+				'warrior', '100',
+			));
+		},
+	});
+
+	test('structure death emits EVENT_OBJECT_DESTROYED with structureType', () => structureKill(async ({ player, tick }) => {
+		await player('100', Game => {
+			const lab = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB)[0]!;
+			Game.creeps.warrior.attack(lab);
+		});
+		await tick();
+		await player('100', Game => {
+			const log = Game.rooms.W1N1.getEventLog();
+			const destroyed = log.find(event => event.event === C.EVENT_OBJECT_DESTROYED);
+			assert.ok(destroyed, 'expected an EVENT_OBJECT_DESTROYED entry');
+			assert.ok(destroyed.data, 'expected nested data payload');
+			assert.strictEqual(destroyed.data.type, C.STRUCTURE_LAB);
+		});
+	}));
+
+	// Two attackers landing on the same structure on the same tick must produce
+	// exactly one EVENT_OBJECT_DESTROYED — the destroyed-event must gate on the
+	// alive→dead transition, not on the post-damage hits value.
+	const multiAttackerKill = simulate({
+		W1N1: room => {
+			room['#level'] = 7;
+			room['#user'] = room.controller!['#user'] = '100';
+			const lab = createLab(new RoomPosition(25, 25, 'W1N1'), '100');
+			room['#insertObject'](lab);
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 24, 'W1N1'),
+				[ ...Fn.map(Fn.range(17), () => C.ATTACK) ],
+				'warriorA', '100',
+			));
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 26, 'W1N1'),
+				[ ...Fn.map(Fn.range(17), () => C.ATTACK) ],
+				'warriorB', '100',
+			));
+		},
+	});
+
+	test('multi-attacker kill emits EVENT_OBJECT_DESTROYED exactly once', () => multiAttackerKill(async ({ player, tick }) => {
+		await player('100', Game => {
+			const lab = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB)[0]!;
+			Game.creeps.warriorA.attack(lab);
+			Game.creeps.warriorB.attack(lab);
+		});
+		await tick();
+		await player('100', Game => {
+			const log = Game.rooms.W1N1.getEventLog();
+			const destroyed = log.filter(event => event.event === C.EVENT_OBJECT_DESTROYED);
+			assert.strictEqual(destroyed.length, 1,
+				`expected exactly one EVENT_OBJECT_DESTROYED for one structure death, got ${destroyed.length}`);
 		});
 	}));
 });

--- a/packages/xxscreeps/mods/construction/game.ts
+++ b/packages/xxscreeps/mods/construction/game.ts
@@ -36,9 +36,14 @@ const siteSchema = registerVariant('Room.objects', ConstructionSite.format);
 const buildEventSchema = registerVariant('Room.eventLog', struct({
 	...variant(C.EVENT_BUILD),
 	event: constant(C.EVENT_BUILD),
+	objectId: Id.format,
 	targetId: Id.format,
 	amount: 'int32',
 	energySpent: 'int32',
+	structureType: 'string',
+	x: 'int8',
+	y: 'int8',
+	incomplete: 'bool',
 }));
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const repairEventSchema = registerVariant('Room.eventLog', struct({

--- a/packages/xxscreeps/mods/construction/processor.ts
+++ b/packages/xxscreeps/mods/construction/processor.ts
@@ -5,6 +5,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, me } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { captureDamage } from 'xxscreeps/mods/combat/creep.js';
 import { Creep, calculateBoundedEffect, calculatePower } from 'xxscreeps/mods/creep/creep.js';
@@ -54,9 +55,21 @@ const intents = [
 				Math.min(buildRemaining, creep.store.energy),
 			);
 			if (energy > 0) {
+				const applied = Math.min(boosted, buildRemaining);
 				creep.store['#subtract'](C.RESOURCE_ENERGY, energy);
-				target.progress += Math.min(boosted, buildRemaining);
+				target.progress += applied;
 				saveAction(creep, 'build', target.pos);
+				appendEventLog(target.room, {
+					event: C.EVENT_BUILD,
+					objectId: creep.id,
+					targetId: target.id,
+					amount: applied,
+					energySpent: energy,
+					structureType: target.structureType,
+					x: target.pos.x,
+					y: target.pos.y,
+					incomplete: target.progress < target.progressTotal,
+				});
 				context.didUpdate();
 			}
 		}
@@ -77,11 +90,17 @@ const intents = [
 					Resource.drop(creep.pos, 'energy', overflow);
 				}
 				const damage = captureDamage(target, effect, C.EVENT_ATTACK_TYPE_DISMANTLE, creep);
-				target.hits -= damage;
-				if (target.hits <= 0) {
-					target['#destroy']();
+				if (damage > 0) {
+					target['#applyDamage'](damage, C.EVENT_ATTACK_TYPE_DISMANTLE, creep);
+					appendEventLog(target.room, {
+						event: C.EVENT_ATTACK,
+						objectId: creep.id,
+						targetId: target.id,
+						attackType: C.EVENT_ATTACK_TYPE_DISMANTLE,
+						damage,
+					});
 				}
-				// TODO: dismantle event
+				// TODO: dismantle action animation
 				// saveAction(creep, 'dismantle', target.pos.x, target.pos.y);
 				context.didUpdate();
 			}
@@ -103,9 +122,17 @@ const intents = [
 			);
 			if (effect > 0) {
 				const energyCost = Math.min(creep.store.energy, Math.ceil(effect * C.REPAIR_COST));
+				const applied = Math.min(boosted, repairHitsMax);
 				creep.store['#subtract'](C.RESOURCE_ENERGY, energyCost);
-				target.hits += Math.min(boosted, repairHitsMax);
+				target.hits += applied;
 				saveAction(creep, 'repair', target.pos);
+				appendEventLog(target.room, {
+					event: C.EVENT_REPAIR,
+					objectId: creep.id,
+					targetId: target.id,
+					amount: applied,
+					energySpent: energyCost,
+				});
 				context.didUpdate();
 			}
 		}

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -1,6 +1,8 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create as createSite } from './construction-site.js';
 
@@ -209,6 +211,94 @@ describe('Construction', () => {
 			});
 			await player('100', Game => {
 				assert.strictEqual(Object.values(Game.constructionSites).length, 0);
+			});
+		}));
+	});
+
+	describe('event log emissions', () => {
+		const buildSim = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				const builder = createCreep(new RoomPosition(25, 25, 'W1N1'), [ C.WORK, C.CARRY ], 'builder', '100');
+				builder.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](builder);
+				room['#insertObject'](createSite(new RoomPosition(26, 25, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road));
+			},
+		});
+
+		test('build emits EVENT_BUILD with amount and energySpent', () => buildSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const site = Object.values(Game.constructionSites)[0]!;
+				assert.strictEqual(Game.creeps.builder.build(site), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W1N1.getEventLog();
+				const build = log.find(entry => entry.event === C.EVENT_BUILD);
+				assert.ok(build, 'expected EVENT_BUILD');
+				assert.strictEqual(build.objectId, Game.creeps.builder.id);
+				assert.strictEqual(build.data.amount, C.BUILD_POWER);
+				assert.strictEqual(build.data.energySpent, C.BUILD_POWER);
+			});
+		}));
+
+		const repairSim = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				const fixer = createCreep(new RoomPosition(25, 25, 'W1N1'), [ C.WORK, C.CARRY ], 'fixer', '100');
+				fixer.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](fixer);
+				const container = createContainer(new RoomPosition(26, 25, 'W1N1'));
+				container.hits = 100;
+				room['#insertObject'](container);
+			},
+		});
+
+		test('creep repair emits EVENT_REPAIR with amount and energySpent', () => repairSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+				assert.strictEqual(Game.creeps.fixer.repair(container), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W1N1.getEventLog();
+				const repair = log.find(entry => entry.event === C.EVENT_REPAIR);
+				assert.ok(repair, 'expected EVENT_REPAIR');
+				assert.strictEqual(repair.objectId, Game.creeps.fixer.id);
+				assert.strictEqual(repair.data.amount, C.REPAIR_POWER);
+				assert.strictEqual(repair.data.energySpent, Math.ceil(C.REPAIR_COST));
+			});
+		}));
+
+		// Dismantle reaches structure death via #applyDamage so EVENT_OBJECT_DESTROYED
+		// fires from Structure's override; without that path the destroyed-event
+		// would be silently dropped on dismantle-kills.
+		const dismantleKill = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				const dismantler = createCreep(new RoomPosition(25, 25, 'W1N1'), [ C.WORK, C.MOVE ], 'dismantler', '100');
+				room['#insertObject'](dismantler);
+				const container = createContainer(new RoomPosition(26, 25, 'W1N1'));
+				container.hits = 10;
+				room['#insertObject'](container);
+			},
+		});
+
+		test('dismantle to death emits EVENT_OBJECT_DESTROYED with structureType', () => dismantleKill(async ({ player, tick }) => {
+			await player('100', Game => {
+				const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+				assert.strictEqual(Game.creeps.dismantler.dismantle(container), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W1N1.getEventLog();
+				const destroyed = log.find(entry => entry.event === C.EVENT_OBJECT_DESTROYED);
+				assert.ok(destroyed, 'expected EVENT_OBJECT_DESTROYED for dismantled structure');
+				assert.ok(destroyed.data, 'expected nested data payload');
+				assert.strictEqual(destroyed.data.type, C.STRUCTURE_CONTAINER);
 			});
 		}));
 	});

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -238,6 +238,7 @@ describe('Construction', () => {
 				const build = log.find(entry => entry.event === C.EVENT_BUILD);
 				assert.ok(build, 'expected EVENT_BUILD');
 				assert.strictEqual(build.objectId, Game.creeps.builder.id);
+				assert.ok(build.data, 'expected nested data payload');
 				assert.strictEqual(build.data.amount, C.BUILD_POWER);
 				assert.strictEqual(build.data.energySpent, C.BUILD_POWER);
 			});
@@ -267,6 +268,7 @@ describe('Construction', () => {
 				const repair = log.find(entry => entry.event === C.EVENT_REPAIR);
 				assert.ok(repair, 'expected EVENT_REPAIR');
 				assert.strictEqual(repair.objectId, Game.creeps.fixer.id);
+				assert.ok(repair.data, 'expected nested data payload');
 				assert.strictEqual(repair.data.amount, C.REPAIR_POWER);
 				assert.strictEqual(repair.data.energySpent, Math.ceil(C.REPAIR_COST));
 			});

--- a/packages/xxscreeps/mods/controller/game.ts
+++ b/packages/xxscreeps/mods/controller/game.ts
@@ -3,7 +3,7 @@ import { registerEnumerated, registerStruct, registerVariant } from 'xxscreeps/e
 import * as C from 'xxscreeps/game/constants/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { RoomObject } from 'xxscreeps/game/object.js';
-import { optional, struct } from 'xxscreeps/schema/index.js';
+import { constant, optional, struct, variant } from 'xxscreeps/schema/index.js';
 import * as Controller from './controller.js';
 import './creep.js';
 
@@ -23,8 +23,38 @@ const roomSchema = registerStruct('Room', {
 });
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const controllerSchema = registerVariant('Room.objects', Controller.format);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const attackControllerEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_ATTACK_CONTROLLER),
+	event: constant(C.EVENT_ATTACK_CONTROLLER),
+	objectId: Id.format,
+}));
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const reserveControllerEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_RESERVE_CONTROLLER),
+	event: constant(C.EVENT_RESERVE_CONTROLLER),
+	objectId: Id.format,
+	amount: 'int32',
+}));
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const upgradeControllerEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_UPGRADE_CONTROLLER),
+	event: constant(C.EVENT_UPGRADE_CONTROLLER),
+	objectId: Id.format,
+	amount: 'int32',
+	energySpent: 'int32',
+}));
 declare module 'xxscreeps/game/room/index.js' {
-	interface Schema { controller: [ typeof roomSchema, typeof controllerSchema ] }
+	interface Schema {
+		controller: [
+			typeof roomSchema,
+			typeof controllerSchema,
+			typeof attackControllerEventSchema,
+			typeof reserveControllerEventSchema,
+			typeof upgradeControllerEventSchema,
+		];
+	}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/xxscreeps/mods/controller/processor.ts
+++ b/packages/xxscreeps/mods/controller/processor.ts
@@ -5,6 +5,7 @@ import { registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Creep, calculateBoundedEffect } from 'xxscreeps/mods/creep/creep.js';
 import { checkActiveStructures } from 'xxscreeps/mods/structure/structure.js';
 import { StructureController, checkActivateSafeMode, checkUnclaim } from './controller.js';
@@ -77,6 +78,10 @@ const intents = [
 				controller['#upgradeBlockedUntil'] = Game.time + C.CONTROLLER_ATTACK_BLOCKED_UPGRADE - 1;
 			}
 			saveAction(creep, 'attack', controller.pos);
+			appendEventLog(controller.room, {
+				event: C.EVENT_ATTACK_CONTROLLER,
+				objectId: creep.id,
+			});
 			context.didUpdate();
 		}
 	}),
@@ -148,6 +153,11 @@ const intents = [
 				context.task(context.shard.scratch.sadd(reservedRoomKey(userId), [ controller.room.name ]));
 			}
 			saveAction(creep, 'reserveController', controller.pos);
+			appendEventLog(controller.room, {
+				event: C.EVENT_RESERVE_CONTROLLER,
+				objectId: creep.id,
+				amount: power,
+			});
 			context.didUpdate();
 		}
 	}),
@@ -201,6 +211,14 @@ const intents = [
 				}
 			}
 			saveAction(creep, 'upgradeController', controller.pos);
+			// Vanilla emits amount=upgrade output (boosted), energySpent=energy
+			// debited from the creep (unboosted).
+			appendEventLog(controller.room, {
+				event: C.EVENT_UPGRADE_CONTROLLER,
+				objectId: creep.id,
+				amount: progress,
+				energySpent: energy,
+			});
 			context.didUpdate();
 		}
 	}),

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -91,4 +91,64 @@ describe('Controller', () => {
 			});
 		}));
 	});
+
+	describe('event log emissions', () => {
+
+		test('attackController emits EVENT_ATTACK_CONTROLLER with no data', () => hostileReservation(async ({ player, tick }) => {
+			await player('100', Game => {
+				Game.creeps.claimer.attackController(Game.rooms.W3N3.controller!);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W3N3.getEventLog();
+				const event = log.find(entry => entry.event === C.EVENT_ATTACK_CONTROLLER);
+				assert.ok(event, 'expected EVENT_ATTACK_CONTROLLER');
+				assert.strictEqual(event.objectId, Game.creeps.claimer.id);
+				assert.ok(!('data' in event),
+					'EVENT_ATTACK_CONTROLLER must omit data field to match vanilla shape');
+			});
+		}));
+
+		test('reserveController emits EVENT_RESERVE_CONTROLLER with amount', () => ownReservation(async ({ player, tick }) => {
+			await player('100', Game => {
+				Game.creeps.claimer.reserveController(Game.rooms.W3N3.controller!);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W3N3.getEventLog();
+				const event = log.find(entry => entry.event === C.EVENT_RESERVE_CONTROLLER);
+				assert.ok(event, 'expected EVENT_RESERVE_CONTROLLER');
+				assert.strictEqual(event.objectId, Game.creeps.claimer.id);
+				assert.strictEqual(event.data.amount, C.CONTROLLER_RESERVE);
+			});
+		}));
+
+		// Controller at (33,32); worker at (34,32) holds 50 energy and one WORK.
+		const upgradeSim = simulate({
+			W3N3: room => {
+				room['#user'] = '100';
+				room['#level'] = 1;
+				room.controller!['#user'] = '100';
+				room.controller!['#downgradeTime'] = 1000;
+				const worker = create(new RoomPosition(34, 32, 'W3N3'), [ C.WORK, C.CARRY ], 'worker', '100');
+				worker.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](worker);
+			},
+		});
+
+		test('upgradeController emits EVENT_UPGRADE_CONTROLLER with amount and energySpent', () => upgradeSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				Game.creeps.worker.upgradeController(Game.rooms.W3N3.controller!);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W3N3.getEventLog();
+				const event = log.find(entry => entry.event === C.EVENT_UPGRADE_CONTROLLER);
+				assert.ok(event, 'expected EVENT_UPGRADE_CONTROLLER');
+				assert.strictEqual(event.objectId, Game.creeps.worker.id);
+				assert.strictEqual(event.data.amount, C.UPGRADE_CONTROLLER_POWER);
+				assert.strictEqual(event.data.energySpent, C.UPGRADE_CONTROLLER_POWER);
+			});
+		}));
+	});
 });

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -119,6 +119,7 @@ describe('Controller', () => {
 				const event = log.find(entry => entry.event === C.EVENT_RESERVE_CONTROLLER);
 				assert.ok(event, 'expected EVENT_RESERVE_CONTROLLER');
 				assert.strictEqual(event.objectId, Game.creeps.claimer.id);
+				assert.ok(event.data, 'expected nested data payload');
 				assert.strictEqual(event.data.amount, C.CONTROLLER_RESERVE);
 			});
 		}));
@@ -146,6 +147,7 @@ describe('Controller', () => {
 				const event = log.find(entry => entry.event === C.EVENT_UPGRADE_CONTROLLER);
 				assert.ok(event, 'expected EVENT_UPGRADE_CONTROLLER');
 				assert.strictEqual(event.objectId, Game.creeps.worker.id);
+				assert.ok(event.data, 'expected nested data payload');
 				assert.strictEqual(event.data.amount, C.UPGRADE_CONTROLLER_POWER);
 				assert.strictEqual(event.data.energySpent, C.UPGRADE_CONTROLLER_POWER);
 			});

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -117,19 +117,12 @@ export class Creep extends withOverlay(RoomObject, shape) {
 		game.creeps[this.name] = this;
 	}
 
-	override '#applyDamage'(power: number, type: number, source?: RoomObject) {
+	override '#applyDamage'(power: number, _type: number, source?: RoomObject) {
 		if (this.spawning) {
 			return;
 		}
 		this.tickRawDamage = (this.tickRawDamage ?? 0) + power;
 		if (source) {
-			appendEventLog(this.room, {
-				event: C.EVENT_ATTACK,
-				objectId: source.id,
-				targetId: this.id,
-				attackType: type,
-				damage: power,
-			});
 			saveAction(this, 'attacked', source.pos);
 		}
 	}

--- a/packages/xxscreeps/mods/creep/game.ts
+++ b/packages/xxscreeps/mods/creep/game.ts
@@ -1,7 +1,10 @@
+import * as Id from 'xxscreeps/engine/schema/id.js';
 import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
+import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
+import { constant, struct, variant } from 'xxscreeps/schema/index.js';
 import { Creep, format as creepFormat } from './creep.js';
 import { Tombstone, format as tombstoneFormat } from './tombstone.js';
 
@@ -48,6 +51,32 @@ declare module 'xxscreeps/game/room/index.js' {
 const creepSchema = registerVariant('Room.objects', creepFormat);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const tombstoneSchema = registerVariant('Room.objects', tombstoneFormat);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const transferEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_TRANSFER),
+	event: constant(C.EVENT_TRANSFER),
+	objectId: Id.format,
+	targetId: Id.format,
+	resourceType: resourceEnumFormat,
+	amount: 'int32',
+}));
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const exitEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_EXIT),
+	event: constant(C.EVENT_EXIT),
+	objectId: Id.format,
+	room: 'string',
+	x: 'int8',
+	y: 'int8',
+}));
 declare module 'xxscreeps/game/room/index.js' {
-	interface Schema { creep: [ typeof creepSchema, typeof tombstoneSchema ] }
+	interface Schema {
+		creep: [
+			typeof creepSchema,
+			typeof tombstoneSchema,
+			typeof transferEventSchema,
+			typeof exitEventSchema,
+		];
+	}
 }

--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -13,6 +13,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomPosition, generateRoomName, parseRoomName } from 'xxscreeps/game/position.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { drop as dropResource } from 'xxscreeps/mods/resource/processor/resource.js';
 import * as ResourceIntent from 'xxscreeps/mods/resource/processor/resource.js';
@@ -267,6 +268,13 @@ const intents = [
 		if (CreepLib.checkTransfer(creep, target, resourceType, amount) === C.OK) {
 			creep.store['#subtract'](resourceType, amount);
 			target.store['#add'](resourceType, amount);
+			appendEventLog(creep.room, {
+				event: C.EVENT_TRANSFER,
+				objectId: creep.id,
+				targetId: target.id,
+				resourceType,
+				amount,
+			});
 			context.didUpdate();
 		}
 	}),
@@ -276,6 +284,13 @@ const intents = [
 		if (CreepLib.checkWithdraw(creep, target, resourceType, amount) === C.OK) {
 			target.store['#subtract'](resourceType, amount);
 			creep.store['#add'](resourceType, amount);
+			appendEventLog(creep.room, {
+				event: C.EVENT_TRANSFER,
+				objectId: target.id,
+				targetId: creep.id,
+				resourceType,
+				amount,
+			});
 			context.didUpdate();
 		}
 	}),
@@ -354,6 +369,13 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 				return new RoomPosition(creep.pos.x, 0, generateRoomName(rx, ry + 1));
 			}
 		}();
+		appendEventLog(creep.room, {
+			event: C.EVENT_EXIT,
+			objectId: creep.id,
+			room: next.roomName,
+			x: next.x,
+			y: next.y,
+		});
 		creep.room['#removeObject'](creep);
 		// Update `creep.pos` for the import command but set it back so that `#flushObjects` can safely
 		// update the internal indices.

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -1,5 +1,7 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create } from './creep.js';
 
@@ -509,6 +511,93 @@ describe('Movement', () => {
 				assert.strictEqual(fullSpeed.fatigue, 8);
 				assert.strictEqual(halfSpeed.fatigue, 0);
 				assert.strictEqual(halfSpeed2.fatigue, 0);
+			});
+		}));
+	});
+});
+
+describe('Event log events', () => {
+	describe('EVENT_OBJECT_DESTROYED on creep death', () => {
+		const ageOut = simulate({
+			W5N5: room => {
+				const creep = create(new RoomPosition(25, 25, 'W5N5'), [ C.MOVE ], 'mortal', '100');
+				creep['#ageTime'] = 2;
+				room['#insertObject'](creep);
+			},
+		});
+
+		test('ageTime expiry emits EVENT_OBJECT_DESTROYED with type creep', () => ageOut(async ({ tick, peekRoom }) => {
+			await tick();
+			await peekRoom('W5N5', room => {
+				const log = room.getEventLog();
+				const destroyed = log.find(event => event.event === C.EVENT_OBJECT_DESTROYED);
+				assert.ok(destroyed, 'expected a death event on the tick the creep aged out');
+				assert.strictEqual(destroyed.data.type, 'creep');
+			});
+		}));
+	});
+
+	describe('EVENT_TRANSFER on creep-to-creep transfer', () => {
+		const sim = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				const giver = create(new RoomPosition(25, 25, 'W1N1'), [ C.CARRY ], 'giver', '100');
+				giver.store['#add'](C.RESOURCE_ENERGY, 10);
+				room['#insertObject'](giver);
+				const receiver = create(new RoomPosition(26, 25, 'W1N1'), [ C.CARRY ], 'receiver', '100');
+				room['#insertObject'](receiver);
+			},
+		});
+
+		test('creep transfer emits EVENT_TRANSFER with source and target ids', () => sim(async ({ player, tick }) => {
+			await player('100', Game => {
+				assert.strictEqual(
+					Game.creeps.giver.transfer(Game.creeps.receiver, C.RESOURCE_ENERGY, 5),
+					C.OK,
+				);
+			});
+			await tick();
+			await player('100', Game => {
+				const log = Game.rooms.W1N1.getEventLog();
+				const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
+				assert.ok(transfer, 'expected EVENT_TRANSFER');
+				assert.strictEqual(transfer.objectId, Game.creeps.giver.id);
+				assert.strictEqual(transfer.data.targetId, Game.creeps.receiver.id);
+				assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
+				assert.strictEqual(transfer.data.amount, 5);
+			});
+		}));
+	});
+
+	describe('EVENT_TRANSFER on withdraw', () => {
+		const sim = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				const container = createContainer(new RoomPosition(25, 25, 'W1N1'));
+				container.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](container);
+				room['#insertObject'](create(new RoomPosition(26, 25, 'W1N1'), [ C.CARRY ], 'taker', '100'));
+			},
+		});
+
+		// Vanilla flips the roles on withdraw: source structure is `objectId`, creep is `targetId`.
+		test('withdraw flips objectId/targetId vs transfer', () => sim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+				assert.strictEqual(Game.creeps.taker.withdraw(container, C.RESOURCE_ENERGY, 7), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+				const log = Game.rooms.W1N1.getEventLog();
+				const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
+				assert.ok(transfer, 'expected EVENT_TRANSFER');
+				assert.strictEqual(transfer.objectId, container.id);
+				assert.strictEqual(transfer.data.targetId, Game.creeps.taker.id);
+				assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
+				assert.strictEqual(transfer.data.amount, 7);
 			});
 		}));
 	});

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -532,6 +532,7 @@ describe('Event log events', () => {
 				const log = room.getEventLog();
 				const destroyed = log.find(event => event.event === C.EVENT_OBJECT_DESTROYED);
 				assert.ok(destroyed, 'expected a death event on the tick the creep aged out');
+				assert.ok(destroyed.data, 'expected nested data payload');
 				assert.strictEqual(destroyed.data.type, 'creep');
 			});
 		}));
@@ -563,6 +564,7 @@ describe('Event log events', () => {
 				const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
 				assert.ok(transfer, 'expected EVENT_TRANSFER');
 				assert.strictEqual(transfer.objectId, Game.creeps.giver.id);
+				assert.ok(transfer.data, 'expected nested data payload');
 				assert.strictEqual(transfer.data.targetId, Game.creeps.receiver.id);
 				assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
 				assert.strictEqual(transfer.data.amount, 5);
@@ -595,6 +597,7 @@ describe('Event log events', () => {
 				const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
 				assert.ok(transfer, 'expected EVENT_TRANSFER');
 				assert.strictEqual(transfer.objectId, container.id);
+				assert.ok(transfer.data, 'expected nested data payload');
 				assert.strictEqual(transfer.data.targetId, Game.creeps.taker.id);
 				assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
 				assert.strictEqual(transfer.data.amount, 7);

--- a/packages/xxscreeps/mods/creep/tombstone.ts
+++ b/packages/xxscreeps/mods/creep/tombstone.ts
@@ -3,6 +3,7 @@ import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomObject, create as createObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { OpenStore, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
@@ -116,6 +117,11 @@ export function buryCreep(creep: Creep, rate = C.CREEP_CORPSE_RATE) {
 		user: creep['#user'],
 	};
 	tombstone['#decayTime'] = Game.time + creep.body.length * C.TOMBSTONE_DECAY_PER_PART;
+	appendEventLog(creep.room, {
+		event: C.EVENT_OBJECT_DESTROYED,
+		objectId: creep.id,
+		type: 'creep',
+	});
 	creep.room['#insertObject'](tombstone);
 	creep.room['#removeObject'](creep);
 }

--- a/packages/xxscreeps/mods/logistics/index.ts
+++ b/packages/xxscreeps/mods/logistics/index.ts
@@ -5,5 +5,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/logistics/processor.ts
+++ b/packages/xxscreeps/mods/logistics/processor.ts
@@ -2,6 +2,7 @@ import { registerIntentProcessor } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { StructureLink, checkTransferEnergy } from './link.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
@@ -16,6 +17,13 @@ const intents = [
 			target.store['#add'](C.RESOURCE_ENERGY, Math.floor(amount * (1 - C.LINK_LOSS_RATIO)));
 			link['#cooldownTime'] = Game.time + C.LINK_COOLDOWN * link.pos.getRangeTo(target) - 1;
 			saveAction(link, 'transferEnergy', target.pos);
+			appendEventLog(link.room, {
+				event: C.EVENT_TRANSFER,
+				objectId: link.id,
+				targetId: target.id,
+				resourceType: C.RESOURCE_ENERGY,
+				amount,
+			});
 			context.didUpdate();
 		}
 	}),

--- a/packages/xxscreeps/mods/logistics/test.ts
+++ b/packages/xxscreeps/mods/logistics/test.ts
@@ -29,6 +29,7 @@ describe('Link', () => {
 			const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
 			assert.ok(transfer, 'expected EVENT_TRANSFER from link transfer');
 			assert.strictEqual(transfer.objectId, sender.id);
+			assert.ok(transfer.data, 'expected nested data payload');
 			assert.strictEqual(transfer.data.targetId, receiver.id);
 			assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
 			assert.strictEqual(transfer.data.amount, 400);

--- a/packages/xxscreeps/mods/logistics/test.ts
+++ b/packages/xxscreeps/mods/logistics/test.ts
@@ -1,0 +1,38 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { create as createLink } from './link.js';
+
+describe('Link', () => {
+	const sim = simulate({
+		W1N1: room => {
+			room['#level'] = 5;
+			room['#user'] = room.controller!['#user'] = '100';
+			const sender = createLink(new RoomPosition(25, 25, 'W1N1'), '100');
+			sender.store['#add'](C.RESOURCE_ENERGY, 800);
+			room['#insertObject'](sender);
+			room['#insertObject'](createLink(new RoomPosition(27, 25, 'W1N1'), '100'));
+		},
+	});
+
+	// Vanilla emits the pre-loss amount; LINK_LOSS_RATIO is applied to receiver only.
+	test('transferEnergy emits EVENT_TRANSFER with the pre-loss amount', () => sim(async ({ player, tick }) => {
+		await player('100', Game => {
+			const [ sender, receiver ] = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LINK);
+			assert.strictEqual(sender.transferEnergy(receiver, 400), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const [ sender, receiver ] = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LINK);
+			const log = Game.rooms.W1N1.getEventLog();
+			const transfer = log.find(event => event.event === C.EVENT_TRANSFER);
+			assert.ok(transfer, 'expected EVENT_TRANSFER from link transfer');
+			assert.strictEqual(transfer.objectId, sender.id);
+			assert.strictEqual(transfer.data.targetId, receiver.id);
+			assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
+			assert.strictEqual(transfer.data.amount, 400);
+			assert.strictEqual(receiver.store[C.RESOURCE_ENERGY], Math.floor(400 * (1 - C.LINK_LOSS_RATIO)));
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/resource/processor/container.ts
+++ b/packages/xxscreeps/mods/resource/processor/container.ts
@@ -1,6 +1,7 @@
 import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { StructureContainer } from '../container.js';
 import { drop } from './resource.js';
 
@@ -12,6 +13,11 @@ registerObjectTickProcessor(StructureContainer, (container, context) => {
 			for (const [ resourceType, amount ] of container.store['#entries']()) {
 				drop(container.pos, resourceType, amount);
 			}
+			appendEventLog(container.room, {
+				event: C.EVENT_OBJECT_DESTROYED,
+				objectId: container.id,
+				type: container.structureType,
+			});
 			container.room['#removeObject'](container);
 		}
 		container['#nextDecayTime'] = Game.time + (ownedController

--- a/packages/xxscreeps/mods/resource/test.ts
+++ b/packages/xxscreeps/mods/resource/test.ts
@@ -1,8 +1,11 @@
 import type { Store } from './store.js';
 import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
 import { LabStore } from 'xxscreeps/mods/chemistry/store.js';
-import { assert, describe, reconstructor, test } from 'xxscreeps/test/index.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { assert, describe, reconstructor, simulate, test } from 'xxscreeps/test/index.js';
 import { renderStore } from './backend.js';
+import { create as createContainer } from './container.js';
 import { OpenStore, RestrictedStore, SingleStore, openStoreFormat, restrictedStoreFormat, singleStoreFormat } from './store.js';
 
 const keys = (object: {}) => [ ...function*() {
@@ -139,4 +142,48 @@ describe('Store', () => {
 			assert.deepStrictEqual({ ...rendered.storeCapacityResource }, { [C.RESOURCE_ENERGY]: C.LAB_ENERGY_CAPACITY, [C.RESOURCE_HYDROXIDE]: C.LAB_MINERAL_CAPACITY });
 		});
 	});
+});
+
+describe('Container decay', () => {
+	const decaySim = simulate({
+		W1N1: room => {
+			room['#user'] = room.controller!['#user'] = '100';
+			// Owned creep keeps the room in the active processing queue so the
+			// container's tick processor is invoked.
+			room['#insertObject'](createCreep(
+				new RoomPosition(0, 0, 'W1N1'),
+				[ C.MOVE ], 'witness', '100',
+			));
+			const container = createContainer(new RoomPosition(25, 25, 'W1N1'));
+			container.hits = 1;
+			container.store['#add'](C.RESOURCE_ENERGY, 100);
+			container['#nextDecayTime'] = 1;
+			room['#insertObject'](container);
+		},
+	});
+
+	test('decayed container spills its store to the ground', () => decaySim(async ({ peekRoom, tick }) => {
+		await tick();
+		await peekRoom('W1N1', room => {
+			const containers = room.find(C.FIND_STRUCTURES)
+				.filter(structure => structure.structureType === C.STRUCTURE_CONTAINER);
+			assert.strictEqual(containers.length, 0, 'decayed container should be removed');
+			const dropped = room.find(C.FIND_DROPPED_RESOURCES)
+				.filter(resource => resource.pos.x === 25 && resource.pos.y === 25);
+			const energy = dropped.find(resource => resource.resourceType === C.RESOURCE_ENERGY);
+			assert.ok(energy, 'expected dropped energy at the decayed container position');
+			assert.strictEqual(energy.amount, 100);
+		});
+	}));
+
+	test('decayed container emits EVENT_OBJECT_DESTROYED with structureType', () => decaySim(async ({ peekRoom, tick }) => {
+		await tick();
+		await peekRoom('W1N1', room => {
+			const log = room.getEventLog();
+			const destroyed = log.find(entry => entry.event === C.EVENT_OBJECT_DESTROYED);
+			assert.ok(destroyed, 'expected EVENT_OBJECT_DESTROYED on container decay');
+			assert.ok(destroyed.data, 'expected nested data payload');
+			assert.strictEqual(destroyed.data.type, C.STRUCTURE_CONTAINER);
+		});
+	}));
 });

--- a/packages/xxscreeps/mods/structure/game.ts
+++ b/packages/xxscreeps/mods/structure/game.ts
@@ -1,8 +1,10 @@
 import type { AnyStructure } from './structure.js';
+import * as Id from 'xxscreeps/engine/schema/id.js';
 import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { registerGlobal } from 'xxscreeps/game/index.js';
 import { registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
+import { constant, struct, variant } from 'xxscreeps/schema/index.js';
 import { Ruin, format as ruinFormat } from './ruin.js';
 import { OwnedStructure, Structure } from './structure.js';
 
@@ -42,7 +44,15 @@ declare module 'xxscreeps/game/room/index.js' {
 
 // Register schema type for `Ruin`
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const schema = registerVariant('Room.objects', ruinFormat);
+const ruinSchema = registerVariant('Room.objects', ruinFormat);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const destroyedEventSchema = registerVariant('Room.eventLog', struct({
+	...variant(C.EVENT_OBJECT_DESTROYED),
+	event: constant(C.EVENT_OBJECT_DESTROYED),
+	objectId: Id.format,
+	type: 'string',
+}));
 declare module 'xxscreeps/game/room/index.js' {
-	interface Schema { structure: [ typeof schema ] }
+	interface Schema { structure: [ typeof ruinSchema, typeof destroyedEventSchema ] }
 }

--- a/packages/xxscreeps/mods/structure/structure.ts
+++ b/packages/xxscreeps/mods/structure/structure.ts
@@ -9,6 +9,7 @@ import { Game, hooks, intents, me, userInfo } from 'xxscreeps/game/index.js';
 import { RoomObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
 import { registerObstacleChecker } from 'xxscreeps/game/pathfinder/index.js';
 import { isBorder, isNearBorder, iterateNeighbors } from 'xxscreeps/game/position.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { compose, declare, optional, struct, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { createRuin } from './ruin.js';
@@ -100,6 +101,11 @@ export class Structure extends withOverlay(RoomObject, shape) {
 	override '#destroy'() {
 		if (super['#destroy']()) {
 			this.room['#insertObject'](createRuin(this));
+			appendEventLog(this.room, {
+				event: C.EVENT_OBJECT_DESTROYED,
+				objectId: this.id,
+				type: this.structureType,
+			});
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
Closes #107.

Wires up the remaining `Room.getEventLog()` events and reshapes the
player-facing payload to vanilla's `{event, objectId, data?}` shape.

## Events

Newly emitted: `EVENT_BUILD`, `EVENT_REPAIR`, `EVENT_TRANSFER`,
`EVENT_EXIT`, `EVENT_ATTACK_CONTROLLER`, `EVENT_RESERVE_CONTROLLER`,
`EVENT_UPGRADE_CONTROLLER`, `EVENT_OBJECT_DESTROYED` (creep death via
`buryCreep`, structure destruction via `Structure#destroy`, container
decay), and `EVENT_ATTACK` for the previously-unwired `DISMANTLE` and
`HIT_BACK` `attackType` variants. `EVENT_HARVEST`, `EVENT_HEAL`, and
`EVENT_POWER` were already emitted on `main`.

## Single emission at the action site

Each event is emitted exactly once at the call site that owns the
information for it. `Creep.prototype['#applyDamage']` no longer emits
`EVENT_ATTACK` — damage application and event recording are decoupled,
and the previous bug where `RANGED_ATTACK_POWER` (the damage-power
constant, =10) was being passed as the `type` discriminator instead of
`EVENT_ATTACK_TYPE_RANGED` is fixed at the same time. The hit-back
override appends its own entry adjacent to the counter-attack.

## Wire format

Events are stored flat (per-entry density on a per-tick room blob);
`getEventLog` translates at the read boundary via a distributing mapped
type so per-variant `entry.data.foo` narrows on the player side. Entries
with no extras omit `data` rather than emitting `data: {}`, matching
vanilla's JSON exactly. `EVENT_BUILD` carries `structureType`, `x`, `y`,
and `incomplete`.

## Destruction detection

`EVENT_OBJECT_DESTROYED` lives at the lifecycle hook for each death
path:

- **Structures destroyed by damage** (attack, rangedAttack,
  rangedMassAttack, dismantle, rampart absorption death) — emitted in
  `Structure#destroy`. Every damage path that brings hits to zero
  funnels through `super.#applyDamage` → `this.#destroy`, and
  `super['#destroy']()`'s return value is the natural one-shot guard,
  so multi-attacker single-tick destruction emits exactly once.
- **Creep deaths** (combat, suicide, age-out) — emitted in `buryCreep`
  in `mods/creep/tombstone.ts`.
- **Container decay** — emitted in
  `mods/resource/processor/container.ts` because decay deliberately
  bypasses `#destroy` (no Ruin from natural decay; contents spill to
  the ground per vanilla `_create-energy.js`).

Per vanilla `_damage.js`, the order on the wire for a kill-shot is
`[DESTROYED, HIT_BACK, ATTACK]` — destroyed event first, then any
counter-attack, then the originating attack. Intent processors emit
`EVENT_ATTACK` after `target['#applyDamage']` so the destroyed event
(emitted from inside the damage chain) lands first.

Verified against screeps-ok.
