### PR TITLE
Strip boost from unboosted body parts to match vanilla shape

### DIFF
--- a/.changeset/body-part-boost-shape.md
+++ b/.changeset/body-part-boost-shape.md
@@ -2,4 +2,4 @@
 "xxscreeps": patch
 ---
 
-Strip `boost` from unboosted body parts so `creep.body[i]` matches the vanilla `{hits, type}` own-property shape; `boost` is only present on boosted parts.
+Strip `boost` from unboosted body parts to match vanilla own-property shape.

--- a/.changeset/body-part-boost-shape.md
+++ b/.changeset/body-part-boost-shape.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Strip `boost` from unboosted body parts so `creep.body[i]` matches the vanilla `{hits, type}` own-property shape; `boost` is only present on boosted parts.

--- a/packages/xxscreeps/mods/chemistry/processor.ts
+++ b/packages/xxscreeps/mods/chemistry/processor.ts
@@ -111,7 +111,7 @@ const intents = [
 
 		// Strip all boosts
 		for (const part of creep.body) {
-			part.boost = undefined;
+			delete part.boost;
 		}
 
 		// Recalculate carry capacity

--- a/packages/xxscreeps/mods/chemistry/test.ts
+++ b/packages/xxscreeps/mods/chemistry/test.ts
@@ -206,6 +206,28 @@ describe('Chemistry', () => {
 			});
 		}));
 
