### PR TITLE
Gate upgradeBlocked before range in checkUpgradeController

### DIFF
--- a/.changeset/upgrade-blocked-before-range.md
+++ b/.changeset/upgrade-blocked-before-range.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Gate `upgradeBlocked` before range in `checkUpgradeController`

--- a/packages/xxscreeps/mods/controller/creep.ts
+++ b/packages/xxscreeps/mods/controller/creep.ts
@@ -185,12 +185,7 @@ export function checkUpgradeController(creep: Creep, target: StructureController
 		() => checkCommon(creep, C.WORK),
 		() => checkHasResource(creep, C.RESOURCE_ENERGY),
 		() => checkTarget(target, StructureController),
+		() => target.upgradeBlocked ? C.ERR_INVALID_TARGET : C.OK,
 		() => checkRange(creep, target, 3),
-		() => {
-			if (target.upgradeBlocked) {
-				return C.ERR_INVALID_TARGET;
-			} else if (!target.my) {
-				return C.ERR_NOT_OWNER;
-			}
-		});
+		() => target.my ? C.OK : C.ERR_NOT_OWNER);
 }

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -64,6 +64,28 @@ describe('Controller', () => {
 		}));
 	});
 
+	describe('upgradeController', () => {
+
+		const upgradeBlockedOutOfRange = simulate({
+			W3N3: room => {
+				room['#user'] = '100';
+				room['#level'] = 1;
+				room.controller!['#user'] = '100';
+				room.controller!['#upgradeBlockedUntil'] = 1000;
+				const worker = create(new RoomPosition(28, 32, 'W3N3'), [ C.WORK, C.CARRY ], 'worker', '100');
+				worker.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](worker);
+			},
+		});
+
+		test('upgrade-blocked controller returns ERR_INVALID_TARGET before ERR_NOT_IN_RANGE', () => upgradeBlockedOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				const controller = Game.rooms.W3N3.controller!;
+				assert.strictEqual(Game.creeps.worker.upgradeController(controller), C.ERR_INVALID_TARGET);
+			});
+		}));
+	});
+
 	describe('activateSafeMode', () => {
 
 		const ownedTwoRooms = simulate({


### PR DESCRIPTION
## Summary

`checkUpgradeController` evaluated `target.upgradeBlocked` in the final lambda, after `checkRange`, so an upgrade-blocked controller that the creep was also out of range from returned `ERR_NOT_IN_RANGE` instead of `ERR_INVALID_TARGET`. Vanilla puts upgrade-blocked ahead of range. Lift the branch.

Part of #117 (`controller` row, `checkUpgradeController`).

## Vanilla precedence

`@screeps/engine/src/game/creeps.js` `Creep.prototype.upgradeController` (lines 919-953):

```js
if (!this.my)                                                     return ERR_NOT_OWNER;
if (this.spawning)                                                return ERR_BUSY;
if (!_hasActiveBodypart(this.body, C.WORK))                       return ERR_NO_BODYPART;
if (!this.carry.energy)                                           return ERR_NOT_ENOUGH_RESOURCES;
if (!target /* not a StructureController */)                      return ERR_INVALID_TARGET;
if (target.upgradeBlocked && target.upgradeBlocked > 0)           return ERR_INVALID_TARGET;
if (!target.pos.inRangeTo(this.pos, 3))                           return ERR_NOT_IN_RANGE;
if (!target.my)                                                   return ERR_NOT_OWNER;
```

Order: `… → INVALID_TARGET (wrong type) → INVALID_TARGET (upgradeBlocked) → NOT_IN_RANGE → NOT_OWNER (target.my)`.

## Before

`packages/xxscreeps/mods/controller/creep.ts` `checkUpgradeController`:

```ts
() => checkCommon(creep, C.WORK),
() => checkHasResource(creep, C.RESOURCE_ENERGY),
() => checkTarget(target, StructureController),
() => checkRange(creep, target, 3),               // runs before upgradeBlocked
() => {
    if (target.upgradeBlocked) return C.ERR_INVALID_TARGET;
    else if (!target.my)       return C.ERR_NOT_OWNER;
}
```

## After

```ts
() => checkCommon(creep, C.WORK),
() => checkHasResource(creep, C.RESOURCE_ENERGY),
() => checkTarget(target, StructureController),
() => target.upgradeBlocked ? C.ERR_INVALID_TARGET : C.OK,   // now precedes range
() => checkRange(creep, target, 3),
() => target.my ? C.OK : C.ERR_NOT_OWNER
```

## Validation

- New regression test `Controller > upgradeController > upgrade-blocked controller returns ERR_INVALID_TARGET before ERR_NOT_IN_RANGE` in `packages/xxscreeps/mods/controller/test.ts`. Confirmed failing before the lift (`-9 !== -7`), passing after.
- `pnpm run build` clean. `npx xxscreeps test` 209/209 pass.
- Verified against screeps-ok: `CTRL-UPGRADE-013:upgradeBlockedBeforeRange` flips green on the patched build.