### PR TITLE
Fix Redis pubsub unsubscribe leak

### DIFF
--- a/.changeset/redis-unsubscribe-leak.md
+++ b/.changeset/redis-unsubscribe-leak.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/redis": patch
+---
+
+Send `UNSUBSCRIBE` when the last local pubsub subscriber disconnects.

--- a/.changeset/redis-unsubscribe-leak.md
+++ b/.changeset/redis-unsubscribe-leak.md
@@ -1,5 +1,0 @@
----
-"@xxscreeps/redis": patch
----
-
-Send `UNSUBSCRIBE` when the last local pubsub subscriber disconnects.

--- a/packages/redis/pubsub.ts
+++ b/packages/redis/pubsub.ts
@@ -1,4 +1,5 @@
 import type { PubSubListener, PubSubProvider, PubSubSubscription } from 'xxscreeps/engine/db/storage/provider.js';
+import { mustNotReject } from 'xxscreeps/utility/async.js';
 import { RedisHolder } from './client.js';
 
 export class RedisPubSubProvider implements PubSubProvider {
@@ -77,6 +78,8 @@ export class RedisPubSubProvider implements PubSubProvider {
 		const subscribers = this.subscribersByKey.get(key)!;
 		if (subscribers.size === 1) {
 			this.subscribersByKey.delete(key);
+			this.publishIgnore.delete(key);
+			mustNotReject(this.listener.invoke(cb => this.listener.batch().unsubscribe(key, cb)));
 		} else {
 			subscribers.delete(subscriber);
 		}


### PR DESCRIPTION
## Summary

Redis pubsub now sends `UNSUBSCRIBE` when the last local subscriber for a key disconnects.

Previously `RedisPubSubProvider.unsubscribe()` only updated the local `subscribersByKey` map. That preserved local dispatch behavior, but left the Redis listener connection subscribed server-side, so Redis would keep delivering messages for channels with no local subscribers.

This patch:
- removes the local subscriber state when the last subscriber disconnects
- clears pending `publishIgnore` entries for that key
- sends Redis `UNSUBSCRIBE` via `mustNotReject()` because subscription cleanup is exposed as a synchronous `Effect`