+		test('body parts match vanilla own-property shape', () => boostSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				// Pre-boost: every part is `{ hits, type }` — no `boost` own property
+				for (const part of Game.creeps.boostme.body) {
+					assert.ok(!('boost' in part), `unboosted ${part.type} part must not have own 'boost' property`);
+				}
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				labs.find(lab => lab.mineralType === 'GO')!.boostCreep(Game.creeps.boostme);
+			});
+			await tick();
+			await player('100', Game => {
+				// Post-boost: only the boosted (TOUGH) parts gain a `boost` own property
+				for (const part of Game.creeps.boostme.body) {
+					if (part.type === C.TOUGH) {
+						assert.ok('boost' in part, 'boosted TOUGH part must have own `boost` property');
+					} else {
+						assert.ok(!('boost' in part), `unboosted ${part.type} part must not have own 'boost' property`);
+					}
+				}
+			});
+		}));
+
 		test('boostCreep deducts resources from lab', () => boostSim(async ({ player, tick }) => {
 			await player('100', Game => {
 				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
@@ -438,6 +460,10 @@ describe('Chemistry', () => {
 				const creep = Game.creeps.unboosted;
 				const boostedParts = creep.body.filter(part => part.boost);
 				assert.strictEqual(boostedParts.length, 0, 'all boosts should be removed');
+				// Vanilla parity: unboost must drop the `boost` own property entirely, not leave it set to undefined.
+				for (const part of creep.body) {
+					assert.ok(!('boost' in part), `unboosted ${part.type} part must not have own 'boost' property`);
+				}
 			});
 		}));
 

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -30,6 +30,11 @@ import { assign } from 'xxscreeps/utility/utility.js';
 export type PartType = typeof C.BODYPARTS_ALL[number];
 type BoostEffects = Partial<Record<string, number>>;
 export type BoostsLookup = Partial<Record<string, Partial<Record<string, BoostEffects>>>>;
+export interface BodyPart {
+	boost?: ResourceType;
+	hits: number;
+	type: PartType;
+}
 
 type MoveToOptions = FindPathOptions & {
 	noPathFinding?: boolean;
@@ -41,7 +46,7 @@ type MoveToOptions = FindPathOptions & {
 export const format = declare('Creep', () => compose(shape, Creep));
 const shape = struct(objectFormat, {
 	...variant('creep'),
-	body: vector(declare('BodyPart', compose(
+	body: vector(compose(
 		struct({
 			boost: optionalResourceEnumFormat,
 			hits: 'int8',
@@ -49,12 +54,11 @@ const shape = struct(objectFormat, {
 		}),
 		{
 			// Vanilla omits `boost` from unboosted parts; only set after applyBoost.
-			compose: ({ boost, hits, type }): { boost?: ResourceType; hits: number; type: PartType } =>
+			compose: ({ boost, hits, type }): BodyPart =>
 				boost === undefined ? { hits, type } : { boost, hits, type },
-			decompose: (part: { boost?: ResourceType; hits: number; type: PartType }) =>
-				({ boost: part.boost, hits: part.hits, type: part.type }),
+			decompose: (part: BodyPart) => ({ boost: part.boost, hits: part.hits, type: part.type }),
 		},
-	))),
+	)),
 	fatigue: 'int32',
 	hits: 'int32',
 	name: 'string',

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -41,11 +41,20 @@ type MoveToOptions = FindPathOptions & {
 export const format = declare('Creep', () => compose(shape, Creep));
 const shape = struct(objectFormat, {
 	...variant('creep'),
-	body: vector(struct({
-		boost: optionalResourceEnumFormat,
-		hits: 'int8',
-		type: enumerated(...C.BODYPARTS_ALL),
-	})),
+	body: vector(declare('BodyPart', compose(
+		struct({
+			boost: optionalResourceEnumFormat,
+			hits: 'int8',
+			type: enumerated(...C.BODYPARTS_ALL),
+		}),
+		{
+			// Vanilla omits `boost` from unboosted parts; only set after applyBoost.
+			compose: ({ boost, hits, type }): { boost?: ResourceType; hits: number; type: PartType } =>
+				boost === undefined ? { hits, type } : { boost, hits, type },
+			decompose: (part: { boost?: ResourceType; hits: number; type: PartType }) =>
+				({ boost: part.boost, hits: part.hits, type: part.type }),
+		},
+	))),
 	fatigue: 'int32',
 	hits: 'int32',
 	name: 'string',
@@ -419,7 +428,7 @@ export class Creep extends withOverlay(RoomObject, shape) {
 }
 
 export function create(pos: RoomPosition, parts: PartType[], name: string, owner: string) {
-	const body = parts.map(type => ({ type, hits: 100, boost: undefined }));
+	const body = parts.map(type => ({ type, hits: 100 }));
 	const creep = assign(createObject(new Creep(), pos), {
 		body,
 		hits: body.length * 100,

--- a/packages/xxscreeps/mods/spawn/processor.ts
+++ b/packages/xxscreeps/mods/spawn/processor.ts
@@ -138,7 +138,7 @@ const intents = [
 				creep['#ageTime'] += calculateRenewAmount(creep);
 				if (creep.body.some(part => part.boost)) {
 					for (const part of creep.body) {
-						part.boost = undefined;
+						delete part.boost;
 					}
 					dropOverflowResources(creep);
 				}


### PR DESCRIPTION
## Issue

Body parts deserialized via the schema struct always have `boost` as an own property — `Object.getOwnPropertyNames(part)` includes `boost: undefined` for unboosted parts. Vanilla only sets `boost` after `applyBoost`, so own-property introspection (`'boost' in part`, `Object.keys`) returns true only for boosted parts. Player code that walks body shape directly sees a different surface on xxscreeps than on the official engine.

## Fix

Wrap the body-part struct in a `compose()` interceptor that strips `boost` on read when undefined and supplies it on write. Switch `unboostCreep` (chemistry) and `renewCreep` (spawn) from `part.boost = undefined` to `delete part.boost` so the in-tick processor view also matches vanilla.

After this change, `creep.body[i]` is `{ hits, type }` for unboosted parts and `{ boost, hits, type }` for boosted parts. Schema binary layout and existing archive entries are unchanged.

## Validation

New `body parts match vanilla own-property shape` test in `mods/chemistry/test.ts` asserts `'boost' in part` is absent pre-boost, present on TOUGH parts post-boost, and absent on the others. `unboostCreep removes all boosts` extended to assert the property is deleted on the strip path. Verified against screeps-ok.