### PR TITLE
Defer spawn ownership checks until after argument validation

### DIFF
--- a/.changeset/spawn-not-owner-precedence.md
+++ b/.changeset/spawn-not-owner-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Defer spawn ownership checks until after argument validation.

--- a/packages/xxscreeps/mods/spawn/spawn.ts
+++ b/packages/xxscreeps/mods/spawn/spawn.ts
@@ -270,10 +270,11 @@ export function checkRecycleCreep(spawn: StructureSpawn, creep: Creep) {
 
 export function checkRenewCreep(spawn: StructureSpawn, creep: Creep) {
 	return chainIntentChecks(
-		() => checkMyStructure(spawn, StructureSpawn),
+		() => checkSpawnType(spawn),
 		() => spawn.spawning ? C.ERR_BUSY : C.OK,
-		() => checkIsActive(spawn),
 		() => checkTarget(creep, Creep),
+		() => checkSpawnOwner(spawn),
+		() => checkIsActive(spawn),
 		() => checkCommon(creep),
 		() => checkRange(spawn, creep, 1),
 		() => {
@@ -296,6 +297,14 @@ export function checkDirections(directions: Direction[] | null) {
 	);
 }
 
+function checkSpawnType(spawn: StructureSpawn) {
+	return spawn instanceof StructureSpawn ? C.OK : C.ERR_INVALID_ARGS;
+}
+
+function checkSpawnOwner(spawn: StructureSpawn) {
+	return spawn.my ? C.OK : C.ERR_NOT_OWNER;
+}
+
 export function checkSpawnCreep(
 	spawn: StructureSpawn,
 	body: PartType[],
@@ -304,7 +313,7 @@ export function checkSpawnCreep(
 	energyStructures: (StructureExtension | StructureSpawn)[] | null,
 ) {
 	return chainIntentChecks(
-		() => checkMyStructure(spawn, StructureSpawn),
+		() => checkSpawnType(spawn),
 		() => checkString(name, 100, true),
 		() => {
 			if (userGame?.creeps[name] !== undefined) {
@@ -313,6 +322,9 @@ export function checkSpawnCreep(
 			if (directions !== null && !checkDirections(directions)) {
 				return C.ERR_INVALID_ARGS;
 			}
+		},
+		() => checkSpawnOwner(spawn),
+		() => {
 			if (spawn.spawning) {
 				return C.ERR_BUSY;
 			}

--- a/packages/xxscreeps/mods/spawn/test.ts
+++ b/packages/xxscreeps/mods/spawn/test.ts
@@ -1,5 +1,4 @@
 import type { StructureExtension } from './extension.js';
-import type { StructureSpawn } from './spawn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Creep, create as createCreep } from 'xxscreeps/mods/creep/creep.js';
@@ -117,49 +116,43 @@ describe('Spawn', () => {
 		},
 	});
 
-	test('SPAWN-CREATE-014:invalid-name-or-options-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
-		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+	test('SPAWN-CREATE-014:invalid-name-or-options-before-not-owner', () => foreignSpawnSim(async ({ player }) => {
 		await player('101', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			const spawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_SPAWN)[0]!;
 			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'x'.repeat(101)), C.ERR_INVALID_ARGS);
 		});
 	}));
 
-	test('SPAWN-CREATE-014:name-exists-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
-		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+	test('SPAWN-CREATE-014:name-exists-before-not-owner', () => foreignSpawnSim(async ({ player }) => {
 		await player('101', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			const spawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_SPAWN)[0]!;
 			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'worker'), C.ERR_NAME_EXISTS);
 		});
 	}));
 
-	test('SPAWN-CREATE-014:invalid-directions-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
-		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+	test('SPAWN-CREATE-014:invalid-directions-before-not-owner', () => foreignSpawnSim(async ({ player }) => {
 		await player('101', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			const spawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_SPAWN)[0]!;
 			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'newCreep', {
 				directions: [ 99 as never ],
 			}), C.ERR_INVALID_ARGS);
 		});
 	}));
 
-	test('RENEW-CREEP-011:busy-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom, tick }) => {
-		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+	test('RENEW-CREEP-011:busy-before-not-owner', () => foreignSpawnSim(async ({ player, tick }) => {
 		await player('100', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
-			assert.strictEqual(spawn.spawnCreep([ C.MOVE, C.MOVE, C.MOVE ], 'busy'), C.OK);
+			assert.strictEqual(Game.spawns.Spawn1!.spawnCreep([ C.MOVE, C.MOVE, C.MOVE ], 'busy'), C.OK);
 		});
 		await tick();
 		await player('101', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			const spawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_SPAWN)[0]!;
 			assert.strictEqual(spawn.renewCreep(Game.creeps.worker!), C.ERR_BUSY);
 		});
 	}));
 
