### PR TITLE
Enable configuring shard name as per yaml config schema

### DIFF
--- a/packages/xxscreeps/backend/context.ts
+++ b/packages/xxscreeps/backend/context.ts
@@ -1,5 +1,6 @@
 import type { World } from 'xxscreeps/game/map.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import config from 'xxscreeps/config/index.js';
 
 export class BackendContext {
 	readonly disposable;
@@ -20,7 +21,7 @@ export class BackendContext {
 		// Connect to services
 		using disposable = new DisposableStack();
 		const db = disposable.use(await Database.connect());
-		const shard = disposable.use(await Shard.connect(db, 'shard0'));
+		const shard = disposable.use(await Shard.connect(db, config.shards[0]!.name));
 		const world = await shard.loadWorld();
 		const rooms = await shard.data.smembers('rooms');
 		const context = new BackendContext(disposable.move(), db, shard, world, new Set(rooms));

--- a/packages/xxscreeps/engine/processor/worker.ts
+++ b/packages/xxscreeps/engine/processor/worker.ts
@@ -1,4 +1,5 @@
 import type { Room } from 'xxscreeps/game/room/room.js';
+import config from 'xxscreeps/config/index.js';
 import { importMods } from 'xxscreeps/config/mods/index.js';
 import { loadTerrain } from 'xxscreeps/driver/pathfinder.js';
 import { consumeSet } from 'xxscreeps/engine/db/async.js';
@@ -51,7 +52,7 @@ let world: World;
 
 // Connect to storage
 using db = await Database.connect();
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 
 // Create responder host and listen for requests
 await makeBasicResponderHost<ProcessorRequest>(import.meta.url, async message => {

--- a/packages/xxscreeps/engine/service/launcher.ts
+++ b/packages/xxscreeps/engine/service/launcher.ts
@@ -15,7 +15,7 @@ const argv = checkArguments({
 
 // Connect to shard
 using db = await Database.connect();
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 await using disposable = new AsyncDisposableStack();
 
 // Open databases, saving on exit (graceful or not). The local database providers save

--- a/packages/xxscreeps/engine/service/main.ts
+++ b/packages/xxscreeps/engine/service/main.ts
@@ -13,7 +13,7 @@ import { checkIsEntry, getServiceChannel } from './index.js';
 checkIsEntry();
 
 using db = await Database.connect();
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 await using disposable = new AsyncDisposableStack();
 
 // Open channels

--- a/packages/xxscreeps/engine/service/processor.ts
+++ b/packages/xxscreeps/engine/service/processor.ts
@@ -30,7 +30,7 @@ using _signal = handleInterruptSignal(() => {
 // Connect to main & storage
 await using disposable = new AsyncDisposableStack();
 using db = await Database.connect();
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 const worldBlob = await shard.data.req('terrain', { blob: true });
 const processorSubscription =	disposable.adopt(
 	await getProcessorChannel(shard).subscribe(),

--- a/packages/xxscreeps/engine/service/runner.ts
+++ b/packages/xxscreeps/engine/service/runner.ts
@@ -36,7 +36,7 @@ using _signal = handleInterruptSignal(() => {
 // Connect to main & storage
 using disposable = new DisposableStack();
 using db = await Database.connect();
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 const runnerSubscription =	disposable.adopt(
 	await getRunnerChannel(shard).subscribe(),
 	subscription => subscription.disconnect());

--- a/packages/xxscreeps/scripts/scrape-world.ts
+++ b/packages/xxscreeps/scripts/scrape-world.ts
@@ -156,7 +156,7 @@ if (dontOverwrite && await db.data.scard('users') > 0) {
 }
 {
 	// Flush databases at the same time because they may point to the same service
-	using shard = await Shard.connect(db, 'shard0');
+	using shard = await Shard.connect(db, config.shards[0]!.name);
 	await Promise.all([
 		shardOnly ? undefined : db.data.flushdb(),
 		shard.data.flushdb(),
@@ -168,7 +168,7 @@ if (dontOverwrite && await db.data.scard('users') > 0) {
 		shard.data.save(),
 	]);
 }
-using shard = await Shard.connect(db, 'shard0');
+using shard = await Shard.connect(db, config.shards[0]!.name);
 const { data } = shard;
 
 // Save terrain data


### PR DESCRIPTION
I've noticed the `shards` key in the configuration yaml file and wanted to use that to set a different shard name so my bot code can differentiate what server it's running on. Unfortunately, `shard0` is still hardcoded in several places, causing this not to work. This PR makes it so I can successfully import and run the server with a different shard name, using the following code in `.screepsrc.yaml`:
```yaml
shards:
  - name: xxmirroar
    data: ./screeps/xxmirroar?socket=.xxmirroar.db
    pubsub: local://xxmirroar?socket=./screeps/.xxmirroar.pubsub
    scratch: local://xxmirroar?socket=./screeps/.xxmirroar.scratch
```

If that's not a usecase you want to support right now, feel free to ignore this PR. :)