### PR TITLE
Split null-target from wrong-type in checkSignController

### DIFF
--- a/.changeset/sign-controller-precedence.md
+++ b/.changeset/sign-controller-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Split null-target from wrong-type in `checkSignController`

--- a/packages/xxscreeps/mods/controller/creep.ts
+++ b/packages/xxscreeps/mods/controller/creep.ts
@@ -3,6 +3,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { intents, me, userGame } from 'xxscreeps/game/index.js';
 import { Creep, checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { checkHasResource } from 'xxscreeps/mods/resource/store.js';
+import { Structure } from 'xxscreeps/mods/structure/structure.js';
 import { extend } from 'xxscreeps/utility/utility.js';
 import { StructureController } from './controller.js';
 
@@ -175,8 +176,9 @@ export function checkReserveController(creep: Creep, target: StructureController
 export function checkSignController(creep: Creep, target: StructureController, message: string | null | undefined) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
-		() => checkTarget(target, StructureController),
+		() => checkTarget(target, Structure),
 		() => checkRange(creep, target, 1),
+		() => target instanceof StructureController ? C.OK : C.ERR_INVALID_TARGET,
 		() => message ? checkString(message, 100) : C.OK);
 }
 

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -1,7 +1,9 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create } from 'xxscreeps/mods/creep/creep.js';
+import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { StructureController } from './controller.js';
 
 describe('Controller', () => {
 
@@ -43,6 +45,34 @@ describe('Controller', () => {
 			await player('100', Game => {
 				const controller = Game.rooms.W3N3.controller!;
 				assert.strictEqual(Game.creeps.claimer.attackController(controller), C.ERR_INVALID_TARGET);
+			});
+		}));
+	});
+
+	describe('signController', () => {
+
+		const wrongTypeOutOfRange = simulate({
+			W3N3: room => {
+				room['#insertObject'](create(new RoomPosition(10, 10, 'W3N3'), [ C.MOVE ], 'signer', '100'));
+				room['#insertObject'](createContainer(new RoomPosition(34, 32, 'W3N3')));
+			},
+		});
+
+		test('out-of-range non-controller target returns ERR_NOT_IN_RANGE', () => wrongTypeOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				const container = Game.rooms.W3N3.find(C.FIND_STRUCTURES)
+					.find(structure => structure.structureType === C.STRUCTURE_CONTAINER)!;
+				assert.strictEqual(
+					Game.creeps.signer.signController(container as unknown as StructureController, 'hello'),
+					C.ERR_NOT_IN_RANGE);
+			});
+		}));
+
+		test('null target returns ERR_INVALID_TARGET', () => wrongTypeOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(
+					Game.creeps.signer.signController(null as unknown as StructureController, 'hello'),
+					C.ERR_INVALID_TARGET);
 			});
 		}));
 	});


### PR DESCRIPTION
## Summary

`checkSignController` returned `ERR_INVALID_TARGET` for any non-controller target — including ones out of range — because a single `checkTarget(target, StructureController)` lumped null and wrong-type together ahead of the range check. Vanilla only short-circuits on null / non-Structure; a wrong-type Structure that's out of range yields `ERR_NOT_IN_RANGE` first.

Part of #117 (`controller` row, `checkSignController`).

## Vanilla precedence

`@screeps/engine/src/game/creeps.js` `Creep.prototype.signController` (lines 1072-1091):

```js
if (this.spawning)                                          return ERR_BUSY;
if (!target || !target.id || !register.structures[target.id]
    || !(target instanceof globals.Structure))              return ERR_INVALID_TARGET;
if (!target.pos.isNearTo(this.pos))                         return ERR_NOT_IN_RANGE;
if (target.structureType != 'controller')                   return ERR_INVALID_TARGET;
```

Order: `BUSY → INVALID_TARGET (null / non-Structure) → NOT_IN_RANGE → INVALID_TARGET (Structure but not controller)`.

## Before

`packages/xxscreeps/mods/controller/creep.ts` `checkSignController`:

```ts
() => checkCommon(creep),                          // BUSY (etc.)
() => checkTarget(target, StructureController),    // INVALID_TARGET — null OR wrong-type
() => checkRange(creep, target, 1),                // NOT_IN_RANGE
() => message ? checkString(message, 100) : OK,
```

## After

```ts
() => checkCommon(creep),
() => checkTarget(target, Structure),                                          // null / non-Structure
() => checkRange(creep, target, 1),                                            // range now precedes wrong-type
() => target instanceof StructureController ? OK : ERR_INVALID_TARGET,         // wrong-type Structure
() => message ? checkString(message, 100) : OK,
```

## Validation

- New regression tests in `packages/xxscreeps/mods/controller/test.ts`:
  - `signController > out-of-range non-controller target returns ERR_NOT_IN_RANGE` — failed before (`-7 !== -9`), passes after.
  - `signController > null target returns ERR_INVALID_TARGET` — guards the null branch.
- `pnpm run build` clean. `npx xxscreeps test` 210/210 pass.
- Verified against screeps-ok: `CTRL-SIGN-004:rangeBeforeNotController` flips green ("Parity: 1 unexpected pass(es) — regression fixed?"); all 8 sign-controller cases pass.