### PR TITLE
Reorder checkCreateFlag for cap-full and name-exists precedence

### DIFF
--- a/.changeset/flag-create-precedence.md
+++ b/.changeset/flag-create-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder checkCreateFlag for cap-full and name-exists precedence

--- a/packages/xxscreeps/mods/flag/flag.ts
+++ b/packages/xxscreeps/mods/flag/flag.ts
@@ -128,15 +128,8 @@ export function checkCreateFlag(
 ) {
 	return chainIntentChecks(
 		pos ? () => checkFlagPosition(pos) : () => C.OK,
+		() => Object.keys(flags).length >= C.FLAGS_LIMIT ? C.ERR_FULL : C.OK,
 		() => checkFlagColors(color, secondaryColor),
-		() => {
-			if (checkString(name, 100, true)) {
-				return C.ERR_INVALID_ARGS;
-			} else if (checkName && (name in flags)) {
-				return C.ERR_NAME_EXISTS;
-
-			} else if (Object.keys(flags).length >= C.FLAGS_LIMIT) {
-				return C.ERR_FULL;
-			}
-		});
+		() => checkName && (name in flags) ? C.ERR_NAME_EXISTS : C.OK,
+		() => checkString(name, 100, true));
 }

--- a/packages/xxscreeps/mods/flag/index.ts
+++ b/packages/xxscreeps/mods/flag/index.ts
@@ -4,5 +4,5 @@ export const manifest: Manifest = {
 	dependencies: [
 		'xxscreeps/mods/memory',
 	],
-	provides: [ 'backend', 'constants', 'driver', 'game' ],
+	provides: [ 'backend', 'constants', 'driver', 'game', 'test' ],
 };

--- a/packages/xxscreeps/mods/flag/test.ts
+++ b/packages/xxscreeps/mods/flag/test.ts
@@ -1,0 +1,45 @@
+import type { Dictionary } from 'xxscreeps/utility/types.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { Color, Flag, checkCreateFlag } from './flag.js';
+
+describe('Flag', () => {
+	describe('checkCreateFlag precedence', () => {
+		const pos = new RoomPosition(25, 25, 'W1N1');
+		const validColor = C.COLOR_RED;
+		const invalidColor = -1 as Color;
+		const longName = 'X'.repeat(101);
+		const fullFlags = (extra?: string): Dictionary<Flag> => {
+			const flags: Dictionary<Flag> = {};
+			for (let ii = 0; ii < C.FLAGS_LIMIT; ++ii) {
+				flags[`Flag${ii}`] = undefined;
+			}
+			if (extra !== undefined) {
+				flags[extra] = undefined;
+			}
+			return flags;
+		};
+
+		test('cap-full fires before invalid color', () => {
+			const result = checkCreateFlag(fullFlags(), pos, 'Flag', invalidColor, validColor, true);
+			assert.strictEqual(result, C.ERR_FULL);
+		});
+
+		test('cap-full fires before name-exists', () => {
+			const result = checkCreateFlag(fullFlags(), pos, 'Flag0', validColor, validColor, true);
+			assert.strictEqual(result, C.ERR_FULL);
+		});
+
+		test('cap-full fires before invalid name length', () => {
+			const result = checkCreateFlag(fullFlags(longName), pos, longName, validColor, validColor, true);
+			assert.strictEqual(result, C.ERR_FULL);
+		});
+
+		test('name-exists fires before invalid name length', () => {
+			const flags: Dictionary<Flag> = { [longName]: undefined };
+			const result = checkCreateFlag(flags, pos, longName, validColor, validColor, true);
+			assert.strictEqual(result, C.ERR_NAME_EXISTS);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`checkCreateFlag` had two precedence inversions vs vanilla, both in the same chain:

1. `ERR_FULL` (FLAGS_LIMIT) was the last check, after color and name validation. Vanilla returns it right after invalid-coords.
2. The name-length `ERR_INVALID_ARGS` branch fired before the `ERR_NAME_EXISTS` collision check. Vanilla returns `ERR_NAME_EXISTS` first.

This PR bundles both reorderings — they live in the same chain and share a "validate cheap state in vanilla order" root cause.

Part of #117 (`flag` row, `checkCreateFlag`).

## Vanilla precedence

`@screeps/engine/src/game/rooms.js` `Room.prototype.createFlag` (lines 978-1017):

```js
if (_.isUndefined(x) || _.isUndefined(y) || x < 0 || x > 49 || y < 0 || y > 49) {
    return C.ERR_INVALID_ARGS;        // invalid coords
}
if (_.size(globals.Game.flags) >= C.FLAGS_LIMIT) {
    return C.ERR_FULL;                // cap-full, BEFORE color/name
}
// ... color defaulting ...
if (!_.contains(C.COLORS_ALL, color))          return C.ERR_INVALID_ARGS;
if (!_.contains(C.COLORS_ALL, secondaryColor)) return C.ERR_INVALID_ARGS;
// ... name defaulting ...
if (_.any(register.flags, {name}) || createdFlagNames.indexOf(name) != -1) {
    return C.ERR_NAME_EXISTS;         // name-exists, BEFORE name-length
}
if (name.length > 100) {
    return C.ERR_INVALID_ARGS;
}
```

Order: `invalid-coords → ERR_FULL → invalid-color → ERR_NAME_EXISTS → name-length`.

## Before

`packages/xxscreeps/mods/flag/flag.ts` `checkCreateFlag`:

```ts
return chainIntentChecks(
    pos ? () => checkFlagPosition(pos) : () => C.OK,
    () => checkFlagColors(color, secondaryColor),
    () => {
        if (checkString(name, 100, true)) {
            return C.ERR_INVALID_ARGS;        // name-length BEFORE name-exists
        } else if (checkName && (name in flags)) {
            return C.ERR_NAME_EXISTS;
        } else if (Object.keys(flags).length >= C.FLAGS_LIMIT) {
            return C.ERR_FULL;                // cap-full LAST
        }
    });
```

## After

```ts
return chainIntentChecks(
    pos ? () => checkFlagPosition(pos) : () => C.OK,
    () => Object.keys(flags).length >= C.FLAGS_LIMIT ? C.ERR_FULL : C.OK,
    () => checkFlagColors(color, secondaryColor),
    () => checkName && (name in flags) ? C.ERR_NAME_EXISTS : C.OK,
    () => checkString(name, 100, true));
```

## Validation

- New regression suite `Flag > checkCreateFlag precedence` in `packages/xxscreeps/mods/flag/test.ts` covers all four inversions:
  - `cap-full fires before invalid color`
  - `cap-full fires before name-exists`
  - `cap-full fires before invalid name length`
  - `name-exists fires before invalid name length`

  Confirmed all four fail on the unmodified chain (`-10 !== -8`, `-3 !== -8`, `-10 !== -8`, `-10 !== -3`) and pass after the reorder.
- `pnpm run build` clean. `npx xxscreeps test` 212/212 pass.
- screeps-ok matrix confirms the fix:
  ```
  Parity: 4 unexpected pass(es) — regression fixed?
    flag-cap-too-late: FLAG-009:flagCapFullBeforeInvalidColor (1),
                       FLAG-009:flagCapFullBeforeNameExists (1),
                       FLAG-009:flagCapFullBeforeInvalidNameLength (1) now PASSES
    flag-name-length-vs-name-exists-inverted:
                       FLAG-009:nameExistsBeforeInvalidNameLength (1) now PASSES
  ```
- `eslint` on changed files introduces 0 new warnings.
