### PR TITLE
Fix client Steam package discovery

### DIFF
--- a/.changeset/client-package-nw-discovery.md
+++ b/.changeset/client-package-nw-discovery.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/client": patch
+---
+
+Auto-locate `package.nw` across Steam install locations and secondary library folders.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -47,6 +47,14 @@ mods:
 
 After that you can now visit: http://localhost:21025/.
 
+The client automatically looks for Steam's Screeps `package.nw` in the default Steam library
+locations on macOS, Windows, and Linux, including secondary libraries from `libraryfolders.vdf`. If
+your install lives somewhere else, set the path explicitly:
+```
+browserClient:
+  package: /full/path/to/package.nw
+```
+
 ## Tips
 This client makes use of "guest mode" which is enabled by default in xxscreeps. This will provide
 you with a read-only view of the server when you are not signed in. The client will show you as

--- a/packages/client/backend.ts
+++ b/packages/client/backend.ts
@@ -1,35 +1,16 @@
 import type { Schema } from './config.js';
-import { promises as fs } from 'node:fs';
-import * as os from 'node:os';
 import { Transform } from 'node:stream';
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import JSZip from 'jszip';
 import { hooks } from 'xxscreeps/backend/index.js';
 import config from 'xxscreeps/config/index.js';
+import { findClientPackage, packageNotFoundMessage } from './package-nw.js';
 
 // Locate and read `package.nw`
