### PR TITLE
Plumb active-rooms set into GameMap.getRoomStatus

### DIFF
--- a/.changeset/getroomstatus-active-rooms.md
+++ b/.changeset/getroomstatus-active-rooms.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Return `'out of borders'` from `GameMap.getRoomStatus()` for closed rooms

--- a/packages/xxscreeps/engine/db/shard.ts
+++ b/packages/xxscreeps/engine/db/shard.ts
@@ -51,7 +51,7 @@ export class Shard {
 		// Connect to shard, load const data
 		const shard = config.shards.find(shard => shard.name === name);
 		if (!shard) {
-			throw new Error(`Unknown shard: ${shard}`);
+			throw new Error(`Unknown shard: ${name}`);
 		}
 		return this.connectWith(db, shard);
 	}
@@ -86,10 +86,15 @@ export class Shard {
 	}
 
 	/**
-	 * Load and parse shard terrain data
+	 * Load and parse shard terrain data together with the active-rooms set so
+	 * `World.map.getRoomStatus()` can distinguish closed rooms from normal ones.
 	 */
 	async loadWorld() {
-		return new World(this.name, await this.data.req('terrain', { blob: true }));
+		const [ terrainBlob, rooms ] = await Promise.all([
+			this.data.req('terrain', { blob: true }),
+			this.data.smembers('rooms'),
+		]);
+		return new World(this.name, terrainBlob, new Set(rooms));
 	}
 
 	/**

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -41,7 +41,7 @@ type FindRoute = {
  */
 export class GameMap {
 	readonly #terrain: TerrainByRoom;
-	readonly #accessibleRooms: ReadonlySet<string> | undefined;
+	readonly #accessibleRooms;
 	readonly #left;
 	readonly #top;
 	readonly #height;
@@ -267,13 +267,11 @@ export class World {
 	name;
 	terrain: TerrainByRoom;
 	terrainBlob;
-	accessibleRooms: ReadonlySet<string> | undefined;
 
 	constructor(name: string, terrainBlob: Readonly<Uint8Array>, accessibleRooms?: ReadonlySet<string>) {
 		this.name = name;
 		this.terrainBlob = terrainBlob;
 		this.terrain = reader(terrainBlob);
-		this.accessibleRooms = accessibleRooms;
 		this.map = new GameMap(this.terrain, accessibleRooms);
 	}
 

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -41,13 +41,15 @@ type FindRoute = {
  */
 export class GameMap {
 	readonly #terrain: TerrainByRoom;
+	readonly #accessibleRooms: ReadonlySet<string> | undefined;
 	readonly #left;
 	readonly #top;
 	readonly #height;
 	readonly #width;
 
-	constructor(terrain: TerrainByRoom) {
+	constructor(terrain: TerrainByRoom, accessibleRooms?: ReadonlySet<string>) {
 		this.#terrain = terrain;
+		this.#accessibleRooms = accessibleRooms;
 		let maxX = -Infinity;
 		let minX = Infinity;
 		let maxY = -Infinity;
@@ -207,9 +209,14 @@ export class GameMap {
 	 * from [this article](https://docs.screeps.com/start-areas.html).
 	 */
 	getRoomStatus(roomName: string) {
-		if (this.#terrain.has(roomName)) {
-			return { status: 'normal', timestamp: null };
+		if (!this.#terrain.has(roomName)) {
+			return;
 		}
+		// Callers without the active-rooms set (sandbox init, processor worker) see every terrain-backed room as `normal`.
+		if (this.#accessibleRooms !== undefined && !this.#accessibleRooms.has(roomName)) {
+			return { status: 'out of borders', timestamp: null };
+		}
+		return { status: 'normal', timestamp: null };
 	}
 
 	/**
@@ -260,12 +267,14 @@ export class World {
 	name;
 	terrain: TerrainByRoom;
 	terrainBlob;
+	accessibleRooms: ReadonlySet<string> | undefined;
 
-	constructor(name: string, terrainBlob: Readonly<Uint8Array>) {
+	constructor(name: string, terrainBlob: Readonly<Uint8Array>, accessibleRooms?: ReadonlySet<string>) {
 		this.name = name;
 		this.terrainBlob = terrainBlob;
 		this.terrain = reader(terrainBlob);
-		this.map = new GameMap(this.terrain);
+		this.accessibleRooms = accessibleRooms;
+		this.map = new GameMap(this.terrain, accessibleRooms);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`GameMap.getRoomStatus()` returns `'normal'` for any terrain-backed room,
ignoring whether the room is in the active set (`shard.data.smembers('rooms')`).
Closed/removed rooms appear `'normal'` to every consumer of `Shard.loadWorld()`
— `/api/game/room-status`, `/map-stats`, the map socket filter, and any
downstream caller.

## Change

- `Shard.loadWorld()` reads `'rooms'` in parallel with the terrain blob
  and passes the set to `new World(...)`.
- `World` and `GameMap` accept an optional `accessibleRooms: ReadonlySet<string>`.
  When supplied, `GameMap.getRoomStatus()` returns `'out of borders'` for
  terrain-backed rooms outside the set; otherwise `'normal'` (unchanged).
- The set is optional because the user-code sandbox (`driver/runtime/index.ts`)
  and the room-tick worker (`engine/processor/worker.ts`) build `World` from
  out-of-process terrain blobs with no `shard.data` handle. Plumbing the
  set into those payloads — and invalidating sandboxes when it changes —
  is intentionally out of scope.

## Standalone bug fix

There's no way to *produce* a closed room from xxscreeps itself today, so
the bug isn't observable in normal operation, but the `'rooms'` set is
already written by `scripts/scrape-world.ts` (world import) and the test
fixture (`packages/xxscreeps/test/import.ts`). Both of those writes are
silently ignored by `getRoomStatus` until this fix lands.

## Bonus

Two-character drive-by in `Shard.connect()`: the unknown-shard error
interpolated `${shard}` (the `undefined` result of the just-failed
`find()`) instead of `${name}`. Happy to split into a separate PR if
you'd rather keep this one strictly to the active-rooms work.

Verified against ok-screeps.