### PR TITLE
Fix iterateActiveParts; add Fn.dropWhile

### DIFF
--- a/.changeset/active-parts-filter.md
+++ b/.changeset/active-parts-filter.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `iterateActiveParts` halting on front-damaged creeps; add `Fn.dropWhile`

--- a/packages/xxscreeps/functional/functional.ts
+++ b/packages/xxscreeps/functional/functional.ts
@@ -19,6 +19,7 @@ export * from './function/chain.js';
 export * from './function/identity.js';
 export * from './function/pipe.js';
 export * from './iterable/concat.js';
+export * from './iterable/dropWhile.js';
 export * from './iterable/filter.js';
 export * from './iterable/fold/accumulate.js';
 export * from './iterable/fold/every.js';

--- a/packages/xxscreeps/functional/iterable/dropWhile.ts
+++ b/packages/xxscreeps/functional/iterable/dropWhile.ts
@@ -1,0 +1,14 @@
+import type { IndexedPredicate } from 'xxscreeps/functional/predicate.js';
+
+/**
+ * Yield elements starting from the first one for which predicate returns `false`
+ */
+export function *dropWhile<Type>(iterable: Iterable<Type>, predicate: IndexedPredicate<Type>) {
+	let dropping = true;
+	let ii = 0;
+	for (const value of iterable) {
+		if (dropping && predicate(value, ii++)) continue;
+		dropping = false;
+		yield value;
+	}
+}

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -445,11 +445,11 @@ export function calculateCarry(body: Creep['body']) {
 		});
 }
 
-const activePartPredicate: Predicate<Creep['body'][number]> = part => part.hits > 0;
+const deadPartPredicate: Predicate<Creep['body'][number]> = part => part.hits === 0;
 
 export function iterateActiveParts(body: Creep['body']) {
-	// Parts die from right to left so you can halt iteration at the first dead part
-	return Fn.takeWhile(body, activePartPredicate);
+	// Damage propagates front-to-back, so dead parts cluster at the front of body.
+	return Fn.dropWhile(body, deadPartPredicate);
 }
 
 registerObstacleChecker(params => {


### PR DESCRIPTION
`recalculateBody` distributes damage front-to-back, so `body[0]` is the first to drop to zero. `iterateActiveParts` used `Fn.takeWhile`, which halted at the first dead part and yielded nothing whenever index 0 was dead — breaking `getActiveBodyparts`, `calculateCarry`, `calculatePower`, and `calculateBoundedEffect` on damaged creeps.

Replace with `Fn.dropWhile` (new sibling of `takeWhile`): dead parts cluster at the front, so dropping them yields the active suffix.

Verified against screeps-ok.