### PR TITLE
Reset module-level Memory state per simulation in test harness

### DIFF
--- a/.changeset/test-simulate-memory-isolation.md
+++ b/.changeset/test-simulate-memory-isolation.md
@@ -1,0 +1,9 @@
+---
+"xxscreeps": patch
+---
+
+Reset module-level Memory state per simulation in test harness
+
+`simulate.ts` now clears `mods/memory/memory.ts` module state (`json` /
+`string` caches and `RawMemory._parsed`) at the start of each test body,
+so cached Memory contents from one test don't leak into the next.

--- a/.changeset/test-simulate-memory-isolation.md
+++ b/.changeset/test-simulate-memory-isolation.md
@@ -2,8 +2,4 @@
 "xxscreeps": patch
 ---
 
-Reset module-level Memory state per simulation in test harness
-
-`simulate.ts` now clears `mods/memory/memory.ts` module state (`json` /
-`string` caches and `RawMemory._parsed`) at the start of each test body,
-so cached Memory contents from one test don't leak into the next.
+Reset test Memory state between simulations.

--- a/packages/xxscreeps/mods/notifications/driver.ts
+++ b/packages/xxscreeps/mods/notifications/driver.ts
@@ -1,5 +1,5 @@
-import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { QueuedNotification } from './notifications.js';
+import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
 import { upsertNotification } from './model.js';
 
