### PR TITLE
Reject Creep.pull(self) with ERR_INVALID_TARGET

### DIFF
--- a/.changeset/creep-pull-self-guard.md
+++ b/.changeset/creep-pull-self-guard.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reject `Creep.pull(self)` with `ERR_INVALID_TARGET`.

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -512,6 +512,7 @@ export function checkPull(creep: Creep, target: Creep | null | undefined) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
 		() => checkTarget(target, Creep),
+		() => target === creep ? C.ERR_INVALID_TARGET : C.OK,
 		() => checkRange(creep, target!, 1),
 		() => target!.spawning ? C.ERR_INVALID_TARGET : C.OK);
 }


### PR DESCRIPTION
Reject `Creep.pull(target)` when `target === creep`, mirroring vanilla `@screeps/engine/src/game/creeps.js:1102` (`target.id == this.id` → `ERR_INVALID_TARGET`). The check slots into the existing chain right after `checkTarget` and before `checkRange`, matching the spawning-target guard added in #152.

Without it, self-pull falls through to the processor's circular-pull resolver and hangs the test runner.

## Validation

`pnpm run test` 177/177. Verified against screeps-ok.