### PR TITLE
Reorder checkWithdraw validation precedence

### DIFF
--- a/.changeset/withdraw-validation-precedence.md
+++ b/.changeset/withdraw-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder checkWithdraw: hoist safe-mode and args, gate store-compat and FULL before NOT_ENOUGH.

--- a/.changeset/withdraw-validation-precedence.md
+++ b/.changeset/withdraw-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder `withdraw` validation so invalid args, safe mode, target store compatibility, and full creep capacity take precedence over missing target resources.

--- a/.changeset/withdraw-validation-precedence.md
+++ b/.changeset/withdraw-validation-precedence.md
@@ -1,5 +1,0 @@
----
-"xxscreeps": patch
----
-
-Reorder checkWithdraw: hoist safe-mode and args, gate store-compat and FULL before NOT_ENOUGH.

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -552,12 +552,15 @@ export function checkTransfer(creep: Creep, target: RoomObject & WithStore, reso
 export function checkWithdraw(creep: Creep, target: Structure & WithStore, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
-		() => checkSafeMode(creep.room, C.ERR_NOT_OWNER),
+		() => C.RESOURCES_ALL.includes(resourceType) && amount >= 0 ? C.OK : C.ERR_INVALID_ARGS,
 		() => checkTarget(target, Ruin, Structure, Tombstone),
 		() => checkInteractionBlocked(creep, target),
+		() => checkSafeMode(creep.room, C.ERR_NOT_OWNER),
+		() => target.store.getCapacity(resourceType) === null ? C.ERR_INVALID_TARGET : C.OK,
 		() => checkRange(creep, target, 1),
-		() => checkHasResource(target, resourceType, amount),
-		() => checkHasCapacity(creep, resourceType, amount));
+		() => checkHasCapacity(creep, resourceType, amount),
+		() => (target.store.getUsedCapacity(resourceType) ?? 0) >= Math.max(1, amount)
+			? C.OK : C.ERR_NOT_ENOUGH_RESOURCES);
 }
 
 function checkInteractionBlocked(creep: Creep, target: Structure & WithStore) {

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -527,16 +527,13 @@ function checkTransferTarget(target: RoomObject & WithStore, resourceType: Resou
 		() => checkTarget(target, RoomObject),
 		() => target.store instanceof Store ? C.OK : C.ERR_INVALID_TARGET,
 		() => target instanceof Creep && target.spawning ? C.ERR_INVALID_TARGET : C.OK,
-		() => target.store.getFreeCapacity(resourceType) === null ? C.ERR_INVALID_TARGET : C.OK);
+		() => checkStoreAccepts(target, resourceType));
 }
 
 export function checkTransfer(creep: Creep, target: RoomObject & WithStore, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
-		() => {
-			if (!C.RESOURCES_ALL.includes(resourceType)) return C.ERR_INVALID_ARGS;
-			if (typeof amount !== 'number' || amount < 0) return C.ERR_INVALID_ARGS;
-		},
+		() => checkResourceArgs(resourceType, amount),
 		() => checkTransferTarget(target, resourceType),
 		() => checkRange(creep, target, 1),
 		() => {

--- a/packages/xxscreeps/mods/creep/creep.ts
+++ b/packages/xxscreeps/mods/creep/creep.ts
@@ -20,7 +20,7 @@ import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { Tombstone } from 'xxscreeps/mods/creep/tombstone.js';
 import * as Memory from 'xxscreeps/mods/memory/memory.js';
 import { Resource, optionalResourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
-import { OpenStore, Store, calculateChecked, checkHasCapacity, checkHasResource, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
+import { OpenStore, Store, calculateChecked, checkHasCapacity, checkHasResource, checkHasResourceAmount, checkResourceArgs, checkStoreAccepts, openStoreFormat } from 'xxscreeps/mods/resource/store.js';
 import { Ruin } from 'xxscreeps/mods/structure/ruin.js';
 import { Structure } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, enumerated, optional, struct, variant, vector, withOverlay } from 'xxscreeps/schema/index.js';
@@ -552,15 +552,14 @@ export function checkTransfer(creep: Creep, target: RoomObject & WithStore, reso
 export function checkWithdraw(creep: Creep, target: Structure & WithStore, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
 		() => checkCommon(creep),
-		() => C.RESOURCES_ALL.includes(resourceType) && amount >= 0 ? C.OK : C.ERR_INVALID_ARGS,
+		() => checkResourceArgs(resourceType, amount),
 		() => checkTarget(target, Ruin, Structure, Tombstone),
 		() => checkInteractionBlocked(creep, target),
 		() => checkSafeMode(creep.room, C.ERR_NOT_OWNER),
-		() => target.store.getCapacity(resourceType) === null ? C.ERR_INVALID_TARGET : C.OK,
+		() => checkStoreAccepts(target, resourceType),
 		() => checkRange(creep, target, 1),
 		() => checkHasCapacity(creep, resourceType, amount),
-		() => (target.store.getUsedCapacity(resourceType) ?? 0) >= Math.max(1, amount)
-			? C.OK : C.ERR_NOT_ENOUGH_RESOURCES);
+		() => checkHasResourceAmount(target, resourceType, amount));
 }
 
 function checkInteractionBlocked(creep: Creep, target: Structure & WithStore) {

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -804,122 +804,66 @@ describe('Withdraw validation precedence', () => {
 			assert.strictEqual(Game.creeps.notEnough!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_NOT_OWNER);
 		});
 	}));
