### PR TITLE
Fix id-string object constructors

### DIFF
--- a/.changeset/id-ctor-overlay-share.md
+++ b/.changeset/id-ctor-overlay-share.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `new Creep(id)` and other id-string constructors to expose primitive overlay fields like `hits` and `fatigue`.

--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -3,15 +3,17 @@ import type { RoomPosition } from './position.js';
 import type { Room } from './room/index.js';
 import type { InspectOptionsStylized } from 'node:util';
 import type { BufferView, TypeOf } from 'xxscreeps/schema/index.js';
-import { inspect } from 'node:util';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { enumeratedForPath } from 'xxscreeps/engine/schema/index.js';
 import * as BufferObject from 'xxscreeps/schema/buffer-object.js';
 import { compose, declare, enumerated, struct, union, vector, withOverlay } from 'xxscreeps/schema/index.js';
+import { ReadOnlyView } from 'xxscreeps/schema/overlay.js';
 import { expandGetters } from 'xxscreeps/utility/inspect.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { format as roomPositionFormat } from './position.js';
 import { Game, registerGlobal } from './index.js';
+
+const getPrototypeOf = Object.getPrototypeOf as (value: object) => object | null;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface Schema {}
@@ -30,6 +32,11 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 	 */
 	declare room: Room;
 
+	/** Set on id-string-constructed views to the canonical handle from the registry. */
+	declare '#liveHandle'?: RoomObject;
+
+	/** @internal */
+	constructor(id: string);
 	/** @internal */
 	constructor(buffer?: BufferView, offset?: number);
 	/** @deprecated */
@@ -43,6 +50,17 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 			this.pos.y = offsetOrYy as number;
 			this.pos.roomName = roomName as string;
 			this.room = Game.rooms[roomName as string];
+		} else if (typeof viewOrXx === 'string') {
+			const object = Game.getObjectById(viewOrXx);
+			if (object === null) {
+				throw new Error('Could not find an object with ID ' + viewOrXx);
+			}
+			const pos = object.pos;
+			super(BufferObject.getBuffer(object), BufferObject.getOffset(object));
+			installReadOnlyView(this, object, new.target.prototype, viewOrXx, pos);
+			(this as RoomObject & { [ReadOnlyView]?: true })[ReadOnlyView] = true;
+			this.room = object.room;
+			this['#liveHandle'] = object;
 		} else {
 			super(viewOrXx as BufferView, offsetOrYy as number);
 		}
@@ -90,6 +108,76 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 		} else {
 			return `${options.stylize(`[${this.constructor.name}]`, 'special')} ${options.stylize('{released}', 'null')}`;
 		}
+	}
+}
+
+function defineReadOnlyGetter(object: object, key: string, enumerable: boolean, get: () => unknown) {
+	Object.defineProperty(object, key, {
+		enumerable,
+		configurable: true,
+		get,
+		set() {},
+	});
+}
+
+function enumerableGetterKeys(prototype: object) {
+	const keys = new Set<string>();
+	for (
+		let current: object | null = prototype;
+		current !== null && current !== Object.prototype;
+		current = getPrototypeOf(current)
+	) {
+		for (const key of Object.getOwnPropertyNames(current)) {
+			if (key === 'constructor' || key.startsWith('#')) {
+				continue;
+			}
+			const descriptor = Object.getOwnPropertyDescriptor(current, key)!;
+			if (descriptor.enumerable && descriptor.get !== undefined) {
+				keys.add(key);
+			}
+		}
+	}
+	return keys;
+}
+
+function installReadOnlyView(target: RoomObject, source: RoomObject, prototype: object, id: string, pos: RoomPosition) {
+	const sourceRecord = source as unknown as Record<string, unknown>;
+	const expanded = expandGetters(source) as Record<string, unknown>;
+	const copied = new Set<string>();
+	const copy = (key: string) => {
+		if (key === 'room') {
+			return;
+		}
+		let value: unknown;
+		try {
+			value = sourceRecord[key];
+		} catch {
+			return;
+		}
+		if (value === undefined || copied.has(key)) {
+			return;
+		}
+		copied.add(key);
+		defineReadOnlyGetter(target, key, true, () => sourceRecord[key]);
+	};
+	copied.add('id');
+	defineReadOnlyGetter(target, 'id', true, () => id);
+	copied.add('pos');
+	defineReadOnlyGetter(target, 'pos', true, () => pos);
+	for (const key of Object.keys(expanded)) {
+		copy(key);
+	}
+	const sourcePrototype = getPrototypeOf(source);
+	if (sourcePrototype !== null) {
+		for (const key of enumerableGetterKeys(sourcePrototype)) {
+			copy(key);
+		}
+	}
+	for (const key of enumerableGetterKeys(prototype)) {
+		if (copied.has(key) || key === 'room') {
+			continue;
+		}
+		defineReadOnlyGetter(target, key, true, () => undefined);
 	}
 }
 
