### PR TITLE
Fix Redis ZADD INCR null handling

### DIFF
--- a/.changeset/redis-zadd-incr-null.md
+++ b/.changeset/redis-zadd-incr-null.md
@@ -1,5 +1,0 @@
----
-"@xxscreeps/redis": patch
----
-
-Fix `ZADD INCR` null reply handling.

--- a/.changeset/redis-zadd-incr-null.md
+++ b/.changeset/redis-zadd-incr-null.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/redis": patch
+---
+
+Fix `ZADD INCR` null reply handling.

--- a/packages/redis/keyval.ts
+++ b/packages/redis/keyval.ts
@@ -224,14 +224,13 @@ export class RedisProvider implements P.KeyValProvider {
 		if (members.length === 0) {
 			return Promise.resolve(0);
 		} else if (options?.incr) {
+			type CallbackType = (err: Error | null, value: unknown) => void;
 			const result = await this.redis.invoke<Buffer | string | null>(cb => this.redis.batch(key).zadd(
 				key,
 				...options.if ? [ options.if ] : [],
 				'incr',
-				...Fn.concat<number | string>(members),
-				(err, result) => {
-					cb(err, result as unknown as Buffer | string | null);
-				}));
+				...Fn.concat<string | number>(members),
+				cb as CallbackType));
 			return result === null ? null : Number(send(result));
 		} else {
 			const result = await this.redis.invoke<number>(cb => this.redis.batch(key).zadd(

--- a/packages/redis/keyval.ts
+++ b/packages/redis/keyval.ts
@@ -218,17 +218,28 @@ export class RedisProvider implements P.KeyValProvider {
 
 	//
 	// sorted sets
+	zadd(key: string, members: [ number, string ][], options: { incr: true } & P.ZAdd): Promise<number | null>;
+	zadd(key: string, members: [ number, string ][], options?: P.ZAdd): Promise<number>;
 	async zadd(key: string, members: [ number, string ][], options?: P.ZAdd) {
 		if (members.length === 0) {
 			return Promise.resolve(0);
+		} else if (options?.incr) {
+			const result = await this.redis.invoke<Buffer | string | null>(cb => this.redis.batch(key).zadd(
+				key,
+				...options.if ? [ options.if ] : [],
+				'incr',
+				...Fn.concat<number | string>(members),
+				(err, result) => {
+					cb(err, result as unknown as Buffer | string | null);
+				}));
+			return result === null ? null : Number(send(result));
 		} else {
 			const result = await this.redis.invoke<number>(cb => this.redis.batch(key).zadd(
 				key,
 				...options?.if ? [ options.if ] : [],
-				...options?.incr ? [ 'incr' ] : [],
 				...Fn.concat<number | string>(members),
 				cb));
-			return options?.incr ? Number(send(result)) : result;
+			return result;
 		}
 	}
 


### PR DESCRIPTION
Redis `ZADD ... INCR` returns nil/null when conditional options like `XX` or `NX` prevent an update.

The xxscreeps processor scheduling path relies on distinguishing that skipped update from a successful zero-count update: `publishRunnerIntentsForRooms()` checks for `count === null`.

`RedisProvider.zadd()` was converting the Redis reply with `Number(send(result))`, which coerced `null` to `0`. This preserves `null` for `INCR` replies and only converts non-null score replies to numbers. Regular non-`INCR` `ZADD` behavior is unchanged.

Verification:
- `pnpm exec tsc -b packages/redis`
- `git diff --check`
- `pnpm exec eslint packages/redis/keyval.ts`