### PR TITLE
Add portal mod with same-shard and cross-shard (stub for now) destinations

### DIFF
--- a/.changeset/portal-mod.md
+++ b/.changeset/portal-mod.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add portal mod with same-shard and cross-shard destinations

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -15,7 +15,6 @@ registerGlobal(function StructureNuker() {});
 registerGlobal(function StructureObserver() {});
 registerGlobal(function StructurePowerBank() {});
 registerGlobal(function StructurePowerSpawn() {});
-registerGlobal(function StructurePortal() {});
 
 declare const globalThis: any;
 hooks.register('runtimeConnector', {

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -11,6 +11,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/logistics',
 		'xxscreeps/mods/market',
 		'xxscreeps/mods/observer',
+		'xxscreeps/mods/portal',
 		'xxscreeps/mods/road',
 		'xxscreeps/mods/source',
 		'xxscreeps/mods/spawn',

--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -357,23 +357,30 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 				return new RoomPosition(creep.pos.x, 0, generateRoomName(rx, ry + 1));
 			}
 		}();
-		creep.room['#removeObject'](creep);
-		// Update `creep.pos` for the import command but set it back so that `#flushObjects` can safely
-		// update the internal indices.
-		const oldPos = creep.pos;
-		creep.pos = next;
-		// Creeps are revitalized when moving to a new room
-		creep.fatigue = 0;
-		// Reset actionLog since the actions were in the previous room
-		creep['#actionLog'] = [];
-		const importPayload = writeRoomObject(creep);
-		creep.pos = oldPos;
-		context.sendRoomIntent(next.roomName, 'import', typedArrayToString(importPayload));
-		context.didUpdate();
+		teleportCreep(creep, next, context);
 	} else {
 		context.wakeAt(creep['#ageTime']);
 	}
 });