-});
-
-describe('Withdraw validation precedence', () => {
-	const safeModeHostile = simulate({
-		W9N9: room => {
-			room['#level'] = 3;
-			room['#user'] = room.controller!['#user'] = '101';
-			room['#safeModeUntil'] = 100;
-
-			room['#insertObject'](create(new RoomPosition(25, 25, 'W9N9'), [ C.CARRY ], 'notEnough', '100'));
-			room['#insertObject'](createContainer(new RoomPosition(26, 25, 'W9N9')));
-		},
-	});
-
-	test('WITHDRAW-017:safemode-not-owner-before-not-enough', () => safeModeHostile(async ({ player }) => {
-		await player('100', Game => {
-			const container = lookForStructures(Game.rooms.W9N9, C.STRUCTURE_CONTAINER)
-				.find(container => container.pos.isEqualTo(26, 25))!;
-			assert.strictEqual(Game.creeps.notEnough!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_NOT_OWNER);
-		});
-	}));
 
 	const friendly = simulate({
 		W7N7: room => {
 			room['#level'] = 3;
 			room['#user'] = room.controller!['#user'] = '100';
-
-			room['#insertObject'](create(new RoomPosition(25, 20, 'W7N7'), [ C.CARRY ], 'argsInvalidTarget', '100'));
-
-			room['#insertObject'](create(new RoomPosition(25, 22, 'W7N7'), [ C.CARRY ], 'argsRange', '100'));
-			const farContainer = createContainer(new RoomPosition(45, 45, 'W7N7'));
-			farContainer.store['#add'](C.RESOURCE_ENERGY, 50);
-			room['#insertObject'](farContainer);
-
-			room['#insertObject'](create(new RoomPosition(25, 24, 'W7N7'), [ C.CARRY ], 'argsRampart', '100'));
-			const blockedContainer = createContainer(new RoomPosition(26, 24, 'W7N7'));
-			blockedContainer.store['#add'](C.RESOURCE_ENERGY, 50);
-			room['#insertObject'](blockedContainer);
-			room['#insertObject'](createRampart(new RoomPosition(26, 24, 'W7N7'), '101'));
-
-			room['#insertObject'](create(new RoomPosition(25, 26, 'W7N7'), [ C.CARRY ], 'capRange', '100'));
+			room['#insertObject'](create(new RoomPosition(25, 25, 'W7N7'), [ C.CARRY ], 'creep', '100'));
+			room['#insertObject'](createContainer(new RoomPosition(26, 25, 'W7N7')));
+			room['#insertObject'](createContainer(new RoomPosition(24, 25, 'W7N7')));
+			room['#insertObject'](createRampart(new RoomPosition(24, 25, 'W7N7'), '101'));
 			room['#insertObject'](createExtension(new RoomPosition(45, 30, 'W7N7'), 3, '100'));
-
-			const full = create(new RoomPosition(25, 28, 'W7N7'), [ C.CARRY ], 'full', '100');
-			full.store['#add'](C.RESOURCE_ENERGY, C.CARRY_CAPACITY);
-			room['#insertObject'](full);
-			room['#insertObject'](createContainer(new RoomPosition(26, 28, 'W7N7')));
-
-			room['#insertObject'](create(new RoomPosition(25, 30, 'W7N7'), [ C.CARRY ], 'emptyContainer', '100'));
-			room['#insertObject'](createContainer(new RoomPosition(26, 30, 'W7N7')));
 		},
 	});
 
 	test('WITHDRAW-017:invalid-args-before-invalid-target', () => friendly(async ({ player }) => {
 		await player('100', Game => {
-			assert.strictEqual(
-				// @ts-expect-error
-				Game.creeps.argsInvalidTarget!.withdraw(null, 'fake'),
-				C.ERR_INVALID_ARGS,
-			);
+			// @ts-expect-error
+			assert.strictEqual(Game.creeps.creep!.withdraw(null, 'fake'), C.ERR_INVALID_ARGS);
 		});
 	}));
 
 	test('WITHDRAW-017:invalid-args-before-target-not-owner', () => friendly(async ({ player }) => {
 		await player('100', Game => {
 			const blocked = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
-				.find(container => container.pos.isEqualTo(26, 24))!;
-			assert.strictEqual(
-				// @ts-expect-error
-				Game.creeps.argsRampart!.withdraw(blocked, 'fake'),
-				C.ERR_INVALID_ARGS,
-			);
+				.find(container => container.pos.isEqualTo(24, 25))!;
+			// @ts-expect-error
+			assert.strictEqual(Game.creeps.creep!.withdraw(blocked, 'fake'), C.ERR_INVALID_ARGS);
 		});
 	}));
 
 	test('WITHDRAW-017:invalid-args-before-range', () => friendly(async ({ player }) => {
 		await player('100', Game => {
-			const far = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
-				.find(container => container.pos.isEqualTo(45, 45))!;
-			assert.strictEqual(
-				// @ts-expect-error
-				Game.creeps.argsRange!.withdraw(far, 'fake'),
-				C.ERR_INVALID_ARGS,
-			);
+			const far = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_EXTENSION)[0]!;
+			// @ts-expect-error
+			assert.strictEqual(Game.creeps.creep!.withdraw(far, 'fake'), C.ERR_INVALID_ARGS);
 		});
 	}));
 
 	test('WITHDRAW-017:invalid-capacity-before-range', () => friendly(async ({ player }) => {
 		await player('100', Game => {
-			const extension = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_EXTENSION)[0]!;
-			assert.strictEqual(
-				Game.creeps.capRange!.withdraw(extension, C.RESOURCE_HYDROGEN),
-				C.ERR_INVALID_TARGET,
-			);
+			const far = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_EXTENSION)[0]!;
+			assert.strictEqual(Game.creeps.creep!.withdraw(far, C.RESOURCE_HYDROGEN), C.ERR_INVALID_TARGET);
 		});
 	}));
 