-const { data, stat } = await async function() {
-	const path = (config as Schema).browserClient?.package ?? function() {
-		switch (process.platform) {
-			case 'darwin': return new URL('./Library/Application Support/Steam/steamapps/common/Screeps/package.nw', `${pathToFileURL(os.homedir())}/`);
-			case 'win32': return 'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Screeps\\package.nw';
-			default: return new URL('./.steam/steam/SteamApps/common/Screeps/package.nw', `${pathToFileURL(os.homedir())}/`);
-		}
-	}();
-	try {
-		const [ data, stat ] = await Promise.all([
-			fs.readFile(path),
-			fs.stat(path),
-		]);
-		return { data, stat };
-	} catch {}
-	console.error(
-		`@xxscreeps/client error: Could not read \`${fileURLToPath(path)}\`. ` +
-		'Please set `browserClient.package` in `.screepsrc.yaml` to the full path of your package.nw file');
-	return {};
-}();
-
-if (data) {
+const { attemptedPaths, clientPackage } = await findClientPackage((config as Schema).browserClient?.package);
+if (clientPackage === undefined) {
+	console.error(packageNotFoundMessage(attemptedPaths));
+} else {
+	const { data, stat } = clientPackage;
 	// Read package zip metadata
 	const zip = new JSZip();
 	await zip.loadAsync(data);

--- a/packages/client/config.schema.json
+++ b/packages/client/config.schema.json
@@ -9,7 +9,7 @@
             "description": "Configuration for '@xxscreeps/client'",
             "properties": {
                 "package": {
-                    "description": "Full path to `package.nw`. This has the following defaults:\nmacOS: ~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw\nWindows: C:\\Program Files (x86)\\Steam\\steamapps\\common\\Screeps\\package.nw",
+                    "description": "Full path to `package.nw`. If unset, @xxscreeps/client searches Steam's default library roots and `libraryfolders.vdf` for Screeps.",
                     "type": "string"
                 }
             },

--- a/packages/client/config.ts
+++ b/packages/client/config.ts
@@ -5,9 +5,8 @@ export type Schema = {
 	 */
 	browserClient?: {
 		/**
-		 * Full path to `package.nw`. This has the following defaults:
-		 * macOS: ~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw
-		 * Windows: C:\Program Files (x86)\Steam\steamapps\common\Screeps\package.nw
+		 * Full path to `package.nw`. If unset, @xxscreeps/client searches Steam's default
+		 * library roots and `libraryfolders.vdf` for Screeps.
 		 */
 		package?: string;
 	};

--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -1,5 +1,5 @@
 import type { Manifest } from 'xxscreeps/config/mods/index.js';
 
 export const manifest: Manifest = {
-	provides: [ 'backend', 'config' ],
+	provides: [ 'backend', 'config', 'test' ],
 };

--- a/packages/client/package-nw.ts
+++ b/packages/client/package-nw.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as Path from 'node:path';
+import { parse as parseVdf } from '@node-steam/vdf';
+import { Fn } from 'xxscreeps/functional/fn.js';
+
+export interface ClientPackage {
+	data: Buffer;
+	path: string;
+	stat: Awaited<ReturnType<typeof fs.stat>>;
+}
+
+export interface PackageSearchResult {
+	attemptedPaths: string[];
+	clientPackage: ClientPackage | undefined;
+}
+
+export interface DiscoveryOptions {
+	env?: NodeJS.ProcessEnv;
+	home?: string;
+	platform?: NodeJS.Platform;
+	readTextFile?: (path: string) => Promise<string>;
+}
+
+interface PlatformPath {
+	isAbsolute: (path: string) => boolean;
+	join: (...paths: string[]) => string;
+}
+
+const steamAppsDirectories = [ 'steamapps', 'SteamApps' ];
+
+function pathForPlatform(platform: NodeJS.Platform): PlatformPath {
+	return platform === 'win32' ? Path.win32 : Path.posix;
+}
+
+function defaultSteamRoots(options: DiscoveryOptions): string[] {
+	const platform = options.platform ?? process.platform;
+	const path = pathForPlatform(platform);
+	const home = options.home ?? os.homedir();
+	const env = options.env ?? process.env;
+	if (platform === 'darwin') {
+		return [ path.join(home, 'Library', 'Application Support', 'Steam') ];
+	}
+	if (platform === 'win32') {
+		return [
+			path.join(env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)', 'Steam'),
+			path.join(env.ProgramFiles ?? 'C:\\Program Files', 'Steam'),
+		];
+	}
+	return [
+		path.join(home, '.steam', 'steam'),
+		path.join(home, '.local', 'share', 'Steam'),
+		path.join(home, '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
+	];
+}
+
+function packagePathsForLibrary(platformPath: PlatformPath, library: string): string[] {
+	return steamAppsDirectories.map(
+		steamApps => platformPath.join(library, steamApps, 'common', 'Screeps', 'package.nw'),
+	);
+}
+
+function parseLibraryFoldersVdf(data: string, path: PlatformPath): string[] {
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = parseVdf(data) as Record<string, unknown>;
+	} catch {
+		return [];
+	}
+	const root = (parsed.LibraryFolders ?? parsed.libraryfolders) as Record<string, unknown> | undefined;
+	if (root === undefined) return [];
+	// Legacy `LibraryFolders` keyed digits to bare path strings; modern
+	// `libraryfolders` keys digits to objects whose `path` field carries the
+	// library root alongside other metadata.
+	const libraries = Object.values(root).flatMap(value => {
+		if (typeof value === 'string') return [ value ];
+		if (typeof value === 'object' && value !== null && 'path' in value && typeof value.path === 'string') {
+			return [ value.path ];
+		}
+		return [];
+	});
+	return [ ...new Set(libraries) ].filter(library => path.isAbsolute(library));
+}
+
+async function discoverSteamLibraries(steamRoot: string, platformPath: PlatformPath, options: DiscoveryOptions): Promise<string[]> {
+	const readTextFile = options.readTextFile ?? ((path: string) => fs.readFile(path, 'utf8'));
+	const libraries = await Fn.mapAwait(steamAppsDirectories, async steamApps => {
+		try {
+			const data = await readTextFile(platformPath.join(steamRoot, steamApps, 'libraryfolders.vdf'));
+			return parseLibraryFoldersVdf(data, platformPath);
+		} catch {
+			return [];
+		}
+	});
+	return [ ...new Set(libraries.flat()) ];
+}
+
+export async function discoverPackagePaths(options: DiscoveryOptions = {}): Promise<string[]> {
+	const platform = options.platform ?? process.platform;
+	const path = pathForPlatform(platform);
+	const roots = defaultSteamRoots(options);
+	const secondaryLists = await Fn.mapAwait(roots, steamRoot => discoverSteamLibraries(steamRoot, path, options));
+	const libraries = [ ...new Set([ ...roots, ...secondaryLists.flat() ]) ];
+	return [ ...new Set(libraries.flatMap(library => packagePathsForLibrary(path, library))) ];
+}
+
+export function packageNotFoundMessage(attemptedPaths: string[]): string {
+	const locations = attemptedPaths.length === 0
+		? [ 'Attempted locations: none' ]
+		: [ 'Attempted locations:', ...attemptedPaths.map(path => `  - ${path}`) ];
+	return [
+		'@xxscreeps/client error: Could not locate Screeps `package.nw`.',
+		...locations,
+		'Please set `browserClient.package` in `.screepsrc.yaml` to the full path of your package.nw file:',
+		'browserClient:',
+		'  package: /full/path/to/package.nw',
+	].join('\n');
+}
+
+export async function findClientPackage(configuredPath: string | undefined, options: DiscoveryOptions = {}): Promise<PackageSearchResult> {
+	const attemptedPaths = configuredPath === undefined
+		? await discoverPackagePaths(options)
+		: [ configuredPath ];
+	for (const path of attemptedPaths) {
+		try {
+			const [ data, stat ] = await Promise.all([
+				fs.readFile(path),
+				fs.stat(path),
+			]);
+			return {
+				attemptedPaths,
+				clientPackage: { data, path, stat },
+			};
+		} catch {}
+	}
+	return { attemptedPaths, clientPackage: undefined };
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,7 +8,9 @@
     "./*": "./dist/*"
   },
   "dependencies": {
-    "jszip": "^3.6.0"
+    "@node-steam/vdf": "^2.2.0",
+    "jszip": "^3.6.0",
+    "tslib": "~2.8.1"
   },
   "devDependencies": {
     "@types/jszip": "^3.4.1",

--- a/packages/client/test.ts
+++ b/packages/client/test.ts
@@ -80,13 +80,13 @@ describe('@xxscreeps/client package discovery', () => {
 			},
 			readTextFile: path => path === libraryFolders
 				? Promise.resolve(libraryFoldersVdf(secondaryLibrary))
-				: Promise.reject(new Error(`Unexpected read: ${path}`)),
+				: Promise.reject(new Error('ENOENT')),
 		});
 		assert.ok(paths.includes(packagePath(Path.win32, secondaryLibrary, 'steamapps')));
 		assert.ok(paths.includes(packagePath(Path.win32, secondaryLibrary, 'SteamApps')));
 	});
 
-	test('discovers Linux defaults and lowercase steamapps secondary libraries', async () => {
+	test('discovers Linux Steam roots and libraryfolders.vdf secondaries', async () => {
 		await using tmp = await temporaryHome();
 		const steamRoot = Path.posix.join(tmp.home, '.steam', 'steam');
 		const secondaryLibrary = Path.posix.join(tmp.home, 'SteamLibrary');
@@ -113,12 +113,8 @@ describe('@xxscreeps/client package discovery', () => {
 	});
 
 	test('configured package path is attempted exactly', async () => {
-		await using tmp = await temporaryHome();
 		const configuredPath = 'D:\\Games\\Screeps\\package.nw';
-		const result = await findClientPackage(configuredPath, {
-			platform: 'linux',
-			home: tmp.home,
-		});
+		const result = await findClientPackage(configuredPath);
 		assert.strictEqual(result.clientPackage, undefined);
 		assert.deepStrictEqual(result.attemptedPaths, [ configuredPath ]);
 	});

--- a/packages/client/test.ts
+++ b/packages/client/test.ts
@@ -1,0 +1,169 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as Path from 'node:path';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { discoverPackagePaths, findClientPackage, packageNotFoundMessage } from './package-nw.js';
+
+interface PathJoiner {
+	join: (...paths: string[]) => string;
+}
+
+interface TemporaryHome {
+	home: string;
+	[Symbol.asyncDispose]: () => Promise<void>;
+}
+
+async function temporaryHome(): Promise<TemporaryHome> {
+	const home = await mkdtemp(Path.join(os.tmpdir(), 'xxscreeps-client-home-'));
+	return {
+		home,
+		async [Symbol.asyncDispose]() {
+			await rm(home, { recursive: true, force: true });
+		},
+	};
+}
+
+function packagePath(path: PathJoiner, library: string, steamApps: string) {
+	return path.join(library, steamApps, 'common', 'Screeps', 'package.nw');
+}
+
+function libraryFoldersVdf(library: string) {
+	return `"libraryfolders"
+{
+  "1"
+  {
+    "path"    "${library.replace(/\\/g, '\\\\')}"
+  }
+}`;
+}
+
+describe('@xxscreeps/client package discovery', () => {
+
+	test('discovers macOS default Steam library paths', async () => {
+		await using tmp = await temporaryHome();
+		const library = Path.posix.join(tmp.home, 'Library', 'Application Support', 'Steam');
+		assert.deepStrictEqual(await discoverPackagePaths({ platform: 'darwin', home: tmp.home }), [
+			packagePath(Path.posix, library, 'steamapps'),
+			packagePath(Path.posix, library, 'SteamApps'),
+		]);
+	});
+
+	test('discovers Windows Program Files Steam library paths', async () => {
+		const programFilesX86 = 'C:\\Program Files (x86)';
+		const programFiles = 'C:\\Program Files';
+		assert.deepStrictEqual(await discoverPackagePaths({
+			platform: 'win32',
+			home: 'C:\\Users\\Test',
+			env: {
+				'ProgramFiles(x86)': programFilesX86,
+				ProgramFiles: programFiles,
+			},
+		}), [
+			packagePath(Path.win32, Path.win32.join(programFilesX86, 'Steam'), 'steamapps'),
+			packagePath(Path.win32, Path.win32.join(programFilesX86, 'Steam'), 'SteamApps'),
+			packagePath(Path.win32, Path.win32.join(programFiles, 'Steam'), 'steamapps'),
+			packagePath(Path.win32, Path.win32.join(programFiles, 'Steam'), 'SteamApps'),
+		]);
+	});
+
+	test('discovers Steam secondary libraries from Windows libraryfolders.vdf', async () => {
+		const programFilesX86 = 'C:\\Program Files (x86)';
+		const steamRoot = Path.win32.join(programFilesX86, 'Steam');
+		const secondaryLibrary = 'D:\\SteamLibrary';
+		const libraryFolders = Path.win32.join(steamRoot, 'steamapps', 'libraryfolders.vdf');
+		const paths = await discoverPackagePaths({
+			platform: 'win32',
+			home: 'C:\\Users\\Test',
+			env: {
+				'ProgramFiles(x86)': programFilesX86,
+				ProgramFiles: 'C:\\Program Files',
+			},
+			readTextFile: path => path === libraryFolders
+				? Promise.resolve(libraryFoldersVdf(secondaryLibrary))
+				: Promise.reject(new Error(`Unexpected read: ${path}`)),
+		});
+		assert.ok(paths.includes(packagePath(Path.win32, secondaryLibrary, 'steamapps')));
+		assert.ok(paths.includes(packagePath(Path.win32, secondaryLibrary, 'SteamApps')));
+	});
+
+	test('discovers Linux defaults and lowercase steamapps secondary libraries', async () => {
+		await using tmp = await temporaryHome();
+		const steamRoot = Path.posix.join(tmp.home, '.steam', 'steam');
+		const secondaryLibrary = Path.posix.join(tmp.home, 'SteamLibrary');
+		await mkdir(Path.posix.join(steamRoot, 'steamapps'), { recursive: true });
+		await writeFile(
+			Path.posix.join(steamRoot, 'steamapps', 'libraryfolders.vdf'),
+			libraryFoldersVdf(secondaryLibrary),
+		);
+
+		const paths = await discoverPackagePaths({ platform: 'linux', home: tmp.home });
+		assert.ok(paths.includes(packagePath(Path.posix, steamRoot, 'steamapps')));
+		assert.ok(paths.includes(packagePath(Path.posix, steamRoot, 'SteamApps')));
+		assert.ok(paths.includes(packagePath(
+			Path.posix,
+			Path.posix.join(tmp.home, '.local', 'share', 'Steam'),
+			'steamapps',
+		)));
+		assert.ok(paths.includes(packagePath(
+			Path.posix,
+			Path.posix.join(tmp.home, '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
+			'steamapps',
+		)));
+		assert.ok(paths.includes(packagePath(Path.posix, secondaryLibrary, 'steamapps')));
+	});
+
+	test('configured package path is attempted exactly', async () => {
+		await using tmp = await temporaryHome();
+		const configuredPath = 'D:\\Games\\Screeps\\package.nw';
+		const result = await findClientPackage(configuredPath, {
+			platform: 'linux',
+			home: tmp.home,
+		});
+		assert.strictEqual(result.clientPackage, undefined);
+		assert.deepStrictEqual(result.attemptedPaths, [ configuredPath ]);
+	});
+
+	test('findClientPackage returns the first readable discovered package', async () => {
+		await using tmp = await temporaryHome();
+		const expectedPath = packagePath(Path.posix, Path.posix.join(tmp.home, '.steam', 'steam'), 'steamapps');
+		await mkdir(Path.dirname(expectedPath), { recursive: true });
+		await writeFile(expectedPath, 'package');
+
+		const result = await findClientPackage(undefined, { platform: 'linux', home: tmp.home });
+		const { clientPackage } = result;
+		if (clientPackage === undefined) {
+			throw new Error('Expected to find package.nw');
+		}
+		assert.strictEqual(clientPackage.path, expectedPath);
+		assert.deepStrictEqual(clientPackage.data, Buffer.from('package'));
+	});
+
+	test('findClientPackage loads package.nw from a secondary Steam library', async () => {
+		await using tmp = await temporaryHome();
+		const steamRoot = Path.posix.join(tmp.home, '.steam', 'steam');
+		const secondaryLibrary = Path.posix.join(tmp.home, 'SteamLibrary');
+		const libraryFolders = Path.posix.join(steamRoot, 'steamapps', 'libraryfolders.vdf');
+		const expectedPath = packagePath(Path.posix, secondaryLibrary, 'steamapps');
+		await mkdir(Path.dirname(libraryFolders), { recursive: true });
+		await mkdir(Path.dirname(expectedPath), { recursive: true });
+		await writeFile(libraryFolders, libraryFoldersVdf(secondaryLibrary));
+		await writeFile(expectedPath, 'secondary package');
+
+		const result = await findClientPackage(undefined, { platform: 'linux', home: tmp.home });
+		const { clientPackage } = result;
+		if (clientPackage === undefined) {
+			throw new Error('Expected to find package.nw in secondary Steam library');
+		}
+		assert.ok(result.attemptedPaths.includes(expectedPath));
+		assert.strictEqual(clientPackage.path, expectedPath);
+		assert.deepStrictEqual(clientPackage.data, Buffer.from('secondary package'));
+	});
+
+	test('packageNotFoundMessage lists attempted paths and override guidance', () => {
+		const configuredPath = 'D:\\Games\\Screeps\\package.nw';
+		const message = packageNotFoundMessage([ configuredPath ]);
+		assert.match(message, /Attempted locations:/);
+		assert.match(message, /D:\\Games\\Screeps\\package\.nw/);
+		assert.match(message, /browserClient:\n {2}package: \/full\/path\/to\/package\.nw/);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,15 @@ importers:
 
   packages/client:
     dependencies:
+      '@node-steam/vdf':
+        specifier: ^2.2.0
+        version: 2.2.0
       jszip:
         specifier: ^3.6.0
         version: 3.10.1
+      tslib:
+        specifier: ~2.8.1
+        version: 2.8.1
       xxscreeps:
         specifier: workspace:~
         version: link:../xxscreeps
@@ -511,6 +517,10 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@node-steam/vdf@2.2.0':
+    resolution: {integrity: sha512-YCfIPsIpyrtOP5AdsarjPqjTElVFrXJlWedWNzjCaIeam06v9ebYgApRAcw9b93awNDboTEiHFMnCvlJJHqKcA==}
+    engines: {node: '>=8.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3182,6 +3192,8 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@node-steam/vdf@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
  This PR changes @xxscreeps/client to discover package.nw automatically from Steam install locations, including secondary library folders, while preserving existing behavior for explicit browserClient.package configuration.

  It addresses the common failure mode where a Steam install is not in one of the previously hardcoded paths, so the client can no longer find the package on systems with custom/secondary libraries.

  ## Compatibility / behavior notes

  - Existing browserClient.package override continues to work.
  - No behavior is changed for users that already configure the path explicitly.
  - Startup diagnostics now reflect all attempted search locations when discovery fails.