### PR TITLE
Validate observer roomName before RCL gate

### DIFF
--- a/.changeset/observer-roomname-rcl.md
+++ b/.changeset/observer-roomname-rcl.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Validate observer roomName before RCL gate

--- a/packages/xxscreeps/mods/observer/observer.ts
+++ b/packages/xxscreeps/mods/observer/observer.ts
@@ -20,10 +20,7 @@ export class StructureObserver extends withOverlay(OwnedStructure, shape) {
 
 	observeRoom(roomName: string) {
 		return chainIntentChecks(
-			() => checkMyStructure(this, StructureObserver),
-			() => checkObserveRoomName(roomName),
-			() => checkIsActive(this),
-			() => checkObserveRoomRange(this, roomName),
+			() => checkObserveRoom(this, roomName),
 			() => intents.save(this, 'observeRoom', roomName));
 	}
 }
@@ -50,14 +47,22 @@ registerBuildableStructure(C.STRUCTURE_OBSERVER, {
 
 //
 // Intent checks
-export function checkObserveRoomName(target: string) {
-	return /^(W|E)\d+(S|N)\d+$/.test(target) ? C.OK : C.ERR_INVALID_ARGS;
+function checkObserveRoomName(target: string) {
+	return Game.map.getRoomStatus(target) ? C.OK : C.ERR_INVALID_ARGS;
 }
 
-export function checkObserveRoomRange(observer: StructureObserver, target: string) {
-	const range = Game.map.getRoomLinearDistance(observer.room.name, target);
-	if (range > C.OBSERVER_RANGE || Game.map.getRoomStatus(target) === undefined) {
+function checkObserveRoomRange(observer: StructureObserver, target: string) {
+	if (Game.map.getRoomLinearDistance(observer.room.name, target) > C.OBSERVER_RANGE) {
 		return C.ERR_NOT_IN_RANGE;
 	}
 	return C.OK;
+}
+
+export function checkObserveRoom(observer: StructureObserver, target: string) {
+	return chainIntentChecks(
+		() => checkMyStructure(observer, StructureObserver),
+		() => checkObserveRoomName(target),
+		() => checkIsActive(observer),
+		() => checkObserveRoomRange(observer, target),
+	);
 }

--- a/packages/xxscreeps/mods/observer/observer.ts
+++ b/packages/xxscreeps/mods/observer/observer.ts
@@ -21,8 +21,9 @@ export class StructureObserver extends withOverlay(OwnedStructure, shape) {
 	observeRoom(roomName: string) {
 		return chainIntentChecks(
 			() => checkMyStructure(this, StructureObserver),
+			() => checkObserveRoomName(roomName),
 			() => checkIsActive(this),
-			() => checkObserveRoom(this, roomName),
+			() => checkObserveRoomRange(this, roomName),
 			() => intents.save(this, 'observeRoom', roomName));
 	}
 }
@@ -49,11 +50,13 @@ registerBuildableStructure(C.STRUCTURE_OBSERVER, {
 
 //
 // Intent checks
-export function checkObserveRoom(observer: StructureObserver, target: string) {
+export function checkObserveRoomName(target: string) {
+	return /^(W|E)\d+(S|N)\d+$/.test(target) ? C.OK : C.ERR_INVALID_ARGS;
+}
+
+export function checkObserveRoomRange(observer: StructureObserver, target: string) {
 	const range = Game.map.getRoomLinearDistance(observer.room.name, target);
-	if (Object.is(range, NaN)) {
-		return C.ERR_INVALID_ARGS;
-	} else if (range > C.OBSERVER_RANGE || Game.map.getRoomStatus(target) === undefined) {
+	if (range > C.OBSERVER_RANGE || Game.map.getRoomStatus(target) === undefined) {
 		return C.ERR_NOT_IN_RANGE;
 	}
 	return C.OK;

--- a/packages/xxscreeps/mods/observer/processor.ts
+++ b/packages/xxscreeps/mods/observer/processor.ts
@@ -3,7 +3,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { ObserverSpy, create as createObserverSpy } from 'xxscreeps/mods/observer/observer-spy.js';
-import { StructureObserver, checkObserveRoomName, checkObserveRoomRange } from 'xxscreeps/mods/observer/observer.js';
+import { StructureObserver, checkObserveRoom } from 'xxscreeps/mods/observer/observer.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { observer: typeof intents }
@@ -12,7 +12,7 @@ declare module 'xxscreeps/engine/processor/index.js' {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
 	registerIntentProcessor(StructureObserver, 'observeRoom', {}, (observer, context, target: string) => {
-		if (checkObserveRoomName(target) === C.OK && checkObserveRoomRange(observer, target) === C.OK) {
+		if (checkObserveRoom(observer, target) === C.OK) {
 			context.sendRoomIntent(target, 'observerObserve', observer['#user']!);
 		}
 	}),

--- a/packages/xxscreeps/mods/observer/processor.ts
+++ b/packages/xxscreeps/mods/observer/processor.ts
@@ -3,7 +3,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { ObserverSpy, create as createObserverSpy } from 'xxscreeps/mods/observer/observer-spy.js';
-import { StructureObserver, checkObserveRoom } from 'xxscreeps/mods/observer/observer.js';
+import { StructureObserver, checkObserveRoomName, checkObserveRoomRange } from 'xxscreeps/mods/observer/observer.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { observer: typeof intents }
@@ -12,7 +12,7 @@ declare module 'xxscreeps/engine/processor/index.js' {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
 	registerIntentProcessor(StructureObserver, 'observeRoom', {}, (observer, context, target: string) => {
-		if (checkObserveRoom(observer, target) === C.OK) {
+		if (checkObserveRoomName(target) === C.OK && checkObserveRoomRange(observer, target) === C.OK) {
 			context.sendRoomIntent(target, 'observerObserve', observer['#user']!);
 		}
 	}),

--- a/packages/xxscreeps/mods/observer/test.ts
+++ b/packages/xxscreeps/mods/observer/test.ts
@@ -87,7 +87,7 @@ describe('Observer', () => {
 			const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
 			// W1N11 is within observer range but does not exist in the world
 			const result = observer.observeRoom('W1N11');
-			assert.strictEqual(result, C.ERR_NOT_IN_RANGE, 'observeRoom to non-existent room should be ERR_NOT_IN_RANGE');
+			assert.strictEqual(result, C.ERR_INVALID_ARGS, 'observeRoom to non-existent room should be ERR_INVALID_ARGS');
 		});
 		// Tick should not crash even if the check were bypassed
 		await tick();

--- a/packages/xxscreeps/mods/observer/test.ts
+++ b/packages/xxscreeps/mods/observer/test.ts
@@ -57,6 +57,14 @@ describe('Observer', () => {
 		});
 	}));
 
+	test('observer_illegal_arg_before_min_level', () => simulation(async ({ player }) => {
+		await player('100', Game => {
+			const observer = lookForStructures(Game.rooms.W1N2, C.STRUCTURE_OBSERVER)[0];
+			const result = observer.observeRoom('not_a_room');
+			assert.strictEqual(result, C.ERR_INVALID_ARGS, 'observeRoom should validate roomName before observer RCL');
+		});
+	}));
+
 	test('observer_range', () => simulation(async ({ player }) => {
 		await player('100', Game => {
 			const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];


### PR DESCRIPTION
## Summary

`StructureObserver.observeRoom` returned `ERR_RCL_NOT_ENOUGH` before `ERR_INVALID_ARGS` when both an inactive observer and a malformed `roomName` applied. Vanilla validates the room name before the RCL gate. This PR hoists the room-name validation while leaving range validation after RCL.

Part of #117 (`observer` row, `StructureObserver.observeRoom`).

## Vanilla precedence

`@screeps/engine/src/game/structures.js` `StructureObserver.prototype.observeRoom`:

```js
if(!_.isString(roomName) || !/^(W|E)\d+(S|N)\d+$/.test(roomName)) {
    return C.ERR_INVALID_ARGS;
}
if(!utils.checkStructureAgainstController(...)) {
    return C.ERR_RCL_NOT_ENOUGH;
}
```

Order: `NOT_OWNER -> INVALID_ARGS -> RCL_NOT_ENOUGH -> NOT_IN_RANGE`.

## Before

`packages/xxscreeps/mods/observer/observer.ts` `observeRoom`:

```ts
() => checkMyStructure(this, StructureObserver),
() => checkIsActive(this),              // RCL_NOT_ENOUGH before roomName validation
() => checkObserveRoom(this, roomName),
```

## After

```ts
() => checkMyStructure(this, StructureObserver),
() => checkObserveRoomName(roomName),   // INVALID_ARGS now precedes RCL
() => checkIsActive(this),
() => checkObserveRoomRange(this, roomName),
```

`checkObserveRoom` composes the room-name and range checks for processor-side revalidation.

## Validation

- New regression test `observer_illegal_arg_before_min_level` in `packages/xxscreeps/mods/observer/test.ts`. Confirmed failing before the fix (`-14 !== -10`), passing after.
- `pnpm run build` clean. `npx xxscreeps test` 209/209 pass.
- Changed-file ESLint clean with `--max-warnings 0`.
- Verified against screeps-ok from `screeps-ok-pr`: `OBSERVER-007:invalidArgsBeforeRcl` now passes and is reported as a fixed expected-failure gap.
