### PR TITLE
fix: Reclaim body energy on Spawn.recycleCreep

### DIFF
--- a/.changeset/yummy-views-try.md
+++ b/.changeset/yummy-views-try.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reclaim body energy on Spawn.recycleCreep

--- a/packages/xxscreeps/mods/spawn/processor.ts
+++ b/packages/xxscreeps/mods/spawn/processor.ts
@@ -123,8 +123,7 @@ const intents = [
 	registerIntentProcessor(StructureSpawn, 'recycleCreep', {}, (spawn, context, id: string) => {
 		const creep = Game.getObjectById<Creep>(id)!;
 		if (checkRecycleCreep(spawn, creep) === C.OK) {
-			// TODO: This stuff
-			creep.hits = 0;
+			buryCreep(creep, 1);
 			context.didUpdate();
 		}
 	}),


### PR DESCRIPTION
Vanilla's recycle-creep.js calls _die(target, 1.0, false, scope). The xxscreeps processor was a TODO that just set creep.hits = 0, which fell through to the natural-death path at CREEP_CORPSE_RATE (0.2) — only a fifth of the canonical energy.

buryCreep(creep, rate) already implements vanilla _die.js (body energy, boost minerals, same-tile container diversion). Wire it up at rate=1.

Verified against screeps-ok.