-	test('WITHDRAW-017:full-before-not-enough', () => friendly(async ({ player }) => {
+	test('WITHDRAW-017:full-before-not-enough', () => friendly(async ({ player, poke }) => {
+		await poke('W7N7', '100', Game => {
+			Game.creeps.creep!.store['#add'](C.RESOURCE_ENERGY, C.CARRY_CAPACITY);
+		});
 		await player('100', Game => {
 			const container = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
-				.find(container => container.pos.isEqualTo(26, 28))!;
-			assert.strictEqual(
-				Game.creeps.full!.withdraw(container, C.RESOURCE_ENERGY),
-				C.ERR_FULL,
-			);
+				.find(container => container.pos.isEqualTo(26, 25))!;
+			assert.strictEqual(Game.creeps.creep!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_FULL);
 		});
 	}));
 
 	test('WITHDRAW-017:not-enough-when-creep-has-room', () => friendly(async ({ player }) => {
 		await player('100', Game => {
 			const container = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
-				.find(container => container.pos.isEqualTo(26, 30))!;
-			assert.strictEqual(
-				Game.creeps.emptyContainer!.withdraw(container, C.RESOURCE_ENERGY),
-				C.ERR_NOT_ENOUGH_RESOURCES,
-			);
+				.find(container => container.pos.isEqualTo(26, 25))!;
+			assert.strictEqual(Game.creeps.creep!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_NOT_ENOUGH_RESOURCES);
 		});
 	}));
 });

--- a/packages/xxscreeps/mods/creep/test.ts
+++ b/packages/xxscreeps/mods/creep/test.ts
@@ -1,6 +1,7 @@
 import * as C from 'xxscreeps/game/constants/index.js';
 import { create as createObject } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createRampart } from 'xxscreeps/mods/defense/rampart.js';
 import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
 import { create as createResource } from 'xxscreeps/mods/resource/resource.js';
 import { Source } from 'xxscreeps/mods/source/source.js';