-	test('RENEW-CREEP-011:invalid-target-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
-		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+	test('RENEW-CREEP-011:invalid-target-before-not-owner', () => foreignSpawnSim(async ({ player }) => {
 		await player('101', Game => {
-			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			const spawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_SPAWN)[0]!;
 			assert.strictEqual(spawn.renewCreep(spawn as never), C.ERR_INVALID_TARGET);
 		});
 	}));

--- a/packages/xxscreeps/mods/spawn/test.ts
+++ b/packages/xxscreeps/mods/spawn/test.ts
@@ -1,4 +1,5 @@
 import type { StructureExtension } from './extension.js';
+import type { StructureSpawn } from './spawn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Creep, create as createCreep } from 'xxscreeps/mods/creep/creep.js';
@@ -104,6 +105,62 @@ describe('Spawn', () => {
 	test('renewCreep undefined', () => simulation(async ({ player }) => {
 		await player('100', Game => {
 			assert.strictEqual(Game.spawns.Spawn1!.renewCreep(undefined as never), C.ERR_INVALID_TARGET);
+		});
+	}));
+
+	const foreignSpawnSim = simulate({
+		W1N1: room => {
+			room['#insertObject'](create(new RoomPosition(25, 25, 'W1N1'), '100', 'Spawn1'));
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.WORK, C.CARRY, C.MOVE ], 'worker', '101'));
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = '100';
+		},
+	});
+
+	test('SPAWN-CREATE-014:invalid-name-or-options-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
+		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+		await player('101', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'x'.repeat(101)), C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('SPAWN-CREATE-014:name-exists-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
+		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+		await player('101', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'worker'), C.ERR_NAME_EXISTS);
+		});
+	}));
+
+	test('SPAWN-CREATE-014:invalid-directions-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
+		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+		await player('101', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.spawnCreep([ C.MOVE ], 'newCreep', {
+				directions: [ 99 as never ],
+			}), C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('RENEW-CREEP-011:busy-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom, tick }) => {
+		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+		await player('100', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.spawnCreep([ C.MOVE, C.MOVE, C.MOVE ], 'busy'), C.OK);
+		});
+		await tick();
+		await player('101', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.renewCreep(Game.creeps.worker!), C.ERR_BUSY);
+		});
+	}));
+
+	test('RENEW-CREEP-011:invalid-target-before-not-owner', () => foreignSpawnSim(async ({ player, peekRoom }) => {
+		const spawnId = await peekRoom('W1N1', room => room.lookForAt(C.LOOK_STRUCTURES, 25, 25)[0]!.id);
+		await player('101', Game => {
+			const spawn = Game.getObjectById<StructureSpawn>(spawnId)!;
+			assert.strictEqual(spawn.renewCreep(spawn as never), C.ERR_INVALID_TARGET);
 		});
 	}));
 


### PR DESCRIPTION
## Summary

`checkSpawnCreep` and `checkRenewCreep` returned `ERR_NOT_OWNER` before earlier vanilla validation branches. This PR splits spawn type validation from ownership locally so ownership can run after argument and target validation without broadening `checkMyStructure`.

Part of #117 (`spawn` row, `checkSpawnCreep` / `checkRenewCreep`).

## Vanilla precedence

`@screeps/engine/src/game/structures.js` `StructureSpawn.prototype.spawnCreep` validates name/options, name existence, and directions before checking spawn ownership.

Order: name/options validity -> name existence -> directions validity -> `NOT_OWNER` -> `BUSY` -> body validity -> energy availability.

`@screeps/engine/src/game/structures.js` `StructureSpawn.prototype.renewCreep` validates spawn busy state and target validity before checking spawn ownership.

Order: `BUSY` -> target validity -> `NOT_OWNER` -> RCL -> range -> energy availability -> TTL-full.

## Before

`packages/xxscreeps/mods/spawn/spawn.ts` `checkSpawnCreep` and `checkRenewCreep` both began with `checkMyStructure(spawn, StructureSpawn)`. Because that helper combines type and ownership validation, foreign spawns returned `ERR_NOT_OWNER` before the vanilla-earlier argument and target checks.

## After

`checkSpawnType` keeps the initial type guard, while `checkSpawnOwner` runs after the earlier vanilla checks:

```ts
checkSpawnCreep: type -> name -> name-exists/directions -> owner -> busy -> RCL -> body/energy
checkRenewCreep: type -> busy -> target -> owner -> RCL -> creep common/range/energy/full
```

## Validation

- New regression tests in `packages/xxscreeps/mods/spawn/test.ts`. Confirmed failing before the reorder with `ERR_NOT_OWNER`, passing after.
- `npm run build` clean.
- `npm test -- Spawn` clean.
- `npm test -- "Spawn isActive"` clean.
- `npm test` clean: 231/231 pass.
- Verified against screeps-ok: `SPAWN-CREATE-014` and `RENEW-CREEP-011` now pass for the fixed precedence cases.
