### PR TITLE
Add RoomPosition.__packedPos setter

### DIFF
--- a/.changeset/packed-pos-setter.md
+++ b/.changeset/packed-pos-setter.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Make `RoomPosition.__packedPos` writable to match vanilla.

--- a/packages/xxscreeps/game/position.ts
+++ b/packages/xxscreeps/game/position.ts
@@ -126,6 +126,11 @@ export class RoomPosition {
 		return (this.#id >>> 8) & 0xff;
 	}
 
+	/** @deprecated */
+	set __packedPos(value: number) {
+		this.#id = ((value & 0xff) << 24) | ((value & 0xff00) << 8) | ((value >>> 16) & 0xffff);
+	}
+
 	// eslint-disable-next-line id-length
 	set x(xx: number) {
 		if (!(xx >= 0 && xx < 50)) {

--- a/packages/xxscreeps/game/test.ts
+++ b/packages/xxscreeps/game/test.ts
@@ -1,0 +1,22 @@
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { RoomPosition } from './position.js';
+
+describe('RoomPosition', () => {
+	test('__packedPos setter round-trips through the getter', () => {
+		const cases: [number, number, string][] = [
+			[ 0, 0, 'W0N0' ],
+			[ 25, 25, 'W1N1' ],
+			[ 49, 49, 'E5S5' ],
+			[ 13, 7, 'E0S0' ],
+		];
+		for (const [ xx, yy, roomName ] of cases) {
+			const original = new RoomPosition(xx, yy, roomName);
+			const target = new RoomPosition(0, 0, 'W0N0');
+			target.__packedPos = original.__packedPos;
+			assert.strictEqual(target.x, original.x);
+			assert.strictEqual(target.y, original.y);
+			assert.strictEqual(target.roomName, original.roomName);
+			assert.strictEqual(target.__packedPos, original.__packedPos);
+		}
+	});
+});

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -1,6 +1,7 @@
 import { importMods } from 'xxscreeps/config/mods/index.js';
 import { flush, summary } from './context.js';
 import './import.js';
+import 'xxscreeps/game/test.js';
 
 await importMods('test');
 try {


### PR DESCRIPTION
## Summary

Mirror vanilla's writable `__packedPos` on `RoomPosition`. The getter has been around forever; the setter was a silent no-op, breaking WASM bot bridges (e.g. TheInternational's commiebot) that construct positions via `pos.__packedPos = value`.

Setter is the bitwise inverse of the existing getter — same byte layout vanilla uses (`rx << 24 | ry << 16 | x << 8 | y`).

Also adds `packages/xxscreeps/game/test.ts` as a tiny test entrypoint for core game tests, since the existing harness only auto-discovers `test.ts` inside mods and `position.ts` isn't in one.

## Validation

- Round-trip test: `target.__packedPos = original.__packedPos` reproduces `x` / `y` / `roomName` across W0N0, W1N1, E5S5, E0S0.
- `npx xxscreeps test`: 178/178.
- Verified against screeps-ok.