### PR TITLE
fix: Bootstrap generated mod imports before command modules

### DIFF
--- a/packages/xxscreeps/config/entry.ts
+++ b/packages/xxscreeps/config/entry.ts
@@ -14,6 +14,15 @@ const noWorkerFlags = [
 const extraFlags = (process.env.NODE_OPTIONS ?? '').split(/ /g).filter(flag => flag !== '');
 const isMissingFlag = (flag: string) => !process.execArgv.includes(flag) && !extraFlags.includes(flag);
 const missingFlags = isMainThread ? requiredFlags.filter(isMissingFlag) : [];
+async function bootstrapRuntimeImports() {
+	// Built-in commands link modules that resolve through config/mods.static.
+	// Generate those files before importing the command module itself.
+	await Promise.all([
+		import('./mods/index.js'),
+		import('./global.js'),
+	]);
+}
+
 if (missingFlags.length) {
 	// In this case we are missing a required flag
 	const niceToHaveFlags = [
@@ -105,6 +114,7 @@ if (missingFlags.length) {
 
 		// Run it outside of try / catch
 		if (modulePath !== undefined) {
+			await bootstrapRuntimeImports();
 			await import(modulePath);
 		}
 


### PR DESCRIPTION
`Simplify entry script` removed the eager mod initialization from `config/entry.ts`, but built-in commands still link modules that resolve through `xxscreeps/config/mods.static/*`. On a cold CI build those generated files do not exist yet, so `npx xxscreeps test` fails during ESM linking before `test/run.ts` can call `importMods()`.

This keeps storage provider registration lazy, but restores the minimal runtime bootstrap needed before importing a built-in command module:

- import `config/mods/index.js` to generate `dist/config/mods.static/*`
- import `config/global.js` before runtime decorators are needed
- then dynamically import the resolved command module

Verified under Node 24:

```bash
pnpm run build
pnpm run test
# 177 tests: 177 passed, 0 failed
```
