### PR TITLE
Add Creep.withdraw enemy-rampart guard; fix moveTo noPathFinding return code

### DIFF
--- a/.changeset/brown-buses-argue.md
+++ b/.changeset/brown-buses-argue.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add Creep.withdraw enemy-rampart guard; fix moveTo noPathFinding return code

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -22,7 +22,7 @@ import * as Memory from 'xxscreeps/mods/memory/memory.js';
 import { Resource, optionalResourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { OpenStore, calculateChecked, checkHasCapacity, checkHasResource, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { Ruin } from 'xxscreeps/mods/structure/ruin.js';
-import { OwnedStructure, Structure, lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
+import { OwnedStructure, Structure } from 'xxscreeps/mods/structure/structure.js';
 import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
@@ -543,17 +543,19 @@ export function checkWithdraw(creep: Creep, target: Structure & WithStore, resou
 	return chainIntentChecks(
 		() => checkCommon(creep),
 		() => checkTarget(target, Ruin, Structure, Tombstone),
-		() => checkEnemyRampart(target),
+		() => checkInteractionBlocked(creep, target),
 		() => checkRange(creep, target, 1),
 		() => checkHasResource(target, resourceType, amount),
 		() => checkHasCapacity(creep, resourceType, amount),
 		() => checkSafeMode(creep.room, C.ERR_NOT_OWNER));
 }
 
-function checkEnemyRampart(target: Structure & WithStore) {
+function checkInteractionBlocked(creep: Creep, target: Structure & WithStore) {
 	if (!(target instanceof OwnedStructure) || target.my) return C.OK;
-	const rampart = lookForStructureAt(target.room, target.pos, C.STRUCTURE_RAMPART);
-	return rampart && !rampart.my && !rampart.isPublic ? C.ERR_NOT_OWNER : C.OK;
+	const user = creep['#user'];
+	const blocked = target.room.lookForAt(C.LOOK_STRUCTURES, target.pos)
+		.some(structure => structure['#doesPreventInteraction'](user));
+	return blocked ? C.ERR_NOT_OWNER : C.OK;
 }
 
 export function calculateCost(creep: Creep) {

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -22,7 +22,7 @@ import * as Memory from 'xxscreeps/mods/memory/memory.js';
 import { Resource, optionalResourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { OpenStore, calculateChecked, checkHasCapacity, checkHasResource, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { Ruin } from 'xxscreeps/mods/structure/ruin.js';
-import { Structure } from 'xxscreeps/mods/structure/structure.js';
+import { OwnedStructure, Structure, lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
@@ -315,7 +315,7 @@ export class Creep extends withOverlay(RoomObject, shape) {
 		// Move to the target
 		const path = searchOrFetchPath();
 		if (!path) {
-			return C.ERR_NO_PATH;
+			return C.ERR_NOT_FOUND;
 		}
 		visualize(path);
 		if (path.length === 0) {
@@ -543,10 +543,17 @@ export function checkWithdraw(creep: Creep, target: Structure & WithStore, resou
 	return chainIntentChecks(
 		() => checkCommon(creep),
 		() => checkTarget(target, Ruin, Structure, Tombstone),
+		() => checkEnemyRampart(target),
 		() => checkRange(creep, target, 1),
 		() => checkHasResource(target, resourceType, amount),
 		() => checkHasCapacity(creep, resourceType, amount),
 		() => checkSafeMode(creep.room, C.ERR_NOT_OWNER));
+}
+
+function checkEnemyRampart(target: Structure & WithStore) {
+	if (!(target instanceof OwnedStructure) || target.my) return C.OK;
+	const rampart = lookForStructureAt(target.room, target.pos, C.STRUCTURE_RAMPART);
+	return rampart && !rampart.my && !rampart.isPublic ? C.ERR_NOT_OWNER : C.OK;
 }
 
 export function calculateCost(creep: Creep) {

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -22,7 +22,7 @@ import * as Memory from 'xxscreeps/mods/memory/memory.js';
 import { Resource, optionalResourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { OpenStore, calculateChecked, checkHasCapacity, checkHasResource, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { Ruin } from 'xxscreeps/mods/structure/ruin.js';
-import { OwnedStructure, Structure } from 'xxscreeps/mods/structure/structure.js';
+import { Structure } from 'xxscreeps/mods/structure/structure.js';
 import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
@@ -551,7 +551,6 @@ export function checkWithdraw(creep: Creep, target: Structure & WithStore, resou
 }
 
 function checkInteractionBlocked(creep: Creep, target: Structure & WithStore) {
-	if (!(target instanceof OwnedStructure) || target.my) return C.OK;
 	const user = creep['#user'];
 	const blocked = target.room.lookForAt(C.LOOK_STRUCTURES, target.pos)
 		.some(structure => structure['#doesPreventInteraction'](user));

--- a/packages/xxscreeps/mods/defense/rampart.ts
+++ b/packages/xxscreeps/mods/defense/rampart.ts
@@ -51,6 +51,10 @@ export class StructureRampart extends withOverlay(OwnedStructure, shape) {
 	override '#checkObstacle'(user: string) {
 		return !this.isPublic && user !== this['#user'];
 	}
+
+	override '#doesPreventInteraction'(user: string) {
+		return !this.isPublic && user !== this['#user'];
+	}
 }
 
 export function create(pos: RoomPosition, owner: string) {

--- a/packages/xxscreeps/mods/structure/structure.ts
+++ b/packages/xxscreeps/mods/structure/structure.ts
@@ -97,6 +97,10 @@ export class Structure extends withOverlay(RoomObject, shape) {
 		return true;
 	}
 
+	'#doesPreventInteraction'(_user: string) {
+		return false;
+	}
+
 	override '#destroy'() {
 		if (super['#destroy']()) {
 			this.room['#insertObject'](createRuin(this));


### PR DESCRIPTION
Two unrelated `Creep` API fixes batched into one PR (both small), exposed by ok-screeps tests WITHDRAW-005 and MOVE-BASIC-019.

`checkWithdraw` had no rampart-ownership test on the target tile, so a creep could withdraw from a hostile structure sitting under a non-public enemy rampart. Vanilla rejects with `ERR_NOT_OWNER` at `@screeps/engine/src/game/creeps.js:525-527`. Added a `checkEnemyRampart` step in the chain after `checkTarget` and before `checkRange`, gated on `target instanceof OwnedStructure && !target.my` so neutral structures, tombstones, and ruins are unaffected. Public ramparts (`rampart.isPublic === true`) skip the guard, matching vanilla's `!i.isPublic` predicate. Used `lookForStructureAt(..., STRUCTURE_RAMPART)` rather than scanning `lookForAt(LOOK_STRUCTURES, ...)` since the rampart construction check already enforces at most one rampart per tile (`mods/defense/rampart.ts:71-76`).

`Creep.moveTo({ noPathFinding: true })` returned `ERR_NO_PATH` when no cached path existed; vanilla returns `ERR_NOT_FOUND` for that specific case (`@screeps/engine/src/game/creeps.js:279-281`), distinct from "no path exists between these points". `searchOrFetchPath` only returns `null` from the `noPathFinding && !cachedPath` branch (cache hits return arrays, `findPathTo` returns arrays), so the `null` sentinel is uniquely the noPathFinding-no-cache case and updating the caller's error code is sufficient. The empty-path fallback below still returns `ERR_NO_PATH` for genuinely unreachable targets.

Verified against ok-screeps.