### PR TITLE
Reorder controller action validation precedence

### DIFF
--- a/.changeset/controller-validation-precedence.md
+++ b/.changeset/controller-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder controller action validation precedence.

--- a/packages/xxscreeps/mods/controller/creep.ts
+++ b/packages/xxscreeps/mods/controller/creep.ts
@@ -113,10 +113,15 @@ extend(Creep, {
 });
 
 // Intent checkers
+function checkClaimPart(creep: Creep) {
+	return creep.getActiveBodyparts(C.CLAIM) > 0 ? C.OK : C.ERR_NO_BODYPART;
+}
+
 export function checkAttackController(creep: Creep, target: StructureController) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.CLAIM),
+		() => checkCommon(creep),
 		() => checkTarget(target, StructureController),
+		() => checkClaimPart(creep),
 		() => checkRange(creep, target, 1),
 		() => checkSafeMode(target.room, C.ERR_NO_BODYPART),
 		() => {
@@ -131,13 +136,16 @@ export function checkAttackController(creep: Creep, target: StructureController)
 
 export function checkClaimController(creep: Creep, target: StructureController) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.CLAIM),
-		() => checkTarget(target, StructureController),
-		() => checkRange(creep, target, 1),
+		() => checkCommon(creep),
 		() => {
 			if (userGame && userGame.gcl.level <= userGame.gcl['#roomCount']) {
 				return C.ERR_GCL_NOT_ENOUGH;
 			}
+		},
+		() => checkTarget(target, StructureController),
+		() => checkClaimPart(creep),
+		() => checkRange(creep, target, 1),
+		() => {
 			const user = target['#user'];
 			if (user !== null) {
 				return C.ERR_INVALID_TARGET;
@@ -161,7 +169,7 @@ export function checkGenerateSafeMode(creep: Creep, target: StructureController)
 
 export function checkReserveController(creep: Creep, target: StructureController) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.CLAIM),
+		() => checkCommon(creep),
 		() => checkTarget(target, StructureController),
 		() => checkRange(creep, target, 1),
 		() => {
@@ -170,7 +178,8 @@ export function checkReserveController(creep: Creep, target: StructureController
 			if ((user !== null && user !== me) || (roomUser !== null && roomUser !== me) || target.level !== 0) {
 				return C.ERR_INVALID_TARGET;
 			}
-		});
+		},
+		() => checkClaimPart(creep));
 }
 
 export function checkSignController(creep: Creep, target: StructureController, message: string | null | undefined) {

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -1,3 +1,4 @@
+import type { GameConstructor } from 'xxscreeps/game/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create } from 'xxscreeps/mods/creep/creep.js';
@@ -9,6 +10,25 @@ describe('Controller', () => {
 
 	// Controller in W3N3 is at (33, 32)
 	const pos = new RoomPosition(34, 32, 'W3N3');
+	const farPos = new RoomPosition(10, 10, 'W3N3');
+
+	function setGclRoomCount(Game: GameConstructor, roomCount: number) {
+		Game.gcl = {
+			level: 1,
+			progress: 0,
+			progressTotal: C.GCL_MULTIPLY,
+			'#roomCount': roomCount,
+		};
+	}
+
+	function exhaustGcl(Game: GameConstructor) {
+		setGclRoomCount(Game, 1);
+	}
+
+	function findContainer(Game: GameConstructor) {
+		return Game.rooms.W3N3!.find(C.FIND_STRUCTURES)
+			.find(structure => structure.structureType === C.STRUCTURE_CONTAINER)!;
+	}
 
 	const hostileReservation = simulate({
 		W3N3: room => {
@@ -21,6 +41,31 @@ describe('Controller', () => {
 	const neutralRoom = simulate({
 		W3N3: room => {
 			room['#insertObject'](create(pos, [ C.CLAIM, C.MOVE ], 'claimer', '100'));
+		},
+	});
+
+	const claimPrecedence = simulate({
+		W3N3: room => {
+			room['#insertObject'](create(pos, [ C.CLAIM ], 'claimer', '100'));
+			room['#insertObject'](create(new RoomPosition(32, 32, 'W3N3'), [ C.MOVE ], 'worker', '100'));
+			room['#insertObject'](create(farPos, [ C.CLAIM ], 'distantClaimer', '100'));
+			room['#insertObject'](createContainer(pos));
+		},
+	});
+
+	const neutralNoClaim = simulate({
+		W3N3: room => {
+			room['#insertObject'](create(pos, [ C.MOVE ], 'worker', '100'));
+			room['#insertObject'](create(farPos, [ C.MOVE ], 'distantWorker', '100'));
+			room['#insertObject'](createContainer(pos));
+		},
+	});
+
+	const hostileNoClaim = simulate({
+		W3N3: room => {
+			room['#user'] = '101';
+			room.controller!['#reservationEndTime'] = 5000;
+			room['#insertObject'](create(pos, [ C.MOVE ], 'worker', '100'));
 		},
 	});
 
@@ -45,6 +90,51 @@ describe('Controller', () => {
 			await player('100', Game => {
 				const controller = Game.rooms.W3N3!.controller!;
 				assert.strictEqual(Game.creeps.claimer!.attackController(controller), C.ERR_INVALID_TARGET);
+			});
+		}));
+
+		test('CTRL-ATTACK-007:invalid-target-before-no-bodypart', () => neutralNoClaim(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(
+					Game.creeps.worker!.attackController(findContainer(Game) as unknown as StructureController),
+					C.ERR_INVALID_TARGET);
+			});
+		}));
+	});
+
+	describe('claimController', () => {
+
+		test('CTRL-CLAIM-008:gcl-not-enough-before-invalid-target', () => claimPrecedence(async ({ player }) => {
+			await player('100', Game => {
+				exhaustGcl(Game);
+				assert.strictEqual(
+					Game.creeps.claimer!.claimController(findContainer(Game) as unknown as StructureController),
+					C.ERR_GCL_NOT_ENOUGH);
+			});
+		}));
+
+		test('CTRL-CLAIM-008:gcl-not-enough-before-no-bodypart', () => claimPrecedence(async ({ player }) => {
+			await player('100', Game => {
+				exhaustGcl(Game);
+				const controller = Game.rooms.W3N3!.controller!;
+				assert.strictEqual(Game.creeps.worker!.claimController(controller), C.ERR_GCL_NOT_ENOUGH);
+			});
+		}));
+
+		test('CTRL-CLAIM-008:gcl-not-enough-before-range', () => claimPrecedence(async ({ player }) => {
+			await player('100', Game => {
+				exhaustGcl(Game);
+				const controller = Game.rooms.W3N3!.controller!;
+				assert.strictEqual(Game.creeps.distantClaimer!.claimController(controller), C.ERR_GCL_NOT_ENOUGH);
+			});
+		}));
+
+		test('CTRL-CLAIM-008:invalid-target-before-no-bodypart', () => neutralNoClaim(async ({ player }) => {
+			await player('100', Game => {
+				setGclRoomCount(Game, 0);
+				assert.strictEqual(
+					Game.creeps.worker!.claimController(findContainer(Game) as unknown as StructureController),
+					C.ERR_INVALID_TARGET);
 			});
 		}));
 	});
@@ -90,6 +180,28 @@ describe('Controller', () => {
 			await player('100', Game => {
 				const controller = Game.rooms.W3N3!.controller!;
 				assert.strictEqual(Game.creeps.claimer!.reserveController(controller), C.OK);
+			});
+		}));
+
+		test('CTRL-RESERVE-008:invalid-target-before-no-bodypart', () => neutralNoClaim(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(
+					Game.creeps.worker!.reserveController(findContainer(Game) as unknown as StructureController),
+					C.ERR_INVALID_TARGET);
+			});
+		}));
+
+		test('CTRL-RESERVE-008:range-before-no-bodypart', () => neutralNoClaim(async ({ player }) => {
+			await player('100', Game => {
+				const controller = Game.rooms.W3N3!.controller!;
+				assert.strictEqual(Game.creeps.distantWorker!.reserveController(controller), C.ERR_NOT_IN_RANGE);
+			});
+		}));
+
+		test('CTRL-RESERVE-008:invalid-controller-state-before-no-bodypart', () => hostileNoClaim(async ({ player }) => {
+			await player('100', Game => {
+				const controller = Game.rooms.W3N3!.controller!;
+				assert.strictEqual(Game.creeps.worker!.reserveController(controller), C.ERR_INVALID_TARGET);
 			});
 		}));
 	});