@@ -141,10 +229,12 @@ export function saveAction(object: WithActionLog, type: ActionLog[number]['type'
 	actionLog.push({ type, x: pos.x, y: pos.y, time: Game.time });
 }
 
-export function getById<T>(Type: new (...args: any) => T, id: string): T {
-	const it = Game.getObjectById(id);
-	if (!it || !(it instanceof Type)) throw new Error('Could not find an object with ID ' + id);
-	// Render all properties
-	inspect(it, true, 1);
-	return it as T;
+type RoomObjectConstructor<Type extends RoomObject = RoomObject> = abstract new (...args: never[]) => Type;
+
+export function getById<Type extends RoomObject>(Type: RoomObjectConstructor<Type>, id: string): Type {
+	const object = Game.getObjectById(id);
+	if (object !== null && object instanceof Type) {
+		return object;
+	}
+	throw new Error('Could not find an object with ID ' + id);
 }

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -8,7 +8,6 @@ registerGlobal('_', lodash);
 registerGlobal(function Deposit() {});
 registerGlobal(function Nuke() {});
 registerGlobal(function PowerCreep() {});
-registerGlobal(function Ruin() {});
 registerGlobal(function StructureFactory() {});
 registerGlobal(function StructureInvaderCore() {});
 registerGlobal(function StructureNuker() {});

--- a/packages/xxscreeps/mods/construction/construction-site.ts
+++ b/packages/xxscreeps/mods/construction/construction-site.ts
@@ -23,12 +23,6 @@ const shape = () => struct(RoomObject.format, {
 });
 
 export class ConstructionSite extends withOverlay(RoomObject.RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<ConstructionSite>(this, RoomObject.getById(ConstructionSite, idOrArg1));
-	}
-
 	@enumerable override get my() { return this['#user'] === me; }
 	@enumerable get owner() { return userInfo.get(this['#user']); }
 	override get '#lookType'() { return C.LOOK_CONSTRUCTION_SITES; }

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -12,7 +12,7 @@ import { Predicate } from 'xxscreeps/functional/predicate.js';
 import { chainIntentChecks, checkRange, checkSafeMode, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, intents, me, userInfo } from 'xxscreeps/game/index.js';
-import { RoomObject, actionLogFormat, create as createObject, getById, format as objectFormat, saveAction } from 'xxscreeps/game/object.js';
+import { RoomObject, actionLogFormat, create as createObject, format as objectFormat, saveAction } from 'xxscreeps/game/object.js';
 import { registerObstacleChecker } from 'xxscreeps/game/pathfinder/index.js';
 import { RoomPosition, fetchPositionArgument } from 'xxscreeps/game/position.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
@@ -65,17 +65,6 @@ export class Creep extends withOverlay(RoomObject, shape) {
 	declare tickRawDamage: number | undefined;
 	/** @internal — raw healing received this tick, always >= 0 */
 	declare tickHealing: number | undefined;
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(typeof idOrArg1 === 'string' ? undefined : idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') {
-			const it = getById(Creep, idOrArg1);
-			this['#ageTime'] = it['#ageTime'];
-			this['#user'] = it['#user'];
-			assign<Creep>(this, it);
-		}
-
-	}
 
 	@enumerable override get hitsMax() { return this.body.length * 100; }
 	@enumerable get owner() { return userInfo.get(this['#user']); }

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -1,9 +1,9 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
-import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { Structure, lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
-import { create } from './creep.js';
+import { Creep, create } from './creep.js';
 
 describe('Movement', () => {
 	const movement = simulate({
@@ -604,4 +604,61 @@ describe('Event log events', () => {
 			});
 		}));
 	});
+});
+
+describe('Id-string constructor', () => {
+	const sim = simulate({
+		W3N3: room => {
+			const creep = create(new RoomPosition(25, 25, 'W3N3'), [ C.WORK ], 'subject', '100');
+			creep.fatigue = 3;
+			creep.store['#add'](C.RESOURCE_ENERGY, 25);
+			room['#insertObject'](creep);
+			room['#insertObject'](createContainer(new RoomPosition(26, 25, 'W3N3')));
+		},
+	});
+
+	test('Creep view reads match the canonical handle', () => sim(async ({ player }) => {
+		await player('100', Game => {
+			const original = Game.creeps.subject;
+			const view = new Creep(original.id);
+			assert.ok(view instanceof Creep);
+			assert.strictEqual(view.id, original.id);
+			assert.strictEqual(view.name, original.name);
+			assert.strictEqual(view.body.length, original.body.length);
+			assert.strictEqual(view.pos.x, original.pos.x);
+			assert.strictEqual(view.pos.y, original.pos.y);
+			assert.strictEqual(view.pos.roomName, original.pos.roomName);
+			assert.strictEqual(view.store[C.RESOURCE_ENERGY], original.store[C.RESOURCE_ENERGY]);
+			assert.strictEqual(view.hits, original.hits);
+			assert.strictEqual(view.fatigue, original.fatigue);
+		});
+	}));
+
+	test('Structure base reads delegate to the concrete object', () => sim(async ({ player }) => {
+		await player('100', Game => {
+			const original = Game.rooms.W3N3.find(C.FIND_STRUCTURES)[0];
+			const structure = new Structure(original.id);
+			assert.strictEqual(structure.structureType, original.structureType);
+			assert.strictEqual(structure.hits, original.hits);
+			assert.strictEqual(structure.hitsMax, original.hitsMax);
+		});
+	}));
+
+	test('writes on a view do not propagate to the canonical handle', () => sim(async ({ player }) => {
+		await player('100', Game => {
+			const original = Game.creeps.subject;
+			const hits = original.hits;
+			const fatigue = original.fatigue;
+			const view = new Creep(original.id);
+			const markedView = view as Creep & { _marker?: string };
+			view.hits = 50;
+			view.fatigue = 1;
+			markedView._marker = 'view';
+			assert.strictEqual(original.hits, hits);
+			assert.strictEqual(original.fatigue, fatigue);
+			assert.strictEqual(view.hits, hits);
+			assert.strictEqual(view.fatigue, fatigue);
+			assert.strictEqual(markedView._marker, 'view');
+		});
+	}));
 });

