### PR TITLE
Fix Creep.transfer redirect to upgradeController; reject pull on spawning

### DIFF
--- a/.changeset/creep-controller-transfer-and-pull-spawning.md
+++ b/.changeset/creep-controller-transfer-and-pull-spawning.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Redirect `Creep.transfer` to `upgradeController` for energy targeting a controller, and reject `Creep.pull` against a spawning creep.

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -23,6 +23,7 @@ import { Resource, optionalResourceEnumFormat } from 'xxscreeps/mods/resource/re
 import { OpenStore, calculateChecked, checkHasCapacity, checkHasResource, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { Ruin } from 'xxscreeps/mods/structure/ruin.js';
 import { Structure } from 'xxscreeps/mods/structure/structure.js';
+import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 
@@ -386,6 +387,9 @@ export class Creep extends withOverlay(RoomObject, shape) {
 	 * amount is used.
 	 */
 	transfer(this: Creep, target: RoomObject & WithStore, resourceType: ResourceType, amount?: number) {
+		if (target instanceof StructureController && resourceType === C.RESOURCE_ENERGY) {
+			return this.upgradeController(target);
+		}
 		const intentAmount = calculateChecked(this, target, () =>
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			amount || Math.min(this.store[resourceType], target.store.getFreeCapacity(resourceType)!));
@@ -509,7 +513,8 @@ export function checkPull(creep: Creep, target: Creep | null | undefined) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
 		() => checkTarget(target, Creep),
-		() => checkRange(creep, target!, 1));
+		() => checkRange(creep, target!, 1),
+		() => target!.spawning ? C.ERR_INVALID_TARGET : C.OK);
 }
 
 export function checkPickup(creep: Creep, target: Resource) {


### PR DESCRIPTION
Two small parity fixes against canonical Creep API behavior, exposed by ok-screeps tests TRANSFER-011 and MOVE-PULL-007:spawning.

`transfer(controller, RESOURCE_ENERGY)` previously fell through to the generic Store path and rejected with `ERR_INVALID_TARGET`, since `StructureController` has no Store. Vanilla short-circuits at the top of `Creep.prototype.transfer` and reroutes to `upgradeController` (`@screeps/engine/src/game/creeps.js`). Mirroring that here adds a one-branch `instanceof` check before the existing Store logic.

I considered placing the wrapper in `mods/controller/creep.ts` to avoid the new import edge, but the controller mod already depends on `mods/creep/creep.js` for `Creep`, and there's no transitive cycle through `mods/controller/controller.ts` (which only pulls from `mods/structure` and `mods/schema`). Importing `StructureController` directly into `mods/creep/creep.ts` is the cleanest fit.

`pull()` previously accepted spawning-creep targets. Vanilla rejects them with `ERR_INVALID_TARGET` before any range check fires. Adding the guard at the end of `checkPull` keeps existing target/range error precedence and only rejects when everything else is otherwise OK, matching vanilla's check ordering.

Verified against ok-screeps.