@@ -12,7 +12,7 @@ export async function dispatchQueuedNotifications(
 	shard: Shard, userId: string, queued: Iterable<QueuedNotification>,
 ) {
 	for (const entry of queued) {
-		const message = `${entry.message}`.slice(0, 500);
+		const message = String(entry.message).slice(0, 500);
 		const groupInterval = typeof entry.groupInterval === 'number' && Number.isFinite(entry.groupInterval)
 			? Math.min(1440, Math.max(0, entry.groupInterval)) : 0;
 		await upsertNotification(shard, userId, entry.type, message, groupInterval);

--- a/packages/xxscreeps/mods/notifications/model.ts
+++ b/packages/xxscreeps/mods/notifications/model.ts
@@ -1,36 +1,13 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { createHash } from 'node:crypto';
-import { Fn } from 'xxscreeps/functional/fn.js';
 
 export type NotificationType = 'msg' | 'error';
-
-export type NotificationRow = {
-	user: string;
-	message: string;
-	date: number;
-	count: number;
-	type: NotificationType;
-};
 
 const userIndexKey = (userId: string) => `user/${userId}/notifications`;
 const rowKey = (userId: string, rowId: string) => `user/${userId}/notifications/${rowId}`;
 
 function rowIdFor(type: NotificationType, timeGroup: number, message: string) {
 	return createHash('sha1').update(`${type}${timeGroup}${message}`).digest('hex');
-}
-
-export function getNotifications(shard: Shard, userId: string): Promise<NotificationRow[]> {
-	return shard.data.smembers(userIndexKey(userId)).then(ids =>
-		Fn.mapAwait(ids, async id => {
-			const fields = await shard.data.hgetall(rowKey(userId, id));
-			return {
-				user: userId,
-				message: fields.message,
-				date: Number(fields.date),
-				count: Number(fields.count),
-				type: fields.type as NotificationType,
-			};
-		}));
 }
 
 /**

--- a/packages/xxscreeps/mods/notifications/test.ts
+++ b/packages/xxscreeps/mods/notifications/test.ts
@@ -1,7 +1,8 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { dispatchQueuedNotifications } from './driver.js';
-import { getNotifications } from './model.js';
 import { flush } from './notifications.js';
 
 const user = '100';
@@ -10,8 +11,32 @@ const empty = simulate({
 	W0N0: () => {},
 });
 
+interface NotificationRow {
+	user: string;
+	message: string;
+	date: number;
+	count: number;
+	type: 'msg' | 'error';
+}
+
+function getNotifications(shard: Shard, userId: string): Promise<NotificationRow[]> {
+	return shard.data.smembers(`user/${userId}/notifications`).then(ids =>
+		Fn.mapAwait(ids, async id => {
+			const fields = await shard.data.hgetall(`user/${userId}/notifications/${id}`);
+			const type = fields.type;
+			assert.ok(type === 'msg' || type === 'error');
+			return {
+				user: userId,
+				message: fields.message,
+				date: Number(fields.date),
+				count: Number(fields.count),
+				type,
+			};
+		}));
+}
+
 // Disposable clock override. Patches `Date.now` for the lifetime of the binding so callers can
-// `using _ = withFrozenTime(now)` and have it restored on scope exit. Tests in a single describe
+// `using frozen = withFrozenTime(now)` and have it restored on scope exit. Tests in a single describe
 // block run serially; concurrent uses would clobber each other's restore.
 function withFrozenTime(now: number): Disposable {
 	const original = Date.now;
@@ -80,7 +105,7 @@ describe('Game.notify', () => {
 
 	test('groupInterval=1 coalesces same-message calls in the bucket window', () => empty(async ({ player, shard }) => {
 		flush();
-		using _frozen = withFrozenTime(1_000_000);
+		using frozen = withFrozenTime(1_000_000);
 		await player(user, Game => {
 			Game.notify('hi', 1);
 			Game.notify('hi', 1);
@@ -108,7 +133,7 @@ describe('Game.notify', () => {
 
 	test('groupInterval clamp ([0, 1440]) reflected in bucket placement', () => empty(async ({ player, shard }) => {
 		flush();
-		using _frozen = withFrozenTime(1_000_000);
+		using frozen = withFrozenTime(1_000_000);
 		await player(user, Game => {
 			Game.notify('low', -5);
 			Game.notify('high', 5000);
@@ -126,7 +151,7 @@ describe('Game.notify', () => {
 		}
 	}));
 
-	test('message coercion via `${i.message}`', () => empty(async ({ player, shard }) => {
+	test('message coercion via template string', () => empty(async ({ player, shard }) => {
 		flush();
 		await player(user, Game => {
 			Game.notify(null as unknown as string);
@@ -141,7 +166,7 @@ describe('Game.notify', () => {
 
 	test('no-args Game.notify() stores "undefined" with current-date', () => empty(async ({ player, shard }) => {
 		flush();
-		using _frozen = withFrozenTime(1_234_567);
+		using frozen = withFrozenTime(1_234_567);
 		await player(user, Game => {
 			assert.strictEqual((Game.notify as unknown as () => number)(), C.OK);
 		});
@@ -156,7 +181,7 @@ describe('Game.notify', () => {
 
 	test('non-numeric groupInterval falls through to current-date', () => empty(async ({ player, shard }) => {
 		flush();
-		using _frozen = withFrozenTime(1_234_567);
+		using frozen = withFrozenTime(1_234_567);
 		await player(user, Game => {
 			Game.notify('strInterval', 'abc' as unknown as number);
 			Game.notify('nanInterval', NaN);

--- a/packages/xxscreeps/mods/notifications/test.ts
+++ b/packages/xxscreeps/mods/notifications/test.ts
@@ -23,11 +23,12 @@ function getNotifications(shard: Shard, userId: string): Promise<NotificationRow
 	return shard.data.smembers(`user/${userId}/notifications`).then(ids =>
 		Fn.mapAwait(ids, async id => {
 			const fields = await shard.data.hgetall(`user/${userId}/notifications/${id}`);
-			const type = fields.type;
+			const { type, message } = fields;
 			assert.ok(type === 'msg' || type === 'error');
+			assert.ok(typeof message === 'string');
 			return {
 				user: userId,
-				message: fields.message,
+				message,
 				date: Number(fields.date),
 				count: Number(fields.count),
 				type,

--- a/packages/xxscreeps/test/simulate.ts
+++ b/packages/xxscreeps/test/simulate.ts
@@ -78,121 +78,118 @@ export function simulate(rooms: Record<string, (room: Room) => void>) {
 		// match that boundary.
 		initializeMemory(null);
 		RawMemory._parsed = undefined;
-		const { db, shard, world } = await instantiateTestShard();
-		try {
-			// Initialize world
-			await Promise.all(Fn.map(Object.entries(rooms), async ([ roomName, callback ]) => {
-				const room = await shard.loadRoom(roomName, shard.time);
-				runOneShot(world, room, shard.time, '', () => callback(room));
-				room['#flushObjects'](null);
+		using testShard = await instantiateTestShard();
+		const { db, shard, world } = testShard;
+
+		// Initialize world
+		await Promise.all(Fn.map(Object.entries(rooms), async ([ roomName, callback ]) => {
+			const room = await shard.loadRoom(roomName, shard.time);
+			runOneShot(world, room, shard.time, '', () => callback(room));
+			room['#flushObjects'](null);
+			const previousUsers = flushUsers(room);
+			await Promise.all([
+				shard.saveRoom(room.name, shard.time + 1, room),
+				shard.saveRoom(room.name, shard.time, room),
+				updateUserRoomRelationships(shard, room, previousUsers),
+			]);
+		}));
+
+		// Run simulation
+		const intentsByRoom = new Map<string, { userId: string; intents: RoomIntentPayload }[]>();
+		const playersThisTick = new Set<string>();
+		let roomInstances = new Map<string, Room>();
+		const that: Simulation = {
+			db,
+			shard,
+			world,
+
+			async peekRoom(roomName, task) {
+				const room = await shard.loadRoom(roomName);
+				return runOneShot(world, room, shard.time, '', () => task(room, Game));
+			},
+
+			async poke(roomName, userId, task) {
+				const room = await shard.loadRoom(roomName);
+				const state = new GameState(world, shard.time, [ room ]);
+				const [ , result ] = runWithState(state, () => runForUser(userId ?? '', state, Game => task(Game, room)));
+				room['#flushObjects'](state);
 				const previousUsers = flushUsers(room);
 				await Promise.all([
-					shard.saveRoom(room.name, shard.time + 1, room),
 					shard.saveRoom(room.name, shard.time, room),
 					updateUserRoomRelationships(shard, room, previousUsers),
 				]);
-			}));
+				roomInstances.delete(roomName);
+				return result;
+			},
 
-			// Run simulation
-			const intentsByRoom = new Map<string, { userId: string; intents: RoomIntentPayload }[]>();
-			const playersThisTick = new Set<string>();
-			let roomInstances = new Map<string, Room>();
-			const that: Simulation = {
-				db,
-				shard,
-				world,
+			async player(userId, task) {
+				assert.ok(!playersThisTick.has(userId), `player '${userId}' already invoked this tick`);
+				playersThisTick.add(userId);
 
-				async peekRoom(roomName, task) {
-					const room = await shard.loadRoom(roomName);
-					return runOneShot(world, room, shard.time, '', () => task(room, Game));
-				},
+				// Fetch game state for player
+				const [ intentRooms, visibleRooms ] = await Promise.all([
+					shard.scratch.smembers(userToIntentRoomsSetKey(userId)),
+					shard.scratch.smembers(userToVisibleRoomsSetKey(userId)),
+				]);
+				const rooms = await Promise.all(Fn.map(visibleRooms, roomName => shard.loadRoom(roomName)));
+				const state = new GameState(world, shard.time, rooms);
+				const [ intents ] = runForUser(userId, state, task);
 
-				async poke(roomName, userId, task) {
-					const room = await shard.loadRoom(roomName);
-					const state = new GameState(world, shard.time, [ room ]);
-					const [ , result ] = runWithState(state, () => runForUser(userId ?? '', state, Game => task(Game, room)));
-					room['#flushObjects'](state);
-					const previousUsers = flushUsers(room);
-					await Promise.all([
-						shard.saveRoom(room.name, shard.time, room),
-						updateUserRoomRelationships(shard, room, previousUsers),
-					]);
-					roomInstances.delete(roomName);
-					return result;
-				},
-
-				async player(userId, task) {
-					assert.ok(!playersThisTick.has(userId), `player '${userId}' already invoked this tick`);
-					playersThisTick.add(userId);
-
-					// Fetch game state for player
-					const [ intentRooms, visibleRooms ] = await Promise.all([
-						shard.scratch.smembers(userToIntentRoomsSetKey(userId)),
-						shard.scratch.smembers(userToVisibleRoomsSetKey(userId)),
-					]);
-					const rooms = await Promise.all(Fn.map(visibleRooms, roomName => shard.loadRoom(roomName)));
-					const state = new GameState(world, shard.time, rooms);
-					const [ intents ] = runForUser(userId, state, task);
-
-					// Save intents
-					for (const roomName of intentRooms) {
-						const roomIntents = intents.getIntentsForRoom(roomName);
-						if (roomIntents) {
-							getOrSet(intentsByRoom, roomName, () => []).push({ userId, intents: roomIntents });
-						}
+				// Save intents
+				for (const roomName of intentRooms) {
+					const roomIntents = intents.getIntentsForRoom(roomName);
+					if (roomIntents) {
+						getOrSet(intentsByRoom, roomName, () => []).push({ userId, intents: roomIntents });
 					}
-				},
+				}
+			},
 
-				async tick(count = 1, players = {}) {
-					for (let ii = 0; ii < count; ++ii) {
-						// Run player code
-						for (const [ userId, task ] of Object.entries(players)) {
-							await that.player(userId, task);
-						}
-						playersThisTick.clear();
-
-						// Initialize processor queue
-						const time = shard.time + 1;
-						const processorTime = await begetRoomProcessQueue(shard, time, time - 1);
-						assert.equal(time, processorTime);
-						const nextRoomInstances = new Map<string, Room>();
-						const contexts = new Map<string, RoomProcessor>();
-
-						// First phase
-						for await (const roomName of consumeSortedSet(shard.scratch, processRoomsSetKey(time), 0, Infinity)) {
-							const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
-							nextRoomInstances.set(roomName, room);
-							const context = new RoomProcessor(shard, world, room, time);
-							contexts.set(roomName, context);
-							for (const { userId, intents } of intentsByRoom.get(roomName) ?? []) {
-								context.saveIntents(userId, intents);
-							}
-							await context.process();
-						}
-						roomInstances = nextRoomInstances;
-						intentsByRoom.clear();
-
-						// Second phase
-						await Promise.all(Fn.map(contexts.values(), context => context.finalize(false)));
-						for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
-							const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
-							const context = new RoomProcessor(shard, world, room, time);
-							await context.process(true);
-							await context.finalize(true);
-							nextRoomInstances.set(roomName, room);
-						}
-
-						// Increment time
-						await shard.data.set('time', time);
-						await shard.channel.publish({ type: 'tick', time });
-						shard.time = time;
+			async tick(count = 1, players = {}) {
+				for (let ii = 0; ii < count; ++ii) {
+					// Run player code
+					for (const [ userId, task ] of Object.entries(players)) {
+						await that.player(userId, task);
 					}
-				},
-			};
-			await body(that);
-		} finally {
-			shard.disconnect();
-			db.disconnect();
-		}
+					playersThisTick.clear();
+
+					// Initialize processor queue
+					const time = shard.time + 1;
+					const processorTime = await begetRoomProcessQueue(shard, time, time - 1);
+					assert.equal(time, processorTime);
+					const nextRoomInstances = new Map<string, Room>();
+					const contexts = new Map<string, RoomProcessor>();
+
+					// First phase
+					for await (const roomName of consumeSortedSet(shard.scratch, processRoomsSetKey(time), 0, Infinity)) {
+						const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
+						nextRoomInstances.set(roomName, room);
+						const context = new RoomProcessor(shard, world, room, time);
+						contexts.set(roomName, context);
+						for (const { userId, intents } of intentsByRoom.get(roomName) ?? []) {
+							context.saveIntents(userId, intents);
+						}
+						await context.process();
+					}
+					roomInstances = nextRoomInstances;
+					intentsByRoom.clear();
+
+					// Second phase
+					await Promise.all(Fn.map(contexts.values(), context => context.finalize(false)));
+					for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
+						const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
+						const context = new RoomProcessor(shard, world, room, time);
+						await context.process(true);
+						await context.finalize(true);
+						nextRoomInstances.set(roomName, room);
+					}
+
+					// Increment time
+					await shard.data.set('time', time);
+					await shard.channel.publish({ type: 'tick', time });
+					shard.time = time;
+				}
+			},
+		};
+		await body(that);
 	};
 }

--- a/packages/xxscreeps/test/simulate.ts
+++ b/packages/xxscreeps/test/simulate.ts
@@ -13,6 +13,7 @@ import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { Game, GameState, initializeGameEnvironment, runForUser, runOneShot, runWithState } from 'xxscreeps/game/index.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
+import { RawMemory, initialize as initializeMemory } from 'xxscreeps/mods/memory/memory.js';
 import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
 
@@ -70,118 +71,128 @@ type Simulation = {
 export function simulate(rooms: Record<string, (room: Room) => void>) {
 	return async (body: (refs: Simulation) => Promise<void>) => {
 
-		using testShard = await instantiateTestShard();
-		const { db, shard, world } = testShard;
-
-		// Initialize world
-		await Promise.all(Fn.map(Object.entries(rooms), async ([ roomName, callback ]) => {
-			const room = await shard.loadRoom(roomName, shard.time);
-			runOneShot(world, room, shard.time, '', () => callback(room));
-			room['#flushObjects'](null);
-			const previousUsers = flushUsers(room);
-			await Promise.all([
-				shard.saveRoom(room.name, shard.time + 1, room),
-				shard.saveRoom(room.name, shard.time, room),
-				updateUserRoomRelationships(shard, room, previousUsers),
-			]);
-		}));
-
-		// Run simulation
-		const intentsByRoom = new Map<string, { userId: string; intents: RoomIntentPayload }[]>();
-		const playersThisTick = new Set<string>();
-		let roomInstances = new Map<string, Room>();
-		const that: Simulation = {
-			db,
-			shard,
-			world,
-
-			async peekRoom(roomName, task) {
-				const room = await shard.loadRoom(roomName);
-				return runOneShot(world, room, shard.time, '', () => task(room, Game));
-			},
-
-			async poke(roomName, userId, task) {
-				const room = await shard.loadRoom(roomName);
-				const state = new GameState(world, shard.time, [ room ]);
-				const [ , result ] = runWithState(state, () => runForUser(userId ?? '', state, Game => task(Game, room)));
-				room['#flushObjects'](state);
+		// Reset module-level Memory state between simulations. The `json` / `string`
+		// caches and `RawMemory._parsed` are module-scoped in `mods/memory/memory.ts`
+		// and would otherwise carry over from the previous test's `runForUser`
+		// invocations. Each `simulate(...)` body is a logically isolated test, so
+		// match that boundary.
+		initializeMemory(null);
+		RawMemory._parsed = undefined;
+		const { db, shard, world } = await instantiateTestShard();
+		try {
+			// Initialize world
+			await Promise.all(Fn.map(Object.entries(rooms), async ([ roomName, callback ]) => {
+				const room = await shard.loadRoom(roomName, shard.time);
+				runOneShot(world, room, shard.time, '', () => callback(room));
+				room['#flushObjects'](null);
 				const previousUsers = flushUsers(room);
 				await Promise.all([
+					shard.saveRoom(room.name, shard.time + 1, room),
 					shard.saveRoom(room.name, shard.time, room),
 					updateUserRoomRelationships(shard, room, previousUsers),
 				]);
-				roomInstances.delete(roomName);
-				return result;
-			},
+			}));
 
-			async player(userId, task) {
-				assert.ok(!playersThisTick.has(userId), `player '${userId}' already invoked this tick`);
-				playersThisTick.add(userId);
+			// Run simulation
+			const intentsByRoom = new Map<string, { userId: string; intents: RoomIntentPayload }[]>();
+			const playersThisTick = new Set<string>();
+			let roomInstances = new Map<string, Room>();
+			const that: Simulation = {
+				db,
+				shard,
+				world,
 
-				// Fetch game state for player
-				const [ intentRooms, visibleRooms ] = await Promise.all([
-					shard.scratch.smembers(userToIntentRoomsSetKey(userId)),
-					shard.scratch.smembers(userToVisibleRoomsSetKey(userId)),
-				]);
-				const rooms = await Promise.all(Fn.map(visibleRooms, roomName => shard.loadRoom(roomName)));
-				const state = new GameState(world, shard.time, rooms);
-				const [ intents ] = runForUser(userId, state, task);
+				async peekRoom(roomName, task) {
+					const room = await shard.loadRoom(roomName);
+					return runOneShot(world, room, shard.time, '', () => task(room, Game));
+				},
 
-				// Save intents
-				for (const roomName of intentRooms) {
-					const roomIntents = intents.getIntentsForRoom(roomName);
-					if (roomIntents) {
-						getOrSet(intentsByRoom, roomName, () => []).push({ userId, intents: roomIntents });
-					}
-				}
-			},
+				async poke(roomName, userId, task) {
+					const room = await shard.loadRoom(roomName);
+					const state = new GameState(world, shard.time, [ room ]);
+					const [ , result ] = runWithState(state, () => runForUser(userId ?? '', state, Game => task(Game, room)));
+					room['#flushObjects'](state);
+					const previousUsers = flushUsers(room);
+					await Promise.all([
+						shard.saveRoom(room.name, shard.time, room),
+						updateUserRoomRelationships(shard, room, previousUsers),
+					]);
+					roomInstances.delete(roomName);
+					return result;
+				},
 
-			async tick(count = 1, players = {}) {
-				for (let ii = 0; ii < count; ++ii) {
-					// Run player code
-					for (const [ userId, task ] of Object.entries(players)) {
-						await that.player(userId, task);
-					}
-					playersThisTick.clear();
+				async player(userId, task) {
+					assert.ok(!playersThisTick.has(userId), `player '${userId}' already invoked this tick`);
+					playersThisTick.add(userId);
 
-					// Initialize processor queue
-					const time = shard.time + 1;
-					const processorTime = await begetRoomProcessQueue(shard, time, time - 1);
-					assert.equal(time, processorTime);
-					const nextRoomInstances = new Map<string, Room>();
-					const contexts = new Map<string, RoomProcessor>();
+					// Fetch game state for player
+					const [ intentRooms, visibleRooms ] = await Promise.all([
+						shard.scratch.smembers(userToIntentRoomsSetKey(userId)),
+						shard.scratch.smembers(userToVisibleRoomsSetKey(userId)),
+					]);
+					const rooms = await Promise.all(Fn.map(visibleRooms, roomName => shard.loadRoom(roomName)));
+					const state = new GameState(world, shard.time, rooms);
+					const [ intents ] = runForUser(userId, state, task);
 
-					// First phase
-					for await (const roomName of consumeSortedSet(shard.scratch, processRoomsSetKey(time), 0, Infinity)) {
-						const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
-						nextRoomInstances.set(roomName, room);
-						const context = new RoomProcessor(shard, world, room, time);
-						contexts.set(roomName, context);
-						for (const { userId, intents } of intentsByRoom.get(roomName) ?? []) {
-							context.saveIntents(userId, intents);
+					// Save intents
+					for (const roomName of intentRooms) {
+						const roomIntents = intents.getIntentsForRoom(roomName);
+						if (roomIntents) {
+							getOrSet(intentsByRoom, roomName, () => []).push({ userId, intents: roomIntents });
 						}
-						await context.process();
 					}
-					roomInstances = nextRoomInstances;
-					intentsByRoom.clear();
+				},
 
-					// Second phase
-					await Promise.all(Fn.map(contexts.values(), context => context.finalize(false)));
-					for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
-						const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
-						const context = new RoomProcessor(shard, world, room, time);
-						await context.process(true);
-						await context.finalize(true);
-						nextRoomInstances.set(roomName, room);
+				async tick(count = 1, players = {}) {
+					for (let ii = 0; ii < count; ++ii) {
+						// Run player code
+						for (const [ userId, task ] of Object.entries(players)) {
+							await that.player(userId, task);
+						}
+						playersThisTick.clear();
+
+						// Initialize processor queue
+						const time = shard.time + 1;
+						const processorTime = await begetRoomProcessQueue(shard, time, time - 1);
+						assert.equal(time, processorTime);
+						const nextRoomInstances = new Map<string, Room>();
+						const contexts = new Map<string, RoomProcessor>();
+
+						// First phase
+						for await (const roomName of consumeSortedSet(shard.scratch, processRoomsSetKey(time), 0, Infinity)) {
+							const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
+							nextRoomInstances.set(roomName, room);
+							const context = new RoomProcessor(shard, world, room, time);
+							contexts.set(roomName, context);
+							for (const { userId, intents } of intentsByRoom.get(roomName) ?? []) {
+								context.saveIntents(userId, intents);
+							}
+							await context.process();
+						}
+						roomInstances = nextRoomInstances;
+						intentsByRoom.clear();
+
+						// Second phase
+						await Promise.all(Fn.map(contexts.values(), context => context.finalize(false)));
+						for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
+							const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
+							const context = new RoomProcessor(shard, world, room, time);
+							await context.process(true);
+							await context.finalize(true);
+							nextRoomInstances.set(roomName, room);
+						}
+
+						// Increment time
+						await shard.data.set('time', time);
+						await shard.channel.publish({ type: 'tick', time });
+						shard.time = time;
 					}
-
-					// Increment time
-					await shard.data.set('time', time);
-					await shard.channel.publish({ type: 'tick', time });
-					shard.time = time;
-				}
-			},
-		};
-		await body(that);
+				},
+			};
+			await body(that);
+		} finally {
+			shard.disconnect();
+			db.disconnect();
+		}
 	};
 }


### PR DESCRIPTION
## Summary

`mods/memory/memory.ts` keeps its parse cache (`json`, `string`) and `RawMemory._parsed` in module-level state. In production every sandbox runs `runtimeConnector.initialize(memoryBlob)` once at startup, so that state is per-process-per-user and isolation is implicit. Tests don't go through that path — every `simulate(...)` body shares one Node process, so cached Memory contents from a prior test's `runForUser` calls survive into the next test's first read.

Reset at the `simulate(...)` body boundary using already-exported pieces (`initialize(null)` and `RawMemory._parsed = undefined`). No new exports from `mods/memory/memory.ts`; the test-isolation logic stays in test infrastructure.

## Why now / what risk does this resolve

Today this is **latent, not observable**. Every consumer that reads Memory keys validates the value (e.g. the `_move` path cache rejects mismatched origin/dest), so no existing test observes the leak.

The risk is forward-looking: a future test that asserts on initial Memory shape, or that reuses creep / room / flag / spawn names across tests in the same file, could quietly read the prior test's writes. #140 doesn't widen the leak (per-object `.memory` accessors still go through the module-level `get()` directly, not `globalThis.Memory`), but it does make the leak more deterministic — after #140, `flush()` always drops the `json` cache, so the next tick re-parses from `string`. A sibling test that reads Memory before writing will reliably see the prior test's parsed blob instead of occasionally hitting a stale-but-matching `_parsed`.

Cheap insurance, contained to test infra.

## Validation

- `pnpm run test` — 177/177 passing on this branch.
- Verified against screeps-ok.