### PR TITLE
Reorder construction creep build/repair validation precedence

### DIFF
--- a/.changeset/construction-creep-validation-precedence.md
+++ b/.changeset/construction-creep-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder construction creep build and repair validation precedence.

--- a/packages/xxscreeps/mods/construction/creep.ts
+++ b/packages/xxscreeps/mods/construction/creep.ts
@@ -56,9 +56,9 @@ extend(Creep, {
 export function checkBuild(creep: Creep, target: ConstructionSite) {
 	return chainIntentChecks(
 		() => checkCommon(creep, C.WORK),
+		() => checkHasResource(creep, C.RESOURCE_ENERGY),
 		() => checkTarget(target, ConstructionSite),
 		() => checkRange(creep, target, 3),
-		() => checkHasResource(creep, C.RESOURCE_ENERGY),
 		() => {
 			// A friendly creep sitting on top of a construction site for an obstacle structure prevents
 			// `build`
@@ -85,7 +85,7 @@ export function checkDismantle(creep: Creep, target: Structure) {
 export function checkRepair(creep: Creep, target: Structure) {
 	return chainIntentChecks(
 		() => checkCommon(creep, C.WORK),
+		() => checkHasResource(creep, C.RESOURCE_ENERGY),
 		() => checkTarget(target, Structure),
-		() => checkRange(creep, target, 3),
-		() => checkHasResource(creep, C.RESOURCE_ENERGY));
+		() => checkRange(creep, target, 3));
 }

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -110,6 +110,88 @@ describe('Construction', () => {
 		});
 	}));
 
+	describe('creep intent precedence', () => {
+		const noEnergyWorker = simulate({
+			W1N1: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				room['#insertObject'](createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.CARRY ], 'worker', '100'));
+			},
+		});
+
+		test('REPAIR-010:not-enough-before-invalid-target', () => noEnergyWorker(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.creeps.worker!.repair(undefined as never), C.ERR_NOT_ENOUGH_RESOURCES);
+			});
+		}));
+
+		test('BUILD-011:not-enough-before-invalid-target', () => noEnergyWorker(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.creeps.worker!.build(undefined as never), C.ERR_NOT_ENOUGH_RESOURCES);
+			});
+		}));
+
+		const noEnergyOutOfRange = simulate({
+			W1N1: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				room['#insertObject'](createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.CARRY ], 'worker', '100'));
+				room['#insertObject'](createContainer(new RoomPosition(20, 20, 'W1N1')));
+				room['#insertObject'](createSite(new RoomPosition(20, 21, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road));
+			},
+		});
+
+		test('REPAIR-010:not-enough-before-range', () => noEnergyOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+				assert.strictEqual(Game.creeps.worker!.repair(container), C.ERR_NOT_ENOUGH_RESOURCES);
+			});
+		}));
+
+		test('BUILD-011:not-enough-before-range', () => noEnergyOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				const site = Object.values(Game.constructionSites)[0]!;
+				assert.strictEqual(Game.creeps.worker!.build(site), C.ERR_NOT_ENOUGH_RESOURCES);
+			});
+		}));
+
+		const noEnergyBlockedTarget = simulate({
+			W1N1: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				room['#insertObject'](createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.CARRY ], 'builder', '100'));
+				room['#insertObject'](createCreep(new RoomPosition(12, 10, 'W1N1'), [ C.MOVE ], 'blocker', '100'));
+				room['#insertObject'](createSite(new RoomPosition(12, 10, 'W1N1'), C.STRUCTURE_EXTENSION, '100', C.CONSTRUCTION_COST.extension));
+			},
+		});
+
+		test('BUILD-011:not-enough-before-blocked-target', () => noEnergyBlockedTarget(async ({ player }) => {
+			await player('100', Game => {
+				const site = Object.values(Game.constructionSites)[0]!;
+				assert.strictEqual(Game.creeps.builder!.build(site), C.ERR_NOT_ENOUGH_RESOURCES);
+			});
+		}));
+
+		const blockedTargetOutOfRange = simulate({
+			W1N1: room => {
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+				const builder = createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.CARRY ], 'builder', '100');
+				builder.store['#add'](C.RESOURCE_ENERGY, 50);
+				room['#insertObject'](builder);
+				room['#insertObject'](createCreep(new RoomPosition(20, 20, 'W1N1'), [ C.MOVE ], 'blocker', '100'));
+				room['#insertObject'](createSite(new RoomPosition(20, 20, 'W1N1'), C.STRUCTURE_EXTENSION, '100', C.CONSTRUCTION_COST.extension));
+			},
+		});
+
+		test('BUILD-011:range-before-blocked-target', () => blockedTargetOutOfRange(async ({ player }) => {
+			await player('100', Game => {
+				const site = Object.values(Game.constructionSites)[0]!;
+				assert.strictEqual(Game.creeps.builder!.build(site), C.ERR_NOT_IN_RANGE);
+			});
+		}));
+	});
+
 	describe('stomping', () => {
 		const stomping = simulate({
 			W1N1: room => {


### PR DESCRIPTION
## Summary

`checkBuild` and `checkRepair` returned target/range errors before `ERR_NOT_ENOUGH_RESOURCES` when the creep had no energy. Vanilla gates carried energy before target and range validation for both methods.

This PR hoists the energy check in both construction creep intent chains. `checkBuild` still keeps range before blocked-target validation.

Part of #117 (`construction` row, `checkBuild` / `checkRepair`).

## Vanilla precedence

`@screeps/engine/src/game/creeps.js` `Creep.prototype.repair` and `Creep.prototype.build`:

```js
if(!this.my)                         return ERR_NOT_OWNER;
if(this.spawning)                    return ERR_BUSY;
if(!hasActiveBodypart(WORK))         return ERR_NO_BODYPART;
if(!this.carry.energy)               return ERR_NOT_ENOUGH_RESOURCES;
if(!target /* wrong type */)         return ERR_INVALID_TARGET;
if(!this.pos.inRangeTo(target, 3))   return ERR_NOT_IN_RANGE;
```

For `build`, the blocked-target checks happen after range.

Order: `NOT_OWNER -> BUSY -> NO_BODYPART -> NOT_ENOUGH_RESOURCES -> INVALID_TARGET -> NOT_IN_RANGE -> blocked target`.

## Before

`packages/xxscreeps/mods/construction/creep.ts`:

```ts
// checkRepair
() => checkCommon(creep, WORK),       // NOT_OWNER, BUSY, NO_BODYPART
() => checkTarget(target, Structure), // INVALID_TARGET
() => checkRange(creep, target, 3),   // NOT_IN_RANGE
() => checkHasResource(creep, energy),// NOT_ENOUGH_RESOURCES  <-- too late

// checkBuild
() => checkCommon(creep, WORK),
() => checkTarget(target, ConstructionSite),
() => checkRange(creep, target, 3),
() => checkHasResource(creep, energy),// NOT_ENOUGH_RESOURCES  <-- too late
() => blockedTargetCheck(),
```

## After

```ts
// checkRepair
() => checkCommon(creep, WORK),
() => checkHasResource(creep, energy),// NOT_ENOUGH_RESOURCES now precedes target/range
() => checkTarget(target, Structure),
() => checkRange(creep, target, 3),

// checkBuild
() => checkCommon(creep, WORK),
() => checkHasResource(creep, energy),// NOT_ENOUGH_RESOURCES now precedes target/range/blocked
() => checkTarget(target, ConstructionSite),
() => checkRange(creep, target, 3),
() => blockedTargetCheck(),           // range still precedes blocked target
```

## Validation

- New regression tests in `packages/xxscreeps/mods/construction/test.ts`:
  - `REPAIR-010:not-enough-before-invalid-target`
  - `REPAIR-010:not-enough-before-range`
  - `BUILD-011:not-enough-before-invalid-target`
  - `BUILD-011:not-enough-before-range`
  - `BUILD-011:not-enough-before-blocked-target`
  - `BUILD-011:range-before-blocked-target`
- Confirmed the narrow test failed before the reorder: 6 tests, 2 passed, 4 failed.
- `npm run build` passed.
- `npm test -- "Construction" "creep intent precedence"` passed: 6/6.
- `npm test -- "Construction"` passed: 19/19.
