### PR TITLE
construction: allow placement in unowned and self-reserved rooms

### DIFF
--- a/.changeset/construction-site-foreign-controller.md
+++ b/.changeset/construction-site-foreign-controller.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Allow `createConstructionSite` at unowned and self-reserved rooms; return `ERR_NOT_OWNER` at hostile

--- a/packages/xxscreeps/mods/construction/room.ts
+++ b/packages/xxscreeps/mods/construction/room.ts
@@ -1,7 +1,7 @@
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { hooks, intents, me, userGame } from 'xxscreeps/game/index.js';
+import { Game, hooks, intents, me, userGame } from 'xxscreeps/game/index.js';
 import { makeObstacleChecker } from 'xxscreeps/game/pathfinder/obstacle.js';
 import { RoomPosition, fetchArguments } from 'xxscreeps/game/position.js';
 import { Room, registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
@@ -96,9 +96,19 @@ export function checkCreateConstructionSite(room: Room, pos: RoomPosition, struc
 		return C.ERR_INVALID_ARGS;
 	}
 
-	// Can't build in someone else's room
-	if (!room.controller?.my) {
-		return C.ERR_RCL_NOT_ENOUGH;
+	// Reject foreign-owned and foreign-reserved rooms; unowned and self-reserved
+	// fall through to the rcl=0 cap, which permits road/container.
+	const controller = room.controller;
+	if (controller) {
+		const ownerId = controller['#user'];
+		if (ownerId != null && ownerId !== me) {
+			return C.ERR_NOT_OWNER;
+		}
+		const reserverId = room['#user'];
+		if (reserverId != null && reserverId !== me &&
+			controller['#reservationEndTime'] > Game.time) {
+			return C.ERR_NOT_OWNER;
+		}
 	}
 
 	// Check structure count for this RCL

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -14,6 +14,81 @@ describe('Construction', () => {
 		},
 	});
 
+	describe('createConstructionSite controller-ownership gating', () => {
+		// A scout creep gives the player visibility so `Game.rooms.W1N1` is populated.
+		const scout = (roomName: string) => createCreep(new RoomPosition(40, 40, roomName), [ C.MOVE ], 'scout', '100');
+
+		// Unowned controller (no owner, no reservation): vanilla allows road/container at rcl=0
+		// but rejects everything else with ERR_RCL_NOT_ENOUGH.
+		const unowned = simulate({
+			W1N1: room => {
+				room['#insertObject'](scout('W1N1'));
+			},
+		});
+		test('unowned controller allows road/container, rejects rcl>0 structures', () => unowned(async ({ player, tick }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(25, 25, 'road'), C.OK);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(26, 25, 'container'), C.OK);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(27, 25, 'spawn', 'S1'), C.ERR_RCL_NOT_ENOUGH);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(28, 25, 'extension'), C.ERR_RCL_NOT_ENOUGH);
+			});
+			await tick();
+			await player('100', Game => {
+				const types = Object.values(Game.constructionSites).map(site => site.structureType).sort();
+				assert.deepStrictEqual(types, [ 'container', 'road' ]);
+			});
+		}));
+
+		// Self-reserved controller behaves like an unowned one for placement: rcl is still 0,
+		// so road/container succeed and the rest fail with ERR_RCL_NOT_ENOUGH.
+		const ownReservation = simulate({
+			W1N1: room => {
+				room['#user'] = '100';
+				room.controller!['#reservationEndTime'] = 5000;
+				room['#insertObject'](scout('W1N1'));
+			},
+		});
+		test('self-reserved controller allows road/container, rejects rcl>0 structures', () => ownReservation(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(25, 25, 'road'), C.OK);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(26, 25, 'container'), C.OK);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(27, 25, 'spawn', 'S1'), C.ERR_RCL_NOT_ENOUGH);
+			});
+		}));
+
+		// Hostile-reserved controller: vanilla returns ERR_NOT_OWNER for every structureType.
+		const hostileReservation = simulate({
+			W1N1: room => {
+				room['#user'] = '101';
+				room.controller!['#reservationEndTime'] = 5000;
+				room['#insertObject'](scout('W1N1'));
+			},
+		});
+		test('hostile-reserved controller rejects every structureType with ERR_NOT_OWNER', () => hostileReservation(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(25, 25, 'road'), C.ERR_NOT_OWNER);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(26, 25, 'container'), C.ERR_NOT_OWNER);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(27, 25, 'spawn', 'S1'), C.ERR_NOT_OWNER);
+			});
+		}));
+
+		// Hostile-owned controller: vanilla returns ERR_NOT_OWNER for every structureType.
+		const hostileOwned = simulate({
+			W1N1: room => {
+				room['#level'] = 4;
+				room['#user'] = room.controller!['#user'] = '101';
+				room['#insertObject'](scout('W1N1'));
+			},
+		});
+		test('hostile-owned controller rejects every structureType with ERR_NOT_OWNER', () => hostileOwned(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(25, 25, 'road'), C.ERR_NOT_OWNER);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(26, 25, 'container'), C.ERR_NOT_OWNER);
+				assert.strictEqual(Game.rooms.W1N1.createConstructionSite(27, 25, 'spawn', 'S1'), C.ERR_NOT_OWNER);
+			});
+		}));
+	});
+
 	test('create site', () => construction(async ({ player, tick }) => {
 		await player('100', Game => {
 			Game.rooms.W1N1.createConstructionSite(25, 25, 'road');


### PR DESCRIPTION
Fixes #185.

## Summary

`Room.createConstructionSite` rejected every placement at any controller not owned by the caller. The check `!room.controller?.my`:

- Rejected unowned rooms (no road/container at rcl 0)
- Rejected the caller's own reservations
- Returned `ERR_RCL_NOT_ENOUGH` for hostile-owned rooms instead of `ERR_NOT_OWNER`

Foreign-owned and foreign-reserved controllers now return `ERR_NOT_OWNER`; unowned and self-reserved rooms fall through to the per-rcl cap check, so road and container succeed at rcl 0.

## Verification

- Unowned controller: road/container OK; rcl>0 types `ERR_RCL_NOT_ENOUGH`
- Self-reserved by caller: road/container OK; rcl>0 types `ERR_RCL_NOT_ENOUGH`
- Hostile-reserved: every structureType `ERR_NOT_OWNER`
- Hostile-owned: every structureType `ERR_NOT_OWNER`
- End-to-end: unowned + road/container survives `tick()` and lands as construction sites