### PR TITLE
Add `xxscreeps cli` read-only console

### DIFF
--- a/.changeset/cli-foundation.md
+++ b/.changeset/cli-foundation.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `xxscreeps cli` read-only console with optional `-e <expression>` one-shot eval.

--- a/packages/xxscreeps/config/entry.ts
+++ b/packages/xxscreeps/config/entry.ts
@@ -68,6 +68,7 @@ if (missingFlags.length) {
 			start: './dist/engine/service/launcher.js',
 			main: './dist/engine/service/main.js',
 			backend: './dist/backend/server.js',
+			cli: './dist/mods/cli/cli.js',
 			processor: './dist/engine/service/processor.js',
 			runner: './dist/engine/service/runner.js',
 			'save-schema': './dist/engine/service/save-schema.js',

--- a/packages/xxscreeps/mods/cli/cli.ts
+++ b/packages/xxscreeps/mods/cli/cli.ts
@@ -1,0 +1,76 @@
+import * as repl from 'node:repl';
+import { inspect } from 'node:util';
+import { ArgumentParser } from 'argparse';
+import config from 'xxscreeps/config/index.js';
+import { importMods } from 'xxscreeps/config/mods/index.js';
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { GameState, hooks, initializeGameEnvironment } from 'xxscreeps/game/index.js';
+import { evaluate } from './evaluate.js';
+
+interface Argv {
+	eval?: string;
+}
+
+const parser = new ArgumentParser({
+	prog: 'xxscreeps cli',
+	description: 'Read-only console attached to the configured shard',
+});
+parser.add_argument('-e', '--eval', {
+	dest: 'eval',
+	help: 'Evaluate <expression> and exit',
+	metavar: '<expression>',
+});
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const argv: Argv = parser.parse_args();
+
+// Connect to the configured DB and shard. `Database.connect` transparently routes through the
+// launcher's responder socket when one is running; otherwise this CLI process holds the lock.
+using db = await Database.connect();
+using shard = await Shard.connect(db, config.shards[0].name);
+
+// Materialize the runtime environment. `initializeGameEnvironment` runs the engine-wide
+// `environment` hook chain. Then we fire `runtimeConnector.initialize` for every mod with an
+// empty payload — that populates globalThis with player constants, class globals, and lodash.
+// `Memory` is wired in `runtimeConnector.receive`, which we never fire, so it stays absent.
+await importMods('game');
+initializeGameEnvironment();
+for (const hook of hooks.map('runtimeConnector')) {
+	hook.initialize?.({} as never);
+}
+
+// Snapshot the committed shard. Every committed room is loaded so admins see the full world,
+// not a per-user view. The snapshot is taken once at startup; later ticks won't appear in the
+// session until you reconnect.
+const world = await shard.loadWorld();
+const roomNames = await shard.data.smembers('rooms');
+const rooms = await Promise.all(Fn.map(roomNames, name => shard.loadRoom(name)));
+const state = new GameState(world, shard.time, rooms);
+
+if (argv.eval === undefined) {
+	const server = repl.start({
+		prompt: 'xxscreeps> ',
+		useGlobal: true,
+		eval(cmd, _context, _filename, callback) {
+			if (cmd.trim() === '') {
+				callback(null, undefined);
+				return;
+			}
+			evaluate(state, cmd).then(
+				value => callback(null, value),
+				err => callback(err as Error, null));
+		},
+	});
+	server.on('exit', () => process.exit(0));
+} else {
+	let exitCode = 0;
+	try {
+		const result = await evaluate(state, argv.eval);
+		process.stdout.write(`${inspect(result)}\n`);
+	} catch (err) {
+		const message = err instanceof Error ? err.stack ?? err.message : String(err);
+		process.stderr.write(`${message}\n`);
+		exitCode = 1;
+	}
+	process.exit(exitCode);
+}

--- a/packages/xxscreeps/mods/cli/evaluate.ts
+++ b/packages/xxscreeps/mods/cli/evaluate.ts
@@ -1,0 +1,45 @@
+import type { GameConstructor, GameState } from 'xxscreeps/game/index.js';
+import * as vm from 'node:vm';
+import { runForUser } from 'xxscreeps/game/index.js';
+
+function compile(source: string): vm.Script {
+	// Try direct script compilation first. This keeps `var` declarations on globalThis so they
+	// persist across REPL turns, mirroring node:repl's default behavior. The retries below run
+	// only if direct compile fails (typically top-level `await`); execution never runs twice.
+	try {
+		return new vm.Script(source, { filename: 'cli' });
+	} catch (err) {
+		if (!(err instanceof SyntaxError)) {
+			throw err;
+		}
+	}
+	try {
+		return new vm.Script(`(async()=>(${source}\n))()`, { filename: 'cli' });
+	} catch (err) {
+		if (!(err instanceof SyntaxError)) {
+			throw err;
+		}
+	}
+	return new vm.Script(`(async()=>{${source}\n})()`, { filename: 'cli' });
+}
+
+/**
+ * Compile and evaluate `source` against a snapshot of committed shard state. Each call enters a
+ * fresh `runForUser` scope with no userId, so per-user collections (`Game.creeps`, `Game.spawns`,
+ * ...) come back empty while `Game.rooms` reflects every committed room. The expression's promise
+ * is resolved outside the runtime scope, so any engine accessor used after `await` sees module
+ * state reset.
+ */
+export function evaluate(state: GameState, source: string): Promise<unknown> {
+	const script = compile(source);
+	const [ , result ] = runForUser('', state, (Game: GameConstructor) => {
+		Object.defineProperty(globalThis, 'Game', {
+			configurable: true,
+			enumerable: true,
+			writable: true,
+			value: Game,
+		});
+		return script.runInThisContext() as unknown;
+	});
+	return Promise.resolve(result);
+}

--- a/packages/xxscreeps/mods/cli/test.ts
+++ b/packages/xxscreeps/mods/cli/test.ts
@@ -1,0 +1,31 @@
+import { inspect } from 'node:util';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { GameState, hooks, initializeGameEnvironment } from 'xxscreeps/game/index.js';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { evaluate } from './evaluate.js';
+import 'xxscreeps/config/mods/import/game.js';
+
+initializeGameEnvironment();
+for (const hook of hooks.map('runtimeConnector')) {
+	hook.initialize?.({} as never);
+}
+
+describe('cli', () => {
+	test('xxscreeps cli -e runs the expression against committed shard state', async () => {
+		using testShard = await instantiateTestShard();
+		const { shard, world } = testShard;
+		const roomNames = await shard.data.smembers('rooms');
+		const rooms = await Promise.all(Fn.map(roomNames, name => shard.loadRoom(name)));
+		const state = new GameState(world, shard.time, rooms);
+
+		// Proof: globalThis-resident constant + a room.find that walks blob-overlay state.
+		// W1N1 is seeded with two `E` tiles in test/data/shard.json.
+		const sourceCount = await evaluate(state, "Game.rooms['W1N1'].find(FIND_SOURCES).length");
+		assert.strictEqual(sourceCount, 2);
+
+		// Inspect formatting matches the one-shot stdout exactly.
+		const printed = await evaluate(state, "Object.keys(Game.rooms).filter(name => name === 'W1N1')");
+		assert.strictEqual(inspect(printed), "[ 'W1N1' ]");
+	});
+});

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -2,6 +2,7 @@ import { importMods } from 'xxscreeps/config/mods/index.js';
 import { flush, summary } from './context.js';
 import './import.js';
 import 'xxscreeps/game/test.js';
+import 'xxscreeps/mods/cli/test.js';
 
 await importMods('test');
 try {


### PR DESCRIPTION
First small slice after #137. Adds `xxscreeps cli`: a launcher-owned, read-only console that connects directly to the configured DB/shard via the inter-process provider shape from 6c5d8ca9, materializes the runtime sandbox (`importMods('game')` + `initializeGameEnvironment` + `runtimeConnector.initialize`), and exposes an admin-global `Game` to either a `node:repl` REPL or `xxscreeps cli -e "<expression>"` one-shot eval. Output uses default Node inspection. `Memory` stays absent — its install lives in `runtimeConnector.receive`, which we never fire.

## What's in

- `xxscreeps cli` and `xxscreeps cli -e <expression>` (argparse via `argparse`, no hand-rolled argv).
- Direct `Database.connect()` + `Shard.connect()`. Falls through to the launcher's responder socket transparently when one is running.
- Per-eval `runForUser('', state, …)` so admin-global `Game.rooms` is full and per-user collections (`Game.creeps`, `Game.spawns`, …) are empty.
- `evaluate.compile` tries direct script compilation first so `var` persists across REPL turns; falls back to async-IIFE wrappers only on `SyntaxError` (top-level `await`, `return` fragments). No double-execution.
- One focused E2E test: seed test shard → `evaluate(state, "Game.rooms['W1N1'].find(FIND_SOURCES).length")` → assert `2`.

## What's NOT in

- Admin command groups (`system.*`, `users.*`, `bots.*`, `map.*`, …).
- Offline mode as a feature (the host-mode fall-through is a side effect of the DB shape, not advertised).
- Sockets / wire protocol / cli-server.
- Terrain reload, importWorld plumbing, cross-process cache invalidation.
- Mutation support, write semantics, tick-boundary or pause coordination.
- Command schemas, structured/JSON output, admin CLI flag translation.
- Hand-rolled argv parsing.

Future slices in this refactor will layer on those one at a time; the goal here is to land the foundation cleanly.

## Verification

- `pnpm run build` clean.
- `pnpm test` — 198/198 (one new test under `cli`).
- `eslint` — zero new warnings on changed files; pre-existing repo-wide warning count unchanged.
- Live against a seeded shard: `Game.time`, `Game.rooms['W1N1'].find(FIND_SOURCES)`, `typeof Memory` → `'undefined'`, `await Promise.resolve(Game.time)`, REPL `var room = …; room.find(…)` all behave as expected. Errors print to stderr and exit `1`.