### PR TITLE
Graceful shutdown contract for sibling-process publishers

### DIFF
--- a/.changeset/feat-shutdown-contract.md
+++ b/.changeset/feat-shutdown-contract.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add a graceful shutdown contract that lets a sibling process publish `shutdown` on the service channel and have main exit cleanly without corrupting state

--- a/packages/xxscreeps/engine/service/launcher.ts
+++ b/packages/xxscreeps/engine/service/launcher.ts
@@ -4,7 +4,7 @@ import { Database, Shard } from 'xxscreeps/engine/db/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { getConsoleChannel } from 'xxscreeps/engine/runner/model.js';
 import { Worker, waitForWorker } from 'xxscreeps/utility/worker.js';
-import { getServiceChannel } from './index.js';
+import { getServiceChannel, handleInterrupt } from './index.js';
 
 const argv = checkArguments({
 	boolean: [ 'no-backend', 'no-processor', 'no-runner' ] as const,
@@ -14,6 +14,17 @@ const argv = checkArguments({
 // Connect to shard
 const db = await Database.connect();
 const shard = await Shard.connect(db, 'shard0');
+
+const serviceChannel = getServiceChannel(shard);
+const shutdown = { requested: false };
+handleInterrupt(() => {
+	if (shutdown.requested) {
+		return;
+	}
+	shutdown.requested = true;
+	console.log('Shutting down...');
+	serviceChannel.publish({ type: 'shutdown' }).catch(() => {});
+});
 
 try {
 
@@ -36,33 +47,43 @@ try {
 	}
 
 	// Start main service
-	const [ , waitForMain ] = getServiceChannel(shard).listenFor(message => message.type === 'mainConnected');
+	const [ , waitForMain ] = serviceChannel.listenFor(message => message.type === 'mainConnected');
 	const main = import('./main.js');
 	await Promise.race([ main, waitForMain ]);
 
-	// Start workers
-	const singleThreaded = config.launcher?.singleThreaded;
-	const { services, backend } = await async function() {
-		if (singleThreaded) {
-			const backend = argv['no-backend'] ? undefined : import('xxscreeps/backend/server.js');
-			const processor = argv['no-processor'] ? undefined : import('./processor.js');
-			const runner = argv['no-runner'] ? undefined : import('./runner.js');
-			const services = Promise.all([ main, processor, runner ]);
-			return { services, backend };
-		} else {
-			const [ backend, processor, runner ] = await Promise.all([
-				argv['no-backend'] ? undefined : Worker.create('xxscreeps/backend/server.js'),
-				argv['no-processor'] ? undefined : Worker.create('xxscreeps/engine/service/processor.js'),
-				argv['no-runner'] ? undefined : Worker.create('xxscreeps/engine/service/runner.js'),
-			]);
-			const services = Promise.all([ main, processor && waitForWorker(processor), runner && waitForWorker(runner) ]);
-			return { services, backend };
-		}
-	}();
-	await Promise.all([
-		services.then(() => console.log('💾 Engine shut down successfully.')),
-		backend,
-	]);
+	// Race-safety: SIGINT may have fired before main subscribed to the service
+	// channel, in which case the original publish had no listener. Now that
+	// main has advertised `mainConnected`, its listener is active — re-publish.
+	if (shutdown.requested) {
+		await serviceChannel.publish({ type: 'shutdown' }).catch(() => {});
+	}
+
+	// Start workers (skip if shutdown already requested — main will exit on its own)
+	const services = shutdown.requested
+		? Promise.all([ main ])
+		: await async function() {
+			const singleThreaded = config.launcher?.singleThreaded;
+			if (singleThreaded) {
+				const backend = argv['no-backend'] ? undefined : import('xxscreeps/backend/server.js');
+				const processor = argv['no-processor'] ? undefined : import('./processor.js');
+				const runner = argv['no-runner'] ? undefined : import('./runner.js');
+				return Promise.all([ main, backend, processor, runner ]);
+			} else {
+				const [ backend, processor, runner ] = await Promise.all([
+					argv['no-backend'] ? undefined : Worker.create('xxscreeps/backend/server.js'),
+					argv['no-processor'] ? undefined : Worker.create('xxscreeps/engine/service/processor.js'),
+					argv['no-runner'] ? undefined : Worker.create('xxscreeps/engine/service/runner.js'),
+				]);
+				return Promise.all([
+					main,
+					backend && waitForWorker(backend),
+					processor && waitForWorker(processor),
+					runner && waitForWorker(runner),
+				]);
+			}
+		}();
+	await services;
+	console.log('💾 Engine shut down successfully.');
 
 } finally {
 	db.disconnect();

--- a/packages/xxscreeps/engine/service/main.ts
+++ b/packages/xxscreeps/engine/service/main.ts
@@ -9,7 +9,7 @@ import * as Async from 'xxscreeps/utility/async.js';
 import { AveragingTimer } from 'xxscreeps/utility/averaging-timer.js';
 import { acquireTimeout } from 'xxscreeps/utility/utility.js';
 import { tickSpeed, watch } from './tick.js';
-import { checkIsEntry, getServiceChannel, handleInterrupt } from './index.js';
+import { checkIsEntry, getServiceChannel } from './index.js';
 
 checkIsEntry();
 
@@ -23,17 +23,21 @@ const [ gameMutex, serviceChannel ] = await Promise.all([
 	getServiceChannel(shard).subscribe(),
 ]);
 
-// Interrupt handler
+// Shutdown is published on the service channel (by the launcher's SIGINT
+// handler or by an admin-CLI command running in a sibling process). Listening
+// here lets main exit cleanly regardless of where the publish came from.
 let halted = false as boolean;
 let halt: Effect | undefined;
 let tickDelay: Deferred<boolean> | undefined;
-handleInterrupt(() => {
-	console.log('Shutting down...');
+const stop = () => {
 	halted = true;
 	halt?.();
 	tickDelay?.resolve(false);
-	serviceChannel.publish({ type: 'shutdown' });
-	unwatch?.();
+};
+const shutdownEffect = serviceChannel.listen(message => {
+	if (message.type === 'shutdown' && !halted) {
+		stop();
+	}
 });
 
 // Configure .screepsrc.yaml watcher to update tick speed immediately
@@ -61,19 +65,30 @@ try {
 	const processorMessages = serviceChannel.iterable();
 	await serviceChannel.publish({ type: 'mainConnected' });
 	for await (const message of Async.breakable(processorMessages, breaker => halt = breaker)) {
-		if (
+		if (message.type === 'shutdown') {
+			halted = true;
+			break;
+		} else if (
 			message.type === 'processorInitialized' &&
 			await shard.scratch.zcard(activeRoomsKey) === rooms.length
 		) {
 			break;
 		}
 	}
-	await begetRoomProcessQueue(shard, shard.time + 1, shard.time);
+	if (!halted) {
+		await begetRoomProcessQueue(shard, shard.time + 1, shard.time);
+	}
 
 	// Game loop
 	while (!halted) {
 		let timeStartedLoop!: number;
+		let tickCompleted = false;
 		await gameMutex.scope(async () => {
+			// Shutdown can land while we're blocked acquiring the mutex (e.g. an
+			// admin-CLI command holds it to mutate state, then publishes shutdown
+			// before releasing). Running a tick body against the post-mutation
+			// state would corrupt shard.time and stall on the abandon timeout.
+			if (halted) return;
 			timeStartedLoop = Date.now();
 			performanceTimer.start();
 
@@ -86,7 +101,8 @@ try {
 			]);
 			await runnerChannel.publish({ type: 'run', time });
 
-			// Wait for tick to finish
+			// Wait for tick to finish. `breakable` so a mid-tick shutdown
+			// interrupts the wait instead of burning the full intentAbandonTimeout.
 			{
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				using timeout = acquireTimeout(
@@ -97,16 +113,21 @@ try {
 							console.log(`Abandoning intents in rooms [${rooms.join(', ')}] for tick ${time}`);
 						}
 					}));
-				for await (const message of serviceMessages) {
+				for await (const message of Async.breakable(serviceMessages, breaker => halt = breaker)) {
 					if (message.type === 'processorInitialized') {
 						await processorChannel.publish({ type: 'process', time });
 					} else if (message.type === 'runnerConnected') {
 						await runnerChannel.publish({ type: 'run', time });
 					} else if (message.type === 'tickFinished') {
+						tickCompleted = true;
 						break;
 					}
 				}
 			}
+
+			// Shutdown (not tickFinished) broke the loop — skip the state update
+			// so shard.time doesn't advance past unrun work.
+			if (!tickCompleted) return;
 
 			// Update game state
 			await shard.data.set('time', time);
@@ -158,6 +179,9 @@ try {
 
 } finally {
 	// Clean up
+	shutdownEffect();
+	stop();
+	unwatch?.();
 	await gameMutex.disconnect();
 	await serviceChannel.publish({ type: 'mainDisconnected' });
 	serviceChannel.disconnect();


### PR DESCRIPTION
## Summary

Move SIGINT ownership to the launcher; make `main` a service-channel listener with bailouts at the three windows where a channel-borne `shutdown` could find it blocked. Shutdown always lands on a coherent tick boundary now — never mid-tick.

**Why for the upcoming admin CLI:** commands like `map.removeRoom` and `system.importWorld` mutate state the engine has cached (worker `roomCache`, `World.accessibleRooms`, `PlayerInstance` sandbox bakes). In-place refresh needs sandbox recreation; the alternative is to restart after the mutation — signaled from the launcher by publishing `shutdown` on the service channel. Without these bailouts that publish either does nothing (main only listens for SIGINT today) or lets main run a tick against post-mutation state.

## Bailouts

- **Init loop** — explicit `'shutdown'` check + skip `begetRoomProcessQueue` if halted. The launcher's SIGINT handler now publishes on the channel rather than halting main directly, so an operator hitting Ctrl-C during boot (wrong config, wrong shard) needs the init iterator to react to the channel message.
- **Mutex acquire** — `if (halted) return;` re-check inside `gameMutex.scope`. Covers `system.importWorld` holding the mutex, wiping scratch + reimporting, then publishing `shutdown` before `main` can run a tick body against post-import state.
- **Tick wait** — wrap inner `for await` in `Async.breakable`, skip state update if shutdown (not `tickFinished`) broke the loop. Otherwise main waits the full `intentAbandonTimeout` because workers received `process` for a tick they cannot complete.

Launcher also re-publishes `shutdown` after `mainConnected` (covers SIGINT-before-subscribe race) and skips worker startup if shutdown was already requested.

## Validation

`pnpm run build && pnpm run test` clean (177/177). Verified against screeps-ok.