### PR DESCRIPTION
## Summary

Controller actions checked missing `CLAIM` too early, which masked higher-precedence
GCL, target, range, and controller-state errors. This PR splits the common creep
ownership/busy checks from the `CLAIM` bodypart gate and moves that gate later in
the affected chains.

Part of #117 (`controller` row, controller action precedence).

## Vanilla precedence

`@screeps/engine/src/game/creeps.js`:

- `claimController` checks `NOT_OWNER -> BUSY -> GCL_NOT_ENOUGH -> target -> CLAIM -> range`.
- `attackController` checks `NOT_OWNER -> BUSY -> target -> CLAIM -> range`.
- `reserveController` checks `NOT_OWNER -> BUSY -> target -> range -> controller state -> CLAIM`.

## Before

`checkAttackController`, `checkClaimController`, and `checkReserveController`
started with:

```ts
() => checkCommon(creep, C.CLAIM)
```

That made `ERR_NO_BODYPART` fire before later target/range/controller checks.

## After

The affected chains now start with `checkCommon(creep)` and perform the explicit
`CLAIM` check at the vanilla-equivalent point for each action.

## Validation

- Added eight focused controller precedence regression tests.
- Confirmed the new tests failed before the reorder: `19 tests: 11 passed, 8 failed`.
- `npm run build` clean.
- `npm test -- Controller` clean: `19 tests: 19 passed, 0 failed`.
- `npm test` clean: `234 tests: 234 passed, 0 failed`.
- Verified against screeps-ok with `screeps-ok-pr`:
  - `CTRL-CLAIM-008:gclNotEnoughBeforeInvalidTarget`
  - `CTRL-CLAIM-008:gclNotEnoughBeforeNoBodypart`
  - `CTRL-CLAIM-008:gclNotEnoughBeforeRange`
  - `CTRL-CLAIM-008:invalidTargetBeforeNoBodypart`
  - `CTRL-RESERVE-008:invalidTargetBeforeNoBodypart`
  - `CTRL-RESERVE-008:rangeBeforeNoBodypart`
  - `CTRL-RESERVE-008:invalidControllerStateBeforeNoBodypart`
  - `CTRL-ATTACK-007:invalidTargetBeforeNoBodypart`