+
+// Move a creep to another room. Used by border crossing and by structures that transport creeps
+// across rooms (e.g. portals). The creep is removed from its current room and an import-payload
+// intent is queued for the destination room.
+export function teleportCreep(creep: Creep, next: RoomPosition, context: ProcessorContext) {
+	creep.room['#removeObject'](creep);
+	// Update `creep.pos` for the import command but set it back so that `#flushObjects` can safely
+	// update the internal indices.
+	const oldPos = creep.pos;
+	creep.pos = next;
+	// Creeps are revitalized when moving to a new room
+	creep.fatigue = 0;
+	// Reset actionLog since the actions were in the previous room
+	creep['#actionLog'] = [];
+	const importPayload = writeRoomObject(creep);
+	creep.pos = oldPos;
+	context.sendRoomIntent(next.roomName, 'import', typedArrayToString(importPayload));
+	context.didUpdate();
+}
 
 registerObjectTickProcessor(Tombstone, (tombstone, context) => {
 	if (tombstone.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -367,7 +367,9 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 // across rooms (e.g. portals). The creep is removed from its current room and an import-payload
 // intent is queued for the destination room.
 export function teleportCreep(creep: Creep, next: RoomPosition, context: ProcessorContext) {
-	creep.room['#removeObject'](creep);
+	if (!creep.room['#removeObject'](creep)) {
+		return;
+	}
 	// Update `creep.pos` for the import command but set it back so that `#flushObjects` can safely
 	// update the internal indices.
 	const oldPos = creep.pos;

--- a/packages/xxscreeps/mods/portal/backend.ts
+++ b/packages/xxscreeps/mods/portal/backend.ts
@@ -3,16 +3,8 @@ import { StructurePortal } from './portal.js';
 
 bindMapRenderer(StructurePortal, () => 'p');
 
-bindRenderer(StructurePortal, (portal, next) => {
-	const decayTime = portal['#decayTime'];
-	const out = {
-		...next(),
-		destination: portal['#destShard'] === ''
-			? { x: portal['#destX'], y: portal['#destY'], room: portal['#destRoom'] }
-			: { shard: portal['#destShard'], room: portal['#destRoom'] },
-	};
-	if (decayTime === 0) {
-		return out;
-	}
-	return { ...out, decayTime };
-});
+bindRenderer(StructurePortal, (portal, next) => ({
+	...next(),
+	destination: portal.destination,
+	decayTime: portal['#decayTime'] || undefined,
+}));

--- a/packages/xxscreeps/mods/portal/backend.ts
+++ b/packages/xxscreeps/mods/portal/backend.ts
@@ -1,0 +1,17 @@
+import { bindMapRenderer, bindRenderer } from 'xxscreeps/backend/index.js';
+import { StructurePortal } from './portal.js';
+
+bindMapRenderer(StructurePortal, () => 'p');
+
+bindRenderer(StructurePortal, (portal, next) => {
+	const out = {
+		...next(),
+		destination: portal['#destShard'] === ''
+			? { x: portal['#destX'], y: portal['#destY'], room: portal['#destRoom'] }
+			: { shard: portal['#destShard'], room: portal['#destRoom'] },
+	};
+	if (portal['#decayTime'] !== 0) {
+		(out as any).decayTime = portal['#decayTime'];
+	}
+	return out;
+});

--- a/packages/xxscreeps/mods/portal/backend.ts
+++ b/packages/xxscreeps/mods/portal/backend.ts
@@ -4,14 +4,15 @@ import { StructurePortal } from './portal.js';
 bindMapRenderer(StructurePortal, () => 'p');
 
 bindRenderer(StructurePortal, (portal, next) => {
+	const decayTime = portal['#decayTime'];
 	const out = {
 		...next(),
 		destination: portal['#destShard'] === ''
 			? { x: portal['#destX'], y: portal['#destY'], room: portal['#destRoom'] }
 			: { shard: portal['#destShard'], room: portal['#destRoom'] },
 	};
-	if (portal['#decayTime'] !== 0) {
-		(out as any).decayTime = portal['#decayTime'];
+	if (decayTime === 0) {
+		return out;
 	}
-	return out;
+	return { ...out, decayTime };
 });

--- a/packages/xxscreeps/mods/portal/game.ts
+++ b/packages/xxscreeps/mods/portal/game.ts
@@ -2,6 +2,7 @@ import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import { registerGlobal } from 'xxscreeps/game/index.js';
 import * as Portal from './portal.js';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const schema = registerVariant('Room.objects', Portal.format);
 declare module 'xxscreeps/game/room/index.js' {
 	interface Schema { portal: typeof schema }

--- a/packages/xxscreeps/mods/portal/game.ts
+++ b/packages/xxscreeps/mods/portal/game.ts
@@ -1,0 +1,13 @@
+import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import { registerGlobal } from 'xxscreeps/game/index.js';
+import * as Portal from './portal.js';
+
+const schema = registerVariant('Room.objects', Portal.format);
+declare module 'xxscreeps/game/room/index.js' {
+	interface Schema { portal: typeof schema }
+}
+
+registerGlobal(Portal.StructurePortal);
+declare module 'xxscreeps/game/runtime.js' {
+	interface Global { StructurePortal: typeof Portal.StructurePortal }
+}

--- a/packages/xxscreeps/mods/portal/index.ts
+++ b/packages/xxscreeps/mods/portal/index.ts
@@ -5,5 +5,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/creep',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'game', 'processor' ],
+	provides: [ 'backend', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/portal/index.ts
+++ b/packages/xxscreeps/mods/portal/index.ts
@@ -1,0 +1,9 @@
+import type { Manifest } from 'xxscreeps/config/mods/index.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/creep',
+		'xxscreeps/mods/structure',
+	],
+	provides: [ 'backend', 'game', 'processor' ],
+};

--- a/packages/xxscreeps/mods/portal/portal.ts
+++ b/packages/xxscreeps/mods/portal/portal.ts
@@ -5,9 +5,9 @@ import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Structure, structureFormat } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
 
-export type SameShardDestination = { shard?: undefined; room: string; x: number; y: number };
-export type CrossShardDestination = { shard: string; room: string };
-export type Destination = SameShardDestination | CrossShardDestination;
+export interface PortalDestination extends RoomPosition { shard?: undefined }
+export interface RemotePortalDestination { shard: string; room: string }
+export type Destination = PortalDestination | RemotePortalDestination;
 
 export const format = declare('Portal', () => compose(shape, StructurePortal));
 const shape = struct(structureFormat, {
@@ -20,17 +20,15 @@ const shape = struct(structureFormat, {
 });
 
 export class StructurePortal extends withOverlay(Structure, shape) {
-	@enumerable get destination(): RoomPosition | { shard: string; room: string } {
-		if (this['#destShard'] !== '') {
-			return { shard: this['#destShard'], room: this['#destRoom'] };
+	@enumerable get destination(): Destination {
+		if (this['#destShard'] === '') {
+			return new RoomPosition(this['#destX'], this['#destY'], this['#destRoom']);
 		}
-		return new RoomPosition(this['#destX'], this['#destY'], this['#destRoom']);
+		return { shard: this['#destShard'], room: this['#destRoom'] };
 	}
 
 	@enumerable get ticksToDecay(): number | undefined {
-		const decayTime = this['#decayTime'];
-		if (decayTime === 0) return undefined;
-		return Math.max(0, decayTime - Game.time);
+		return this['#decayTime'] === 0 ? undefined : Math.max(0, this['#decayTime'] - Game.time);
 	}
 
 	override get structureType() { return C.STRUCTURE_PORTAL; }
@@ -45,7 +43,7 @@ export function create(pos: RoomPosition, destination: Destination, decayTime = 
 	const portal = RoomObject.create(new StructurePortal(), pos);
 	if (destination.shard === undefined) {
 		portal['#destShard'] = '';
-		portal['#destRoom'] = destination.room;
+		portal['#destRoom'] = destination.roomName;
 		portal['#destX'] = destination.x;
 		portal['#destY'] = destination.y;
 	} else {

--- a/packages/xxscreeps/mods/portal/portal.ts
+++ b/packages/xxscreeps/mods/portal/portal.ts
@@ -20,9 +20,6 @@ const shape = struct(structureFormat, {
 });
 
 export class StructurePortal extends withOverlay(Structure, shape) {
-	override get structureType() { return C.STRUCTURE_PORTAL; }
-	override get '#lookType'() { return C.LOOK_STRUCTURES; }
-
 	@enumerable get destination(): RoomPosition | { shard: string; room: string } {
 		if (this['#destShard'] !== '') {
 			return { shard: this['#destShard'], room: this['#destRoom'] };
@@ -36,6 +33,9 @@ export class StructurePortal extends withOverlay(Structure, shape) {
 		return Math.max(0, decayTime - Game.time);
 	}
 
+	override get structureType() { return C.STRUCTURE_PORTAL; }
+	override get '#lookType'() { return C.LOOK_STRUCTURES; }
+
 	override '#checkObstacle'() {
 		return false;
 	}
@@ -43,16 +43,16 @@ export class StructurePortal extends withOverlay(Structure, shape) {
 
 export function create(pos: RoomPosition, destination: Destination, decayTime = 0) {
 	const portal = RoomObject.create(new StructurePortal(), pos);
-	if (destination.shard !== undefined) {
-		portal['#destShard'] = destination.shard;
-		portal['#destRoom'] = destination.room;
-		portal['#destX'] = 0;
-		portal['#destY'] = 0;
-	} else {
+	if (destination.shard === undefined) {
 		portal['#destShard'] = '';
 		portal['#destRoom'] = destination.room;
 		portal['#destX'] = destination.x;
 		portal['#destY'] = destination.y;
+	} else {
+		portal['#destShard'] = destination.shard;
+		portal['#destRoom'] = destination.room;
+		portal['#destX'] = 0;
+		portal['#destY'] = 0;
 	}
 	portal['#decayTime'] = decayTime;
 	return portal;

--- a/packages/xxscreeps/mods/portal/portal.ts
+++ b/packages/xxscreeps/mods/portal/portal.ts
@@ -1,0 +1,59 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import * as RoomObject from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { Structure, structureFormat } from 'xxscreeps/mods/structure/structure.js';
+import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
+
+export type SameShardDestination = { shard?: undefined; room: string; x: number; y: number };
+export type CrossShardDestination = { shard: string; room: string };
+export type Destination = SameShardDestination | CrossShardDestination;
+
+export const format = declare('Portal', () => compose(shape, StructurePortal));
+const shape = struct(structureFormat, {
+	...variant('portal'),
+	'#destShard': 'string',
+	'#destRoom': 'string',
+	'#destX': 'int8',
+	'#destY': 'int8',
+	'#decayTime': 'int32',
+});
+
+export class StructurePortal extends withOverlay(Structure, shape) {
+	override get structureType() { return C.STRUCTURE_PORTAL; }
+	override get '#lookType'() { return C.LOOK_STRUCTURES; }
+
+	@enumerable get destination(): RoomPosition | { shard: string; room: string } {
+		if (this['#destShard'] !== '') {
+			return { shard: this['#destShard'], room: this['#destRoom'] };
+		}
+		return new RoomPosition(this['#destX'], this['#destY'], this['#destRoom']);
+	}
+
+	@enumerable get ticksToDecay(): number | undefined {
+		const decayTime = this['#decayTime'];
+		if (decayTime === 0) return undefined;
+		return Math.max(0, decayTime - Game.time);
+	}
+
+	override '#checkObstacle'() {
+		return false;
+	}
+}
+
+export function create(pos: RoomPosition, destination: Destination, decayTime = 0) {
+	const portal = RoomObject.create(new StructurePortal(), pos);
+	if (destination.shard !== undefined) {
+		portal['#destShard'] = destination.shard;
+		portal['#destRoom'] = destination.room;
+		portal['#destX'] = 0;
+		portal['#destY'] = 0;
+	} else {
+		portal['#destShard'] = '';
+		portal['#destRoom'] = destination.room;
+		portal['#destX'] = destination.x;
+		portal['#destY'] = destination.y;
+	}
+	portal['#decayTime'] = decayTime;
+	return portal;
+}

--- a/packages/xxscreeps/mods/portal/processor.ts
+++ b/packages/xxscreeps/mods/portal/processor.ts
@@ -1,0 +1,30 @@
+import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { Creep } from 'xxscreeps/mods/creep/creep.js';
+import { teleportCreep } from 'xxscreeps/mods/creep/processor.js';
+import { StructurePortal } from './portal.js';
+
+registerObjectTickProcessor(StructurePortal, (portal, context) => {
+	// Decay
+	const decayTime = portal['#decayTime'];
+	if (decayTime !== 0 && Game.time >= decayTime) {
+		portal.room['#removeObject'](portal);
+		context.didUpdate();
+		return;
+	}
+
+	// Cross-shard portals are not yet supported (single-shard server)
+	if (portal['#destShard'] === '') {
+		const dest = new RoomPosition(portal['#destX'], portal['#destY'], portal['#destRoom']);
+		for (const object of portal.room['#lookAt'](portal.pos)) {
+			if (object instanceof Creep && object['#user'].length > 2) {
+				teleportCreep(object, dest, context);
+			}
+		}
+	}
+
+	if (decayTime !== 0) {
+		context.wakeAt(decayTime);
+	}
+});

--- a/packages/xxscreeps/mods/portal/processor.ts
+++ b/packages/xxscreeps/mods/portal/processor.ts
@@ -1,12 +1,10 @@
 import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import { Game } from 'xxscreeps/game/index.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Creep } from 'xxscreeps/mods/creep/creep.js';
 import { teleportCreep } from 'xxscreeps/mods/creep/processor.js';
 import { StructurePortal } from './portal.js';
 
 registerObjectTickProcessor(StructurePortal, (portal, context) => {
-	// Decay
 	const decayTime = portal['#decayTime'];
 	if (decayTime !== 0 && Game.time >= decayTime) {
 		portal.room['#removeObject'](portal);
@@ -15,8 +13,8 @@ registerObjectTickProcessor(StructurePortal, (portal, context) => {
 	}
 
 	// Cross-shard portals are not yet supported (single-shard server)
-	if (portal['#destShard'] === '') {
-		const dest = new RoomPosition(portal['#destX'], portal['#destY'], portal['#destRoom']);
+	const dest = portal.destination;
+	if (dest.shard === undefined) {
 		for (const object of portal.room['#lookAt'](portal.pos)) {
 			if (object instanceof Creep && object['#user'].length > 2) {
 				teleportCreep(object, dest, context);

--- a/packages/xxscreeps/mods/portal/test.ts
+++ b/packages/xxscreeps/mods/portal/test.ts
@@ -13,7 +13,7 @@ describe('Portal', () => {
 		W1N1: room => {
 			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
-				{ room: 'W2N2', x: 30, y: 30 },
+				new RoomPosition(30, 30, 'W2N2'),
 				/* decayTime */ 100,
 			));
 		},
@@ -32,7 +32,7 @@ describe('Portal', () => {
 		W1N1: room => {
 			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
-				{ room: 'W2N2', x: 30, y: 30 },
+				new RoomPosition(30, 30, 'W2N2'),
 				/* decayTime */ 0,
 			));
 		},
@@ -48,7 +48,7 @@ describe('Portal', () => {
 		W1N1: room => {
 			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
-				{ room: 'W3N3', x: 17, y: 23 },
+				new RoomPosition(17, 23, 'W3N3'),
 			));
 		},
 	})(async ({ peekRoom }) => {
@@ -82,11 +82,11 @@ describe('Portal', () => {
 		W1N1: room => {
 			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
-				{ room: 'W2N2', x: 20, y: 20 },
+				new RoomPosition(20, 20, 'W2N2'),
 			));
 			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
-				{ room: 'W2N2', x: 21, y: 21 },
+				new RoomPosition(21, 21, 'W2N2'),
 			));
 			room['#insertObject'](createCreep(
 				new RoomPosition(25, 25, 'W1N1'),

--- a/packages/xxscreeps/mods/portal/test.ts
+++ b/packages/xxscreeps/mods/portal/test.ts
@@ -1,0 +1,76 @@
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { StructurePortal, create } from './portal.js';
+
+const findPortal = (room: any) =>
+	room['#objects'].find((object: any) => object instanceof StructurePortal) as StructurePortal | undefined;
+
+describe('Portal', () => {
+	test('decaying portal exposes positive ticksToDecay', () => simulate({
+		W1N1: room => {
+			room['#insertObject'](create(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ room: 'W2N2', x: 30, y: 30 },
+				/* decayTime */ 100,
+			));
+		},
+	})(async ({ peekRoom }) => {
+		await peekRoom('W1N1', (room, game) => {
+			const portal = findPortal(room);
+			assert.ok(portal, 'portal should exist');
+			const ttd = portal!.ticksToDecay;
+			assert.ok(typeof ttd === 'number' && ttd > 0 && ttd <= 100,
+				`ticksToDecay should count down from #decayTime; got ${ttd}`);
+			assert.strictEqual(ttd, 100 - game.time);
+		});
+	}));
+
+	test('permanent portal has undefined ticksToDecay', () => simulate({
+		W1N1: room => {
+			room['#insertObject'](create(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ room: 'W2N2', x: 30, y: 30 },
+				/* decayTime */ 0,
+			));
+		},
+	})(async ({ peekRoom }) => {
+		await peekRoom('W1N1', room => {
+			const portal = findPortal(room);
+			assert.ok(portal, 'permanent portal should exist');
+			assert.strictEqual(portal!.ticksToDecay, undefined);
+		});
+	}));
+
+	test('same-shard destination is a RoomPosition with x/y/roomName', () => simulate({
+		W1N1: room => {
+			room['#insertObject'](create(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ room: 'W3N3', x: 17, y: 23 },
+			));
+		},
+	})(async ({ peekRoom }) => {
+		await peekRoom('W1N1', room => {
+			const portal = findPortal(room);
+			const dest = portal!.destination as RoomPosition;
+			assert.strictEqual(dest.roomName, 'W3N3');
+			assert.strictEqual(dest.x, 17);
+			assert.strictEqual(dest.y, 23);
+		});
+	}));
+
+	test('cross-shard destination is { shard, room }', () => simulate({
+		W1N1: room => {
+			room['#insertObject'](create(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ shard: 'shard1', room: 'W5N5' },
+			));
+		},
+	})(async ({ peekRoom }) => {
+		await peekRoom('W1N1', room => {
+			const portal = findPortal(room);
+			const dest = portal!.destination as { shard: string; room: string };
+			assert.strictEqual(dest.shard, 'shard1');
+			assert.strictEqual(dest.room, 'W5N5');
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/portal/test.ts
+++ b/packages/xxscreeps/mods/portal/test.ts
@@ -1,14 +1,17 @@
+import type { Room } from 'xxscreeps/game/room/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
-import { StructurePortal, create } from './portal.js';
+import { StructurePortal, create as createPortal } from './portal.js';
 
-const findPortal = (room: any) =>
-	room['#objects'].find((object: any) => object instanceof StructurePortal) as StructurePortal | undefined;
+const findPortal = (room: Room) =>
+	room.find(C.FIND_STRUCTURES).find(object => object instanceof StructurePortal);
 
 describe('Portal', () => {
 	test('decaying portal exposes positive ticksToDecay', () => simulate({
 		W1N1: room => {
-			room['#insertObject'](create(
+			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
 				{ room: 'W2N2', x: 30, y: 30 },
 				/* decayTime */ 100,
@@ -18,7 +21,7 @@ describe('Portal', () => {
 		await peekRoom('W1N1', (room, game) => {
 			const portal = findPortal(room);
 			assert.ok(portal, 'portal should exist');
-			const ttd = portal!.ticksToDecay;
+			const ttd = portal.ticksToDecay;
 			assert.ok(typeof ttd === 'number' && ttd > 0 && ttd <= 100,
 				`ticksToDecay should count down from #decayTime; got ${ttd}`);
 			assert.strictEqual(ttd, 100 - game.time);
@@ -27,7 +30,7 @@ describe('Portal', () => {
 
 	test('permanent portal has undefined ticksToDecay', () => simulate({
 		W1N1: room => {
-			room['#insertObject'](create(
+			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
 				{ room: 'W2N2', x: 30, y: 30 },
 				/* decayTime */ 0,
@@ -37,13 +40,13 @@ describe('Portal', () => {
 		await peekRoom('W1N1', room => {
 			const portal = findPortal(room);
 			assert.ok(portal, 'permanent portal should exist');
-			assert.strictEqual(portal!.ticksToDecay, undefined);
+			assert.strictEqual(portal.ticksToDecay, undefined);
 		});
 	}));
 
 	test('same-shard destination is a RoomPosition with x/y/roomName', () => simulate({
 		W1N1: room => {
-			room['#insertObject'](create(
+			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
 				{ room: 'W3N3', x: 17, y: 23 },
 			));
@@ -51,7 +54,9 @@ describe('Portal', () => {
 	})(async ({ peekRoom }) => {
 		await peekRoom('W1N1', room => {
 			const portal = findPortal(room);
-			const dest = portal!.destination as RoomPosition;
+			assert.ok(portal, 'portal should exist');
+			const dest = portal.destination;
+			assert.ok(dest instanceof RoomPosition);
 			assert.strictEqual(dest.roomName, 'W3N3');
 			assert.strictEqual(dest.x, 17);
 			assert.strictEqual(dest.y, 23);
@@ -60,7 +65,7 @@ describe('Portal', () => {
 
 	test('cross-shard destination is { shard, room }', () => simulate({
 		W1N1: room => {
-			room['#insertObject'](create(
+			room['#insertObject'](createPortal(
 				new RoomPosition(25, 25, 'W1N1'),
 				{ shard: 'shard1', room: 'W5N5' },
 			));
@@ -68,9 +73,40 @@ describe('Portal', () => {
 	})(async ({ peekRoom }) => {
 		await peekRoom('W1N1', room => {
 			const portal = findPortal(room);
-			const dest = portal!.destination as { shard: string; room: string };
-			assert.strictEqual(dest.shard, 'shard1');
-			assert.strictEqual(dest.room, 'W5N5');
+			assert.ok(portal, 'portal should exist');
+			assert.deepStrictEqual(portal.destination, { shard: 'shard1', room: 'W5N5' });
+		});
+	}));
+
+	test('overlapping portals only import a creep once', () => simulate({
+		W1N1: room => {
+			room['#insertObject'](createPortal(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ room: 'W2N2', x: 20, y: 20 },
+			));
+			room['#insertObject'](createPortal(
+				new RoomPosition(25, 25, 'W1N1'),
+				{ room: 'W2N2', x: 21, y: 21 },
+			));
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 25, 'W1N1'),
+				[ C.MOVE ],
+				'traveler',
+				'100',
+			));
+		},
+	})(async ({ peekRoom, tick }) => {
+		await tick();
+		await peekRoom('W2N2', room => {
+			const creeps = room.find(C.FIND_CREEPS).filter(creep => creep.name === 'traveler');
+			assert.strictEqual(creeps.length, 1);
+			assert.ok(creeps[0].pos.isEqualTo(20, 20));
+		});
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(
+				room.find(C.FIND_CREEPS).some(creep => creep.name === 'traveler'),
+				false,
+			);
 		});
 	}));
 });

--- a/packages/xxscreeps/scripts/scrape-world.ts
+++ b/packages/xxscreeps/scripts/scrape-world.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { Destination } from 'xxscreeps/mods/portal/portal.js';
 import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
 import type { Store } from 'xxscreeps/mods/resource/store.js';
 import type { Structure } from 'xxscreeps/mods/structure/structure.js';
@@ -32,6 +33,7 @@ import { StructureWall } from 'xxscreeps/mods/defense/wall.js';
 import { saveMemoryBlob } from 'xxscreeps/mods/memory/model.js';
 import { StructureExtractor } from 'xxscreeps/mods/mineral/extractor.js';
 import { Mineral } from 'xxscreeps/mods/mineral/mineral.js';
+import { StructurePortal } from 'xxscreeps/mods/portal/portal.js';
 import { OpenStore, SingleStore } from 'xxscreeps/mods/resource/store.js';
 import { StructureRoad } from 'xxscreeps/mods/road/road.js';
 import { StructureKeeperLair } from 'xxscreeps/mods/source/keeper-lair.js';
@@ -75,6 +77,35 @@ function withStore(from: any, into: { store: Store }) {
 	for (const type in from.store) {
 		into.store['#add'](type as ResourceType, from.store[type]);
 	}
+}
+
+function getPortalDestination(object: any): Destination | undefined {
+	const rawDestination = object.destination as unknown;
+	const destination = rawDestination !== null && typeof rawDestination === 'object'
+		? rawDestination as Record<string, unknown>
+		: {};
+	const shard = destination.shard ?? object.destShard as unknown;
+	const room = destination.room ?? object.destRoom as unknown;
+	if (typeof shard === 'string' && typeof room === 'string') {
+		return { shard, room };
+	}
+	const xx = destination.x ?? object.destX as unknown;
+	const yy = destination.y ?? object.destY as unknown;
+	if (typeof room === 'string' && typeof xx === 'number' && typeof yy === 'number') {
+		return { room, x: xx, y: yy };
+	}
+}
+
+function getPortalDecayTime(object: any): number {
+	const decayTime = object.decayTime as unknown;
+	if (typeof decayTime === 'number') {
+		return decayTime;
+	}
+	const ticksToDecay = object.ticksToDecay as unknown;
+	if (typeof ticksToDecay === 'number') {
+		return gameTime + ticksToDecay;
+	}
+	return 0;
 }
 
 // Create .screepsrc.yaml
@@ -130,7 +161,7 @@ if ((rcInfo?.size ?? 0) === 0) {
 	const preamble = schema === undefined ? '' : `# yaml-language-server: $schema=${schema}\n`;
 	const defaultConfig: any = {};
 	for (const modConfig of Configs) {
-		merge(defaultConfig, modConfig.configDefaults ?? {});
+		merge(defaultConfig, modConfig.configDefaults);
 	}
 	defaultConfig.mods = [ ...mods ];
 	await fs.writeFile(configPath, preamble + jsYaml.dump(defaultConfig));
@@ -258,6 +289,28 @@ const rooms = loki.getCollection('rooms').find().map(room => {
 				return mineral;
 			}
 
+			case 'portal': {
+				const destination = getPortalDestination(object);
+				if (destination === undefined) {
+					return;
+				}
+				const portal = new StructurePortal();
+				withStructure(object, portal);
+				if (destination.shard === undefined) {
+					portal['#destShard'] = '';
+					portal['#destRoom'] = destination.room;
+					portal['#destX'] = destination.x;
+					portal['#destY'] = destination.y;
+				} else {
+					portal['#destShard'] = destination.shard;
+					portal['#destRoom'] = destination.room;
+					portal['#destX'] = 0;
+					portal['#destY'] = 0;
+				}
+				portal['#decayTime'] = getPortalDecayTime(object);
+				return portal;
+			}
+
 			case 'rampart': {
 				const rampart = new StructureRampart();
 				withStructure(object, rampart);
@@ -334,7 +387,7 @@ if (!shardOnly) {
 	// Save user code content
 	const overwriteModules = new Map<string, string>();
 	const codePath = argv['overwrite-code'];
-	if (codePath) {
+	if (codePath !== undefined) {
 		const names = await fs.readdir(codePath);
 		const files = await Promise.all(names.map(async name => {
 			const data = await fs.readFile(path.join(codePath, name), 'utf8');

--- a/packages/xxscreeps/scripts/scrape-world.ts
+++ b/packages/xxscreeps/scripts/scrape-world.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { RoomObject } from 'xxscreeps/game/object.js';
-import type { Destination } from 'xxscreeps/mods/portal/portal.js';
 import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
 import type { Store } from 'xxscreeps/mods/resource/store.js';
 import type { Structure } from 'xxscreeps/mods/structure/structure.js';
@@ -77,35 +76,6 @@ function withStore(from: any, into: { store: Store }) {
 	for (const type in from.store) {
 		into.store['#add'](type as ResourceType, from.store[type]);
 	}
-}
-
-function getPortalDestination(object: any): Destination | undefined {
-	const rawDestination = object.destination as unknown;
-	const destination = rawDestination !== null && typeof rawDestination === 'object'
-		? rawDestination as Record<string, unknown>
-		: {};
-	const shard = destination.shard ?? object.destShard as unknown;
-	const room = destination.room ?? object.destRoom as unknown;
-	if (typeof shard === 'string' && typeof room === 'string') {
-		return { shard, room };
-	}
-	const xx = destination.x ?? object.destX as unknown;
-	const yy = destination.y ?? object.destY as unknown;
-	if (typeof room === 'string' && typeof xx === 'number' && typeof yy === 'number') {
-		return { room, x: xx, y: yy };
-	}
-}
-
-function getPortalDecayTime(object: any): number {
-	const decayTime = object.decayTime as unknown;
-	if (typeof decayTime === 'number') {
-		return decayTime;
-	}
-	const ticksToDecay = object.ticksToDecay as unknown;
-	if (typeof ticksToDecay === 'number') {
-		return gameTime + ticksToDecay;
-	}
-	return 0;
 }
 
 // Create .screepsrc.yaml
@@ -290,12 +260,9 @@ const rooms = loki.getCollection('rooms').find().map(room => {
 			}
 
 			case 'portal': {
-				const destination = getPortalDestination(object);
-				if (destination === undefined) {
-					return;
-				}
 				const portal = new StructurePortal();
 				withStructure(object, portal);
+				const { destination } = object;
 				if (destination.shard === undefined) {
 					portal['#destShard'] = '';
 					portal['#destRoom'] = destination.room;
@@ -307,7 +274,7 @@ const rooms = loki.getCollection('rooms').find().map(room => {
 					portal['#destX'] = 0;
 					portal['#destY'] = 0;
 				}
-				portal['#decayTime'] = getPortalDecayTime(object);
+				portal['#decayTime'] = object.decayTime ?? 0;
 				return portal;
 			}
 


### PR DESCRIPTION
Implements `StructurePortal` as a real game object, replacing the empty `registerGlobal` stub in `game/runtime.ts`. Mirrors vanilla `@screeps/engine` semantics: same-shard `destination` returns a `RoomPosition`, cross-shard returns `{shard, room}`. `ticksToDecay` is `undefined` for permanent portals.

## Changes

- New `mods/portal/` module — schema, processor (decay + creep teleport), backend renderers, manifest. Wired into `mods/classic`.
- Extract `teleportCreep` helper from `mods/creep/processor.ts` so the portal processor reuses the existing border-cross `writeRoomObject` / `sendRoomIntent('import')` path.
- `scrape-world` reads portal destination + decay time from imported world data so portals survive a world import.
- Cross-shard teleport short-circuits (single-shard server); destination shape is still preserved on read.
- Same-shard teleport gates on `#user.length > 2` to match the existing border-cross NPC exclusion.

## Validation

- New `mods/portal/test.ts` covers destination shape (same-shard / cross-shard) and `ticksToDecay` (decaying / permanent).
- Verified against screeps-ok.