### PR TITLE
Add Deposit mod

### DIFF
--- a/.changeset/good-ducks-heal.md
+++ b/.changeset/good-ducks-heal.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add Deposit mod

--- a/.changeset/plain-feet-see.md
+++ b/.changeset/plain-feet-see.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add 'deposit' mod

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -4,6 +4,7 @@ export const manifest: Manifest = {
 	dependencies: [
 		'xxscreeps/mods/chemistry',
 		'xxscreeps/mods/defense',
+		'xxscreeps/mods/deposit',
 		'xxscreeps/mods/factory',
 		'xxscreeps/mods/flag',
 		'xxscreeps/mods/intershardResource',

--- a/packages/xxscreeps/mods/deposit/backend.ts
+++ b/packages/xxscreeps/mods/deposit/backend.ts
@@ -1,0 +1,13 @@
+import { bindMapRenderer, bindRenderer, bindTerrainRenderer } from 'xxscreeps/backend/index.js';
+import { Deposit } from './deposit.js';
+
+bindMapRenderer(Deposit, () => 'd');
+bindTerrainRenderer(Deposit, () => 0x777777);
+
+bindRenderer(Deposit, (deposit, next) => ({
+	...next(),
+	cooldown: deposit.cooldown,
+	depositType: deposit.depositType,
+	lastCooldown: deposit.lastCooldown,
+	nextDecayTime: deposit['#nextDecayTime'],
+}));

--- a/packages/xxscreeps/mods/deposit/deposit.ts
+++ b/packages/xxscreeps/mods/deposit/deposit.ts
@@ -1,0 +1,53 @@
+import type { BufferView } from 'xxscreeps/schema/index.js';
+import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game, registerGlobal } from 'xxscreeps/game/index.js';
+import * as RoomObject from 'xxscreeps/game/object.js';
+import { checkCommon } from 'xxscreeps/mods/creep/creep.js';
+import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
+import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
+import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
+import { assign } from 'xxscreeps/utility/utility.js';
+
+export const format = declare('Deposit', () => compose(shape, Deposit));
+const shape = struct(RoomObject.format, {
+	...variant('deposit'),
+	depositType: resourceEnumFormat,
+	'#harvested': 'int32',
+	'#cooldownTime': 'int32',
+	'#lastCooldown': 'int32',
+	'#nextDecayTime': 'int32',
+});
+
+export class Deposit extends withOverlay(RoomObject.RoomObject, shape) {
+
+	constructor(id?: string);
+	constructor(buffer?: BufferView, offset?: number);
+	constructor(idOrBuffer?: BufferView | string, offset?: number) {
+		super(typeof idOrBuffer === 'string' ? undefined : idOrBuffer, offset);
+		if (typeof idOrBuffer === 'string') assign<Deposit>(this, RoomObject.getById(Deposit, idOrBuffer));
+	}
+
+	@enumerable get cooldown() { return Math.max(0, this['#cooldownTime'] - Game.time); }
+	@enumerable get lastCooldown() { return this['#lastCooldown']; }
+	@enumerable get ticksToDecay() { return Math.max(0, this['#nextDecayTime'] - Game.time); }
+
+	get '#lookType'() { return C.LOOK_DEPOSITS; }
+}
+
+registerGlobal(Deposit);
+declare module 'xxscreeps/game/runtime.js' {
+	interface Global { Deposit: typeof Deposit }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const harvest = registerHarvestable(Deposit, function(creep) {
+	return chainIntentChecks(
+		() => checkCommon(creep, C.WORK),
+		() => checkTarget(this, Deposit),
+		() => checkRange(creep, this, 1),
+		() => this.cooldown === 0 ? undefined : C.ERR_TIRED);
+});
+declare module 'xxscreeps/mods/harvestable/index.js' {
+	interface Harvest { deposit: typeof harvest }
+}

--- a/packages/xxscreeps/mods/deposit/deposit.ts
+++ b/packages/xxscreeps/mods/deposit/deposit.ts
@@ -6,7 +6,6 @@ import { checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
 import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 
 export const format = declare('Deposit', () => compose(shape, Deposit));
 const shape = struct(RoomObject.format, {
@@ -19,12 +18,6 @@ const shape = struct(RoomObject.format, {
 });
 
 export class Deposit extends withOverlay(RoomObject.RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Deposit>(this, RoomObject.getById(Deposit, idOrArg1));
-	}
-
 	@enumerable get cooldown() { return Math.max(0, this['#cooldownTime'] - Game.time); }
 	@enumerable get ticksToDecay() { return Math.max(0, this['#nextDecayTime'] - Game.time); }
 

--- a/packages/xxscreeps/mods/deposit/deposit.ts
+++ b/packages/xxscreeps/mods/deposit/deposit.ts
@@ -1,4 +1,3 @@
-import type { BufferView } from 'xxscreeps/schema/index.js';
 import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, registerGlobal } from 'xxscreeps/game/index.js';
@@ -13,23 +12,20 @@ export const format = declare('Deposit', () => compose(shape, Deposit));
 const shape = struct(RoomObject.format, {
 	...variant('deposit'),
 	depositType: resourceEnumFormat,
+	lastCooldown: 'int32',
 	'#harvested': 'int32',
 	'#cooldownTime': 'int32',
-	'#lastCooldown': 'int32',
 	'#nextDecayTime': 'int32',
 });
 
 export class Deposit extends withOverlay(RoomObject.RoomObject, shape) {
 
-	constructor(id?: string);
-	constructor(buffer?: BufferView, offset?: number);
-	constructor(idOrBuffer?: BufferView | string, offset?: number) {
-		super(typeof idOrBuffer === 'string' ? undefined : idOrBuffer, offset);
-		if (typeof idOrBuffer === 'string') assign<Deposit>(this, RoomObject.getById(Deposit, idOrBuffer));
+	constructor(idOrArg1?: any, arg2?: any) {
+		super(idOrArg1, arg2);
+		if (typeof idOrArg1 === 'string') assign<Deposit>(this, RoomObject.getById(Deposit, idOrArg1));
 	}
 
 	@enumerable get cooldown() { return Math.max(0, this['#cooldownTime'] - Game.time); }
-	@enumerable get lastCooldown() { return this['#lastCooldown']; }
 	@enumerable get ticksToDecay() { return Math.max(0, this['#nextDecayTime'] - Game.time); }
 
 	get '#lookType'() { return C.LOOK_DEPOSITS; }

--- a/packages/xxscreeps/mods/deposit/game.ts
+++ b/packages/xxscreeps/mods/deposit/game.ts
@@ -1,0 +1,22 @@
+import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
+import * as Deposit from './deposit.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const depositSchema = registerVariant('Room.objects', Deposit.format);
+declare module 'xxscreeps/game/room/index.js' {
+	interface Schema { deposit: [ typeof depositSchema ] }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const find = registerFindHandlers({
+	[C.FIND_DEPOSITS]: room => room['#lookFor'](C.LOOK_DEPOSITS),
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const look = registerLook<Deposit.Deposit>()(C.LOOK_DEPOSITS);
+declare module 'xxscreeps/game/room/index.js' {
+	interface Find { deposit: typeof find }
+	interface Look { deposit: typeof look }
+}

--- a/packages/xxscreeps/mods/deposit/index.ts
+++ b/packages/xxscreeps/mods/deposit/index.ts
@@ -1,0 +1,10 @@
+import type { Manifest } from 'xxscreeps/config/mods/index.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/factory',
+		'xxscreeps/mods/harvestable',
+		'xxscreeps/mods/resource',
+	],
+	provides: [ 'backend', 'game', 'processor', 'test' ],
+};

--- a/packages/xxscreeps/mods/deposit/processor.ts
+++ b/packages/xxscreeps/mods/deposit/processor.ts
@@ -1,0 +1,35 @@
+import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import { calculatePower } from 'xxscreeps/mods/creep/creep.js';
+import { registerHarvestProcessor } from 'xxscreeps/mods/harvestable/processor.js';
+import { DEPOSIT_DECAY_TIME, DEPOSIT_EXHAUST_MULTIPLY, DEPOSIT_EXHAUST_POW } from 'xxscreeps/mods/mineral/constants.js';
+import * as Resource from 'xxscreeps/mods/resource/processor/resource.js';
+import { Deposit } from './deposit.js';
+
+registerHarvestProcessor(Deposit, (creep, deposit) => {
+	const amount = calculatePower(creep, C.WORK, C.HARVEST_DEPOSIT_POWER, 'harvest');
+	const overflow = Math.max(amount - creep.store.getFreeCapacity(deposit.depositType), 0);
+	creep.store['#add'](deposit.depositType, amount - overflow);
+	if (overflow > 0) {
+		Resource.drop(creep.pos, deposit.depositType, overflow);
+	}
+	deposit['#harvested'] += amount;
+	const cooldown = Math.ceil(DEPOSIT_EXHAUST_MULTIPLY * deposit['#harvested'] ** DEPOSIT_EXHAUST_POW);
+	deposit['#lastCooldown'] = cooldown;
+	if (cooldown > 1) {
+		deposit['#cooldownTime'] = Game.time + cooldown;
+	}
+	deposit['#nextDecayTime'] = Game.time + DEPOSIT_DECAY_TIME;
+	return amount;
+});
+
+registerObjectTickProcessor(Deposit, (deposit, context) => {
+	const nextDecayTime = deposit['#nextDecayTime'];
+	if (nextDecayTime !== 0 && Game.time >= nextDecayTime) {
+		deposit.room['#removeObject'](deposit);
+		context.didUpdate();
+	} else if (nextDecayTime !== 0) {
+		context.wakeAt(nextDecayTime);
+	}
+});

--- a/packages/xxscreeps/mods/deposit/processor.ts
+++ b/packages/xxscreeps/mods/deposit/processor.ts
@@ -16,7 +16,7 @@ registerHarvestProcessor(Deposit, (creep, deposit) => {
 	}
 	deposit['#harvested'] += amount;
 	const cooldown = Math.ceil(DEPOSIT_EXHAUST_MULTIPLY * deposit['#harvested'] ** DEPOSIT_EXHAUST_POW);
-	deposit['#lastCooldown'] = cooldown;
+	deposit.lastCooldown = cooldown;
 	if (cooldown > 1) {
 		deposit['#cooldownTime'] = Game.time + cooldown;
 	}

--- a/packages/xxscreeps/mods/deposit/test.ts
+++ b/packages/xxscreeps/mods/deposit/test.ts
@@ -1,0 +1,108 @@
+import type { PartType } from 'xxscreeps/mods/creep/creep.js';
+import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import * as RoomObject from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { DEPOSIT_DECAY_TIME, DEPOSIT_EXHAUST_MULTIPLY, DEPOSIT_EXHAUST_POW } from 'xxscreeps/mods/mineral/constants.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { Deposit } from './deposit.js';
+
+interface DepositSimOptions {
+	body?: PartType[];
+	cooldownTicks?: number;
+	decayTicks?: number;
+	harvested?: number;
+}
+
+function createDeposit(pos: RoomPosition, depositType: ResourceType, harvested: number, nextDecayTime: number) {
+	const deposit = RoomObject.create(new Deposit(), pos);
+	deposit.depositType = depositType;
+	deposit['#harvested'] = harvested;
+	deposit['#cooldownTime'] = 0;
+	deposit['#lastCooldown'] = 0;
+	deposit['#nextDecayTime'] = nextDecayTime;
+	return deposit;
+}
+
+function cooldown(harvested: number) {
+	return Math.ceil(DEPOSIT_EXHAUST_MULTIPLY * harvested ** DEPOSIT_EXHAUST_POW);
+}
+
+function depositSim(options: DepositSimOptions = {}) {
+	return simulate({
+		W1N1: room => {
+			const deposit = createDeposit(
+				new RoomPosition(25, 25, 'W1N1'),
+				C.RESOURCE_SILICON,
+				options.harvested ?? 0,
+				Game.time + (options.decayTicks ?? 100),
+			);
+			deposit['#cooldownTime'] = options.cooldownTicks === undefined ? 0 : Game.time + options.cooldownTicks;
+			room['#insertObject'](deposit);
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 26, 'W1N1'),
+				options.body ?? [ C.WORK, C.CARRY, C.MOVE ],
+				'harvester',
+				'100'));
+		},
+	});
+}
+
+describe('Deposit', () => {
+	test('harvest stores resources and updates cooldown curve', () => depositSim({
+		body: [ C.WORK, C.WORK, C.WORK, C.CARRY, C.MOVE ],
+		harvested: 997,
+	})(async ({ player, poke, tick }) => {
+		await player('100', Game => {
+			const deposit = Game.rooms.W1N1.find(C.FIND_DEPOSITS)[0];
+			assert.strictEqual(Game.creeps.harvester.harvest(deposit), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.harvester.store[C.RESOURCE_SILICON], 3);
+		});
+		await poke('W1N1', '100', (_Game, room) => {
+			const deposit = room['#lookFor'](C.LOOK_DEPOSITS)[0];
+			assert.strictEqual(deposit.lastCooldown, cooldown(1000));
+			assert.strictEqual(deposit.cooldown, cooldown(1000));
+		});
+	}));
+
+	test('harvest returns ERR_TIRED while cooling', () => depositSim({
+		cooldownTicks: 1000,
+	})(async ({ player, tick }) => {
+		await player('100', Game => {
+			const deposit = Game.rooms.W1N1.find(C.FIND_DEPOSITS)[0];
+			assert.strictEqual(Game.creeps.harvester.harvest(deposit), C.ERR_TIRED);
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.harvester.store[C.RESOURCE_SILICON], 0);
+		});
+	}));
+
+	test('deposit is deleted when decay time expires', () => depositSim({
+		decayTicks: 2,
+	})(async ({ player, tick }) => {
+		await tick(2);
+		await player('100', Game => {
+			assert.strictEqual(Game.rooms.W1N1.find(C.FIND_DEPOSITS).length, 0);
+		});
+	}));
+
+	test('harvest refreshes decay time', () => depositSim({
+		decayTicks: 5,
+	})(async ({ player, tick }) => {
+		await player('100', Game => {
+			const deposit = Game.rooms.W1N1.find(C.FIND_DEPOSITS)[0];
+			assert.strictEqual(Game.creeps.harvester.harvest(deposit), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const deposit = Game.rooms.W1N1.find(C.FIND_DEPOSITS)[0];
+			assert.strictEqual(deposit.ticksToDecay, DEPOSIT_DECAY_TIME);
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/deposit/test.ts
+++ b/packages/xxscreeps/mods/deposit/test.ts
@@ -21,7 +21,7 @@ function createDeposit(pos: RoomPosition, depositType: ResourceType, harvested: 
 	deposit.depositType = depositType;
 	deposit['#harvested'] = harvested;
 	deposit['#cooldownTime'] = 0;
-	deposit['#lastCooldown'] = 0;
+	deposit.lastCooldown = 0;
 	deposit['#nextDecayTime'] = nextDecayTime;
 	return deposit;
 }


### PR DESCRIPTION
## Summary
- Add `xxscreeps/mods/deposit` with Deposit object registration, find/look support, backend rendering, harvest processing, cooldown tracking, and decay removal.
- Add Deposit to the classic mod set and depend on factory for deposit resource registration.
- Add internal Deposit tests and a patch changeset.

## Scope
- This PR implements the seeded Deposit engine surface exercised by the existing screeps-ok catalog.
- Highway deposit generation, stronghold deposit loot, power creep deposit interactions, and screeps-ok post-merge adapter/docs updates are left for follow-up work.
- Constants/resource enum cleanup is intentionally deferred so this diff stays focused on Deposit behavior. The current import/dependency path is covered by build, unit tests, and screeps-ok xxscreeps parity.

## Testing
- `npm run build`
- `npm test -- Deposit`
- `npm test`
- `screeps-ok`:
  - `1161/1342 passed, 18 expected failures, 163 skipped`
  - Deposit-related cases passed: `DEPOSIT-*`, `DEPOSIT-HARVEST-*`, `SHAPE-DEPOSIT-001`