### PR TITLE
Make Game.map.getWorldSize() return the inclusive room-coordinate span

### DIFF
--- a/.changeset/world-size-inclusive-span.md
+++ b/.changeset/world-size-inclusive-span.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `Game.map.getWorldSize()` to return the inclusive room-coordinate span

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -63,8 +63,9 @@ export class GameMap {
 		}
 		this.#left = minX;
 		this.#top = minY;
-		this.#width = maxX - minX;
-		this.#height = maxY - minY;
+		// Inclusive room counts; `getWorldSize()` and the continuous-wrap math in `getRoomLinearDistance` consume these directly.
+		this.#width = maxX - minX + 1;
+		this.#height = maxY - minY + 1;
 	}
 
 	'#getCenterRoom'() {


### PR DESCRIPTION
The constructor's `#width = maxX - minX` and `#height = maxY - minY`
are the exclusive distance between the extreme rx/ry coordinates of
the loaded terrain. `getWorldSize()` returns `Math.max(#height, #width)`
directly, so it reports one less than the inclusive room count along
the longest edge — but the JSDoc example ("W50N50 to E50S50 → 102")
requires the inclusive form.

Add `+ 1` to both. Two other consumers of these fields shift along:

- `getRoomLinearDistance(a, b, true)` continuous-mode wrap was
  off-by-one, returning 0 for two rooms one step apart across the
  world wrap; now returns 1.
- `#getCenterRoom()` — consumed by `/api/user/world-start-room` as
  a starting-room hint — shifts by one cell on some worlds.

## Validation

Verified against screeps-ok.