@@ -801,6 +802,124 @@ describe('Withdraw validation precedence', () => {
 			const container = lookForStructures(Game.rooms.W9N9, C.STRUCTURE_CONTAINER)
 				.find(container => container.pos.isEqualTo(26, 34))!;
 			assert.strictEqual(Game.creeps.notEnough!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_NOT_OWNER);
+		});
+	}));
+});
+
+describe('Withdraw validation precedence', () => {
+	const safeModeHostile = simulate({
+		W9N9: room => {
+			room['#level'] = 3;
+			room['#user'] = room.controller!['#user'] = '101';
+			room['#safeModeUntil'] = 100;
+
+			room['#insertObject'](create(new RoomPosition(25, 25, 'W9N9'), [ C.CARRY ], 'notEnough', '100'));
+			room['#insertObject'](createContainer(new RoomPosition(26, 25, 'W9N9')));
+		},
+	});
+
+	test('WITHDRAW-017:safemode-not-owner-before-not-enough', () => safeModeHostile(async ({ player }) => {
+		await player('100', Game => {
+			const container = lookForStructures(Game.rooms.W9N9, C.STRUCTURE_CONTAINER)
+				.find(container => container.pos.isEqualTo(26, 25))!;
+			assert.strictEqual(Game.creeps.notEnough!.withdraw(container, C.RESOURCE_ENERGY), C.ERR_NOT_OWNER);
+		});
+	}));
+
+	const friendly = simulate({
+		W7N7: room => {
+			room['#level'] = 3;
+			room['#user'] = room.controller!['#user'] = '100';
+
+			room['#insertObject'](create(new RoomPosition(25, 20, 'W7N7'), [ C.CARRY ], 'argsInvalidTarget', '100'));
+
+			room['#insertObject'](create(new RoomPosition(25, 22, 'W7N7'), [ C.CARRY ], 'argsRange', '100'));
+			const farContainer = createContainer(new RoomPosition(45, 45, 'W7N7'));
+			farContainer.store['#add'](C.RESOURCE_ENERGY, 50);
+			room['#insertObject'](farContainer);
+
+			room['#insertObject'](create(new RoomPosition(25, 24, 'W7N7'), [ C.CARRY ], 'argsRampart', '100'));
+			const blockedContainer = createContainer(new RoomPosition(26, 24, 'W7N7'));
+			blockedContainer.store['#add'](C.RESOURCE_ENERGY, 50);
+			room['#insertObject'](blockedContainer);
+			room['#insertObject'](createRampart(new RoomPosition(26, 24, 'W7N7'), '101'));
+
+			room['#insertObject'](create(new RoomPosition(25, 26, 'W7N7'), [ C.CARRY ], 'capRange', '100'));
+			room['#insertObject'](createExtension(new RoomPosition(45, 30, 'W7N7'), 3, '100'));
+
+			const full = create(new RoomPosition(25, 28, 'W7N7'), [ C.CARRY ], 'full', '100');
+			full.store['#add'](C.RESOURCE_ENERGY, C.CARRY_CAPACITY);
+			room['#insertObject'](full);
+			room['#insertObject'](createContainer(new RoomPosition(26, 28, 'W7N7')));
+
+			room['#insertObject'](create(new RoomPosition(25, 30, 'W7N7'), [ C.CARRY ], 'emptyContainer', '100'));
+			room['#insertObject'](createContainer(new RoomPosition(26, 30, 'W7N7')));
+		},
+	});
+
+	test('WITHDRAW-017:invalid-args-before-invalid-target', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			assert.strictEqual(
+				// @ts-expect-error
+				Game.creeps.argsInvalidTarget!.withdraw(null, 'fake'),
+				C.ERR_INVALID_ARGS,
+			);
+		});
+	}));
+
+	test('WITHDRAW-017:invalid-args-before-target-not-owner', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			const blocked = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
+				.find(container => container.pos.isEqualTo(26, 24))!;
+			assert.strictEqual(
+				// @ts-expect-error
+				Game.creeps.argsRampart!.withdraw(blocked, 'fake'),
+				C.ERR_INVALID_ARGS,
+			);
+		});
+	}));
+
+	test('WITHDRAW-017:invalid-args-before-range', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			const far = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
+				.find(container => container.pos.isEqualTo(45, 45))!;
+			assert.strictEqual(
+				// @ts-expect-error
+				Game.creeps.argsRange!.withdraw(far, 'fake'),
+				C.ERR_INVALID_ARGS,
+			);
+		});
+	}));
+
+	test('WITHDRAW-017:invalid-capacity-before-range', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			const extension = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_EXTENSION)[0]!;
+			assert.strictEqual(
+				Game.creeps.capRange!.withdraw(extension, C.RESOURCE_HYDROGEN),
+				C.ERR_INVALID_TARGET,
+			);
+		});
+	}));
+
+	test('WITHDRAW-017:full-before-not-enough', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			const container = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
+				.find(container => container.pos.isEqualTo(26, 28))!;
+			assert.strictEqual(
+				Game.creeps.full!.withdraw(container, C.RESOURCE_ENERGY),
+				C.ERR_FULL,
+			);
+		});
+	}));
+
+	test('WITHDRAW-017:not-enough-when-creep-has-room', () => friendly(async ({ player }) => {
+		await player('100', Game => {
+			const container = lookForStructures(Game.rooms.W7N7, C.STRUCTURE_CONTAINER)
+				.find(container => container.pos.isEqualTo(26, 30))!;
+			assert.strictEqual(
+				Game.creeps.emptyContainer!.withdraw(container, C.RESOURCE_ENERGY),
+				C.ERR_NOT_ENOUGH_RESOURCES,
+			);
 		});
 	}));
 });

