### PR TITLE
factory: hoist recipe and level mismatch above RCL gate

### DIFF
--- a/.changeset/factory-intent-precedence.md
+++ b/.changeset/factory-intent-precedence.md
@@ -1,0 +1,5 @@
+---
+'xxscreeps': patch
+---
+
+Hoist factory recipe and level-mismatch above RCL gate

--- a/packages/xxscreeps/mods/factory/factory.ts
+++ b/packages/xxscreeps/mods/factory/factory.ts
@@ -77,7 +77,7 @@ export type CommodityRecipe = {
 };
 
 export function getCommodityRecipe(resource: string): CommodityRecipe | undefined {
-	return C.COMMODITIES[resource] as CommodityRecipe | undefined;
+	return C.COMMODITIES[resource];
 }
 
 /**
@@ -107,8 +107,9 @@ function checkRecipeLevel(factory: StructureFactory, recipe: CommodityRecipe) {
 	}
 }
 
-// Validation order matches lab's checkRunReaction (ownership, cooldown, isActive, then recipe-dependent checks)
+// Validation order: ownership, cooldown, recipe checks, then RCL gate.
 export function checkProduce(factory: StructureFactory, resourceType: ResourceType) {
+	let recipe: CommodityRecipe | undefined;
 	return chainIntentChecks(
 		() => checkMyStructure(factory, StructureFactory),
 		() => {
@@ -116,15 +117,20 @@ export function checkProduce(factory: StructureFactory, resourceType: ResourceTy
 				return C.ERR_TIRED;
 			}
 		},
-		() => checkIsActive(factory),
 		() => {
-			const recipe = getCommodityRecipe(resourceType);
+			recipe = getCommodityRecipe(resourceType);
 			if (recipe === undefined) {
 				return C.ERR_INVALID_ARGS;
 			}
 			const levelCheck = checkRecipeLevel(factory, recipe);
 			if (levelCheck !== undefined) {
 				return levelCheck;
+			}
+		},
+		() => checkIsActive(factory),
+		() => {
+			if (recipe === undefined) {
+				return C.ERR_INVALID_ARGS;
 			}
 			let componentsTotal = 0;
 			for (const [ component, amount ] of Object.entries(recipe.components)) {

--- a/packages/xxscreeps/mods/factory/test.ts
+++ b/packages/xxscreeps/mods/factory/test.ts
@@ -224,7 +224,7 @@ describe('Factory', () => {
 			await player('100', Game => {
 				const factory = getFactory(Game);
 				// silicon is a deposit resource with no commodity recipe
-				assert.strictEqual(factory.produce(C.RESOURCE_SILICON as ResourceType), C.ERR_INVALID_ARGS);
+				assert.strictEqual(factory.produce(C.RESOURCE_SILICON), C.ERR_INVALID_ARGS);
 			});
 		}));
 
@@ -237,6 +237,20 @@ describe('Factory', () => {
 				room['#user'] = room.controller!['#user'] = '100';
 			},
 		});
+
+		test('invalid resource type before rcl gate', () => lowRclSim(async ({ player }) => {
+			await player('100', Game => {
+				const factory = getFactory(Game);
+				assert.strictEqual(factory.produce('not_a_real_resource' as ResourceType), C.ERR_INVALID_ARGS);
+			});
+		}));
+
+		test('level-mismatched recipe before rcl gate', () => lowRclSim(async ({ player }) => {
+			await player('100', Game => {
+				const factory = getFactory(Game);
+				assert.strictEqual(factory.produce(C.RESOURCE_COMPOSITE), C.ERR_INVALID_TARGET);
+			});
+		}));
 
 		test('inactive factory at low RCL', () => lowRclSim(async ({ player }) => {
 			await player('100', Game => {


### PR DESCRIPTION
## Summary
Hoist factory `produce()` recipe and level checks above the RCL gate so invalid recipe inputs return canonical errors before `ERR_RCL_NOT_ENOUGH`.

## Vanilla precedence
In vanilla `StructureFactory.prototype.produce` the order is:

- `ERR_NOT_OWNER`
- `ERR_TIRED`
- `ERR_INVALID_ARGS` (missing commodity)
- `ERR_INVALID_TARGET` (level mismatch)
- `ERR_RCL_NOT_ENOUGH`
- then busy/full/resource checks.

This follows the vanilla implementation of `StructureFactory.prototype.produce` in `@screeps/engine/src/game/structures.js`.

## Before
xxscreeps previously checked `checkIsActive` (RCL gate) before recipe lookup and level validation, so low-RCL rooms could return `ERR_RCL_NOT_ENOUGH` before `ERR_INVALID_ARGS` / `ERR_INVALID_TARGET`.

## After
`checkProduce` now validates recipe existence and level first, then runs `checkIsActive`, preserving later component/full checks.

This is a continuation of PR #114’s factory intent-order cleanup and addresses the remaining gap from issue `#117`.

## Validation
- Added regression tests for:
  - `FACTORY-PRODUCE-011:invalidArgsBeforeRcl`
  - `FACTORY-PRODUCE-011:levelMismatchBeforeRcl`
- Added `.changeset/factory-intent-precedence.md` (`xxscreeps` patch) with message: `Hoist factory recipe and level-mismatch above RCL gate`.
- `build`, `eslint`, and `xxscreeps test` pass in this worktree (`199 tests: 199 passed`).
