### PR TITLE
Reorder checkPickup to gate ERR_FULL before range

### DIFF
--- a/.changeset/pickup-full-before-range.md
+++ b/.changeset/pickup-full-before-range.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder `checkPickup` to gate `ERR_FULL` before range

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -514,9 +514,9 @@ export function checkPickup(creep: Creep, target: Resource) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
 		() => checkTarget(target, Resource),
-		() => checkRange(creep, target, 1),
 		() => creep.store.getFreeCapacity(target.resourceType) > 0
-			? C.OK : C.ERR_FULL);
+			? C.OK : C.ERR_FULL,
+		() => checkRange(creep, target, 1));
 }
 
 export function checkTransfer(creep: Creep, target: RoomObject & WithStore, resourceType: ResourceType, amount: number) {

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -1,6 +1,7 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
+import { create as createResource } from 'xxscreeps/mods/resource/resource.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create } from './creep.js';
@@ -514,6 +515,26 @@ describe('Movement', () => {
 			});
 		}));
 	});
+});
+
+describe('Pickup', () => {
+	const fullAndOutOfRange = simulate({
+		W1N1: room => {
+			room['#level'] = 1;
+			room['#user'] = room.controller!['#user'] = '100';
+			const picker = create(new RoomPosition(25, 25, 'W1N1'), [ C.CARRY, C.MOVE ], 'picker', '100');
+			picker.store['#add'](C.RESOURCE_ENERGY, C.CARRY_CAPACITY);
+			room['#insertObject'](picker);
+			room['#insertObject'](createResource(new RoomPosition(30, 30, 'W1N1'), C.RESOURCE_ENERGY, 50));
+		},
+	});
+
+	test('full creep returns ERR_FULL before ERR_NOT_IN_RANGE', () => fullAndOutOfRange(async ({ player }) => {
+		await player('100', Game => {
+			const pile = Game.rooms.W1N1.find(C.FIND_DROPPED_RESOURCES)[0];
+			assert.strictEqual(Game.creeps.picker.pickup(pile), C.ERR_FULL);
+		});
+	}));
 });
 
 describe('Event log events', () => {


### PR DESCRIPTION
## Summary

`checkPickup` returned `ERR_NOT_IN_RANGE` before `ERR_FULL` when both applied. Vanilla returns `ERR_FULL` first. This PR swaps the two checks so the precedence matches.

Part of #117 (`creep` row, `checkPickup`).

## Vanilla precedence

`@screeps/engine/src/game/creeps.js` `Creep.prototype.pickup` (lines 566-587):

```js
if (!this.my)                                       return ERR_NOT_OWNER;
if (this.spawning)                                  return ERR_BUSY;
if (!target /* not a Resource */ )                  return ERR_INVALID_TARGET;
if (used >= storeCapacity)                          return ERR_FULL;
if (!target.pos.isNearTo(this.pos))                 return ERR_NOT_IN_RANGE;
```

Order: `NOT_OWNER → BUSY → INVALID_TARGET → FULL → NOT_IN_RANGE`.

## Before

`packages/xxscreeps/mods/creep/creep.ts` `checkPickup`:

```ts
() => checkCommon(creep),         // NOT_OWNER, BUSY
() => checkTarget(target, Resource), // INVALID_TARGET
() => checkRange(creep, target, 1),  // NOT_IN_RANGE  <-- runs before FULL
() => creep.store.getFreeCapacity(target.resourceType) > 0
    ? OK : ERR_FULL,
```

## After

```ts
() => checkCommon(creep),
() => checkTarget(target, Resource),
() => creep.store.getFreeCapacity(target.resourceType) > 0
    ? OK : ERR_FULL,                  // FULL now precedes range
() => checkRange(creep, target, 1),
```

## Validation

- New regression test `Pickup > full creep returns ERR_FULL before ERR_NOT_IN_RANGE` in `packages/xxscreeps/mods/creep/test.ts`. Confirmed failing before the swap (`-9 !== -8`), passing after.
- `pnpm run build` clean. `npx xxscreeps test` 209/209 pass.
- Verified against screeps-ok: `PICKUP-010:fullBeforeRange` flips green on the patched build.