--- a/packages/xxscreeps/mods/creep/tombstone.ts
+++ b/packages/xxscreeps/mods/creep/tombstone.ts
@@ -2,12 +2,11 @@ import type { ResourceType } from 'xxscreeps/mods/resource/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
-import { RoomObject, create as createObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
+import { RoomObject, create as createObject, format as objectFormat } from 'xxscreeps/game/object.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { OpenStore, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 import { Creep } from './creep.js';
 
 export const format = declare('Tombstone', () => compose(shape, Tombstone));
@@ -34,12 +33,6 @@ const shape = struct(objectFormat, {
  * A remnant of dead creeps. This is a walkable object.
  */
 export class Tombstone extends withOverlay(RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Tombstone>(this, getById(Tombstone, idOrArg1));
-	}
-
 	/**
 	 * The amount of game ticks before this tombstone decays.
 	 */

--- a/packages/xxscreeps/mods/mineral/mineral.ts
+++ b/packages/xxscreeps/mods/mineral/mineral.ts
@@ -7,7 +7,6 @@ import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
 import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 
 export const format = declare('Mineral', () => compose(shape, Mineral));
 const shape = struct(RoomObject.format, {
@@ -20,12 +19,6 @@ const shape = struct(RoomObject.format, {
 
 // Game object declaration
 export class Mineral extends withOverlay(RoomObject.RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Mineral>(this, RoomObject.getById(Mineral, idOrArg1));
-	}
-
 	@enumerable get ticksToRegeneration() {
 		const nextTime = this['#nextRegenerationTime'];
 		return nextTime === 0 ? undefined : Math.max(0, nextTime - Game.time);

--- a/packages/xxscreeps/mods/resource/resource.ts
+++ b/packages/xxscreeps/mods/resource/resource.ts
@@ -26,12 +26,6 @@ const shape = struct(RoomObject.format, {
 
 // Game object
 export class Resource extends withOverlay(RoomObject.RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Resource>(this, RoomObject.getById(Resource, idOrArg1));
-	}
-
 	get energy() { return this.resourceType === C.RESOURCE_ENERGY ? this.amount : undefined; }
 	get '#lookType'() { return C.LOOK_RESOURCES; }
 }

--- a/packages/xxscreeps/mods/source/source.ts
+++ b/packages/xxscreeps/mods/source/source.ts
@@ -1,7 +1,6 @@
 import { Game, registerGlobal } from 'xxscreeps/game/index.js';
 import * as RoomObject from 'xxscreeps/game/object.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 import * as C from './constants.js';
 
 export const format = declare('Source', () => compose(shape, Source));
@@ -14,12 +13,6 @@ const shape = struct(RoomObject.format, {
 
 // Game object declaration
 export class Source extends withOverlay(RoomObject.RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Source>(this, RoomObject.getById(Source, idOrArg1));
-	}
-
 	@enumerable get ticksToRegeneration() {
 		return this['#nextRegenerationTime'] === 0 ? undefined : Math.max(0, this['#nextRegenerationTime'] - Game.time);
 	}

--- a/packages/xxscreeps/mods/structure/ruin.ts
+++ b/packages/xxscreeps/mods/structure/ruin.ts
@@ -2,11 +2,10 @@ import type { Store } from 'xxscreeps/mods/resource/store.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
-import { RoomObject, create as createObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
+import { RoomObject, create as createObject, format as objectFormat } from 'xxscreeps/game/object.js';
 import { OpenStore, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { OwnedStructure, Structure } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 
 export const format = declare('Ruin', () => compose(shape, Ruin));
 const shape = struct(objectFormat, {
@@ -26,12 +25,6 @@ const shape = struct(objectFormat, {
  * A destroyed structure. This is a walkable object.
  */
 export class Ruin extends withOverlay(RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Ruin>(this, getById(Ruin, idOrArg1));
-	}
-
 	/**
 	 * The amount of game ticks before this ruin decays.
 	 */

--- a/packages/xxscreeps/mods/structure/structure.ts
+++ b/packages/xxscreeps/mods/structure/structure.ts
@@ -6,12 +6,11 @@ import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, hooks, intents, me, userInfo } from 'xxscreeps/game/index.js';
-import { RoomObject, getById, format as objectFormat } from 'xxscreeps/game/object.js';
+import { RoomObject, format as objectFormat } from 'xxscreeps/game/object.js';
 import { registerObstacleChecker } from 'xxscreeps/game/pathfinder/index.js';
 import { isBorder, isNearBorder, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { compose, declare, optional, struct, withOverlay } from 'xxscreeps/schema/index.js';
-import { assign } from 'xxscreeps/utility/utility.js';
 import { createRuin } from './ruin.js';
 
 export type AnyStructure = Extract<AnyRoomObject, Structure>;
@@ -38,26 +37,30 @@ const ownedShape = struct(structureFormat, {
  * The base prototype object of all structures.
  */
 export class Structure extends withOverlay(RoomObject, shape) {
-
-	constructor(idOrArg1?: any, arg2?: any) {
-		super(idOrArg1, arg2);
-		if (typeof idOrArg1 === 'string') assign<Structure>(this, getById(Structure, idOrArg1));
-	}
-
 	/**
 	 * One of the `STRUCTURE_*` constants.
 	 */
-	@enumerable get structureType(): string { throw new Error(); }
+	@enumerable get structureType(): string {
+		// `new Structure(id)` views delegate to the canonical concrete object —
+		// `structureType`/`hits`/`hitsMax` are overlay-backed only on concrete subclass prototypes.
+		const live = this['#liveHandle'];
+		if (live === undefined) throw new Error();
+		return (live as Structure).structureType;
+	}
 
 	/**
 	 * The current amount of hit points of the structure.
 	 */
-	@enumerable override get hits(): number | undefined { return undefined; }
+	@enumerable override get hits(): number | undefined {
+		return (this['#liveHandle'] as Structure | undefined)?.hits;
+	}
 
 	/**
 	 * The total amount of hit points of the structure.
 	 */
-	@enumerable override get hitsMax(): number | undefined { return undefined; }
+	@enumerable override get hitsMax(): number | undefined {
+		return (this['#liveHandle'] as Structure | undefined)?.hitsMax;
+	}
 
 	get '#lookType'() { return C.LOOK_STRUCTURES; }
 

--- a/packages/xxscreeps/schema/overlay.ts
+++ b/packages/xxscreeps/schema/overlay.ts
@@ -11,7 +11,12 @@ import { entriesWithSymbols } from './symbol.js';
 const { defineProperty } = Object;
 const { apply } = Reflect;
 
+export const ReadOnlyView = Symbol('ReadOnlyView');
+
 type GetterReader = (this: BufferObject) => any;
+interface ReadOnlyBufferObject extends BufferObject {
+	[ReadOnlyView]?: true;
+}
 
 const injected = new WeakSet();
 export function injectGetters(layout: StructLayout, prototype: object, builder: Builder) {
@@ -48,11 +53,13 @@ export function injectGetters(layout: StructLayout, prototype: object, builder: 
 			)) {
 				return function() {
 					const value = apply(get, this, []);
-					defineProperty(this, key, {
-						enumerable,
-						writable: true,
-						value,
-					});
+					if ((this as ReadOnlyBufferObject)[ReadOnlyView] !== true) {
+						defineProperty(this, key, {
+							enumerable,
+							writable: true,
+							value,
+						});
+					}
 					return value;
 				};
 			}
@@ -67,6 +74,9 @@ export function injectGetters(layout: StructLayout, prototype: object, builder: 
 			enumerable,
 			get,
 			set(value) {
+				if ((this as ReadOnlyBufferObject)[ReadOnlyView] === true) {
+					return;
+				}
 				defineProperty(this, key, {
 					enumerable,
 					writable: true,
@@ -90,11 +100,16 @@ type AbstractBufferObjectSubclass<Instance extends BufferObject = any> =
 	abstract new(view?: BufferView, offset?: number) => Instance;
 type BufferObjectSubclass<Instance extends BufferObject> =
 	new(view?: BufferView, offset?: number) => Instance;
+type AbstractIdStringObjectSubclass<Instance extends BufferObject = BufferObject> =
+	abstract new(id: string) => Instance;
+type IdStringObjectSubclass<Instance extends BufferObject> =
+	new(id: string) => Instance;
 type BufferObjectConstructor<
 	Base extends AbstractBufferObjectSubclass,
 	Instance extends BufferObject,
 > = Omit<Base, 'prototype'> & (Base extends BufferObjectSubclass<any>
-	? BufferObjectSubclass<Instance> : AbstractBufferObjectSubclass<Instance>);
+	? BufferObjectSubclass<Instance> : AbstractBufferObjectSubclass<Instance>) &
+	(Base extends AbstractIdStringObjectSubclass ? IdStringObjectSubclass<Instance> : unknown);
 
 /**
  * Injects types inherited from format into class prototype. Just passes the base class back


### PR DESCRIPTION
## Summary

- Centralize RoomObject id-string construction on the canonical `Game.getObjectById(id)` object and intentionally drop the constructor-path `instanceof` validation to match vanilla, including `new Creep(structureId)`.
- Add a `ReadOnlyView` sentinel for id-constructed views so writes to overlay-defined fields are explicitly discarded while ad-hoc own-property writes still work.
- Remove the duplicate placeholder `Ruin` runtime global. That placeholder shadowed the real structure mod `Ruin` class in isolated player runtime; Tombstone did not have that duplicate, which is why Tombstone id construction already worked.

## Notes

The exported `getById(Type, id)` helper remains strict; only the constructor id-string branch uses vanilla's direct lookup behavior.

The id-constructed view still shares the canonical buffer, but public fields are exposed through read-only getters so cross-type views read the canonical object's public values and requested-type-only fields read `undefined` instead of stale offset data.

## Validation

- `pnpm run build`
- `pnpm test` -> 200/200 passing
- `pnpm exec eslint --max-warnings 0` on changed files: no new warnings; the command still reports the repo's existing warnings in those files
- `screeps-ok-pr` parity now passes the id-constructor coverage that previously failed:
  - `tests/27-undocumented/27.11-id-constructors.test.ts`: `UNDOC-IDCTOR-001`, `UNDOC-IDCTOR-003`, `UNDOC-IDCTOR-004`
  - `tests/27-undocumented/27.6-identity.test.ts`: `UNDOC-CTOR-002`, `UNDOC-CTOR-003`, `UNDOC-CTOR-004`, `UNDOC-CTOR-006`, `UNDOC-CTOR-007`, `UNDOC-CTOR-008`
  - The parity reporter still exits non-zero until `screeps-ok` removes the stale expected-failure registrations for the two now-fixed gaps.