--- a/packages/xxscreeps/mods/resource/store.ts
+++ b/packages/xxscreeps/mods/resource/store.ts
@@ -370,6 +370,8 @@ export function checkHasResourceAmount(target: WithStore, resourceType: Resource
 		? C.OK : C.ERR_NOT_ENOUGH_RESOURCES;
 }
 
+// TODO: `checkResourceArgs` and `checkStoreAccepts` should be called individually before invoking
+// this one. If all call sites are ok then the nested intent checks here should be removed
 export function checkHasResource(target: WithStore, resourceType: ResourceType | undefined, amount = 1) {
 	return chainIntentChecks(
 		() => checkResourceArgs(resourceType, amount),

--- a/packages/xxscreeps/mods/resource/store.ts
+++ b/packages/xxscreeps/mods/resource/store.ts
@@ -1,6 +1,7 @@
 import type { ResourceType } from './resource.js';
 import type { BufferView, TypeOf } from 'xxscreeps/schema/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { hooks } from 'xxscreeps/game/index.js';
 import { BufferObject } from 'xxscreeps/schema/buffer-object.js';
@@ -350,16 +351,28 @@ export function checkHasCapacity(target: WithStore, resourceType: ResourceType, 
 	}
 }
 
-export function checkHasResource(target: WithStore, resourceType: ResourceType | undefined, amount = 1) {
+export function checkResourceArgs(resourceType: ResourceType | undefined, amount: number) {
 	if (!C.RESOURCES_ALL.includes(resourceType!)) {
 		return C.ERR_INVALID_ARGS;
 	} else if (typeof amount !== 'number' || amount < 0) {
 		return C.ERR_INVALID_ARGS;
-	} else if (target.store.getCapacity(resourceType) === null) {
-		return C.ERR_INVALID_TARGET;
-	} else if (target.store[resourceType!] >= Math.max(1, amount)) {
-		return C.OK;
-	} else {
-		return C.ERR_NOT_ENOUGH_RESOURCES;
 	}
+	return C.OK;
+}
+
+export function checkStoreAccepts(target: WithStore, resourceType: ResourceType) {
+	return target.store.getCapacity(resourceType) === null
+		? C.ERR_INVALID_TARGET : C.OK;
+}
+
+export function checkHasResourceAmount(target: WithStore, resourceType: ResourceType, amount: number) {
+	return target.store[resourceType] >= Math.max(1, amount)
+		? C.OK : C.ERR_NOT_ENOUGH_RESOURCES;
+}
+
+export function checkHasResource(target: WithStore, resourceType: ResourceType | undefined, amount = 1) {
+	return chainIntentChecks(
+		() => checkResourceArgs(resourceType, amount),
+		() => checkStoreAccepts(target, resourceType!),
+		() => checkHasResourceAmount(target, resourceType!, amount));
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                         
                                                                  
  `checkWithdraw` had several precedence inversions vs vanilla:
                                                                                                                                                                                                                                     
  1. `ERR_NOT_OWNER` from safe-mode was the last check in the chain; vanilla returns it after target validity and rampart-block but before store-compat, range, capacity, and resource.
  2. `ERR_INVALID_ARGS` (bad `resourceType`, negative `amount`) was never gated — invalid args slipped through and surfaced as later error codes.                                                                                    
  3. `ERR_INVALID_TARGET` for "target's store cannot hold this resource" surfaced via `checkHasResource` after range had already fired.          
  4. `ERR_FULL` (creep capacity) and `ERR_NOT_ENOUGH_RESOURCES` (target stock) were in inverted order — vanilla returns `ERR_FULL` first.                                                                                            
                                                                                                                                                                                                                                     
  This PR restores vanilla's chain order.                                                                                                                                                                                            
                                                                                                                                                                                                                                     
  Part of #117 (`creep` row, `checkWithdraw`).                                                                                                                                                                                       
                                                                                                                                                                                                                                     
  ## Vanilla precedence               
                                                                                                                                                                                                                                     
  `@screeps/engine/src/game/creeps.js` `Creep.prototype.withdraw` (lines 493-562):
                                                                                  
  ```js
  if (!this.my)                                       return ERR_NOT_OWNER;
  if (this.spawning)                                  return ERR_BUSY;     
  if (amount < 0)                                     return ERR_INVALID_ARGS;                                                                                                                                                       
  if (!_.contains(C.RESOURCES_ALL, resourceType))     return ERR_INVALID_ARGS;
  if (!target /* or wrong type */)                    return ERR_INVALID_TARGET;                                                                                                                                                     
  // ...                                                                                                                                                                                                                             
  if (target.my === false && rampart blocking)        return ERR_NOT_OWNER;                                                                                                                                                          
  if (room.controller.safeMode && !controller.my)     return ERR_NOT_OWNER;                                                                                                                                                          
  // ... nuker/power_bank short-circuit ...                                                                                                                                                                                          
  if (!capacityForResource(target, resourceType))     return ERR_INVALID_TARGET;                                                                                                                                                     
  if (!target.pos.isNearTo(this.pos))                 return ERR_NOT_IN_RANGE;                                                                                                                                                       
  if (emptySpace <= 0)                                return ERR_FULL;                                                                                                                                                               
  // ... default amount ...                                           
  if (amount > emptySpace)                            return ERR_FULL;                                                                                                                                                               
  if (target.store[resourceType] < amount)            return ERR_NOT_ENOUGH_RESOURCES;
                                                                                                                                                                                                                                     
  Order: NOT_OWNER → BUSY → INVALID_ARGS → INVALID_TARGET → NOT_OWNER (rampart) → NOT_OWNER (safe-mode) → INVALID_TARGET (store-compat) → NOT_IN_RANGE → FULL → NOT_ENOUGH_RESOURCES.                                                
                                                                                                                                                                                                                                     
  Before                                                                                                                                                                                                                             
                                                                                                                                                                                                                                     
  () => checkCommon(creep),                                       
  () => checkTarget(target, Ruin, Structure, Tombstone),
  () => checkInteractionBlocked(creep, target),                                                                                                                                                                                      
  () => checkRange(creep, target, 1),
  () => checkHasResource(target, resourceType, amount),                                                                                                                                                                              
  () => checkHasCapacity(creep, resourceType, amount),            
  () => checkSafeMode(creep.room, C.ERR_NOT_OWNER));                                                                                                                                                                                 
  
  After                                                                                                                                                                                                                              
                                                                  
  () => checkCommon(creep),           
  () => C.RESOURCES_ALL.includes(resourceType) && amount >= 0 ? C.OK : C.ERR_INVALID_ARGS,                                                                                                                                           
  () => checkTarget(target, Ruin, Structure, Tombstone),
  () => checkInteractionBlocked(creep, target),                                                                                                                                                                                      
  () => checkSafeMode(creep.room, C.ERR_NOT_OWNER),               
  () => target.store.getCapacity(resourceType) === null ? C.ERR_INVALID_TARGET : C.OK,                                                                                                                                               
  () => checkRange(creep, target, 1),                             
  () => checkHasCapacity(creep, resourceType, amount),                                                                                                                                                                               
  () => checkHasResource(target, resourceType, amount));          
                                                                                                                                                                                                                                     
  Validation                                                      
                                      
  - New regression suite Withdraw validation precedence in packages/xxscreeps/mods/creep/test.ts pins each affected position: safemode-not-owner-before-not-enough, invalid-args-before-{invalid-target,target-not-owner,range},     
  invalid-capacity-before-range, full-before-not-enough, not-enough-when-creep-has-room.
  - Verified against screeps-ok: 11 WITHDRAW-017:* matrix cases flip green