### PR TITLE
Align Creep.harvest validation precedence with vanilla

### DIFF
--- a/.changeset/harvest-depleted-precedence.md
+++ b/.changeset/harvest-depleted-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Align Creep.harvest validation precedence with vanilla

--- a/packages/xxscreeps/mods/deposit/deposit.ts
+++ b/packages/xxscreeps/mods/deposit/deposit.ts
@@ -2,7 +2,6 @@ import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/check
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, registerGlobal } from 'xxscreeps/game/index.js';
 import * as RoomObject from 'xxscreeps/game/object.js';
-import { checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
 import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
@@ -32,7 +31,6 @@ declare module 'xxscreeps/game/runtime.js' {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const harvest = registerHarvestable(Deposit, function(creep) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.WORK),
 		() => checkTarget(this, Deposit),
 		() => checkRange(creep, this, 1),
 		() => this.cooldown === 0 ? undefined : C.ERR_TIRED);

--- a/packages/xxscreeps/mods/harvestable/creep.ts
+++ b/packages/xxscreeps/mods/harvestable/creep.ts
@@ -8,7 +8,7 @@ import { extend } from 'xxscreeps/utility/utility.js';
 // `harvest` intent check
 export function checkHarvest(creep: Creep, target: Harvestable | undefined) {
 	return chainIntentChecks(
-		() => checkCommon(creep),
+		() => checkCommon(creep, C.WORK),
 		() => target?.['#checkHarvest'] ? target['#checkHarvest'](creep) : C.ERR_INVALID_TARGET,
 	) as HarvestResult;
 }

--- a/packages/xxscreeps/mods/mineral/index.ts
+++ b/packages/xxscreeps/mods/mineral/index.ts
@@ -6,5 +6,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/mineral/mineral.ts
+++ b/packages/xxscreeps/mods/mineral/mineral.ts
@@ -2,7 +2,6 @@ import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/check
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, registerGlobal } from 'xxscreeps/game/index.js';
 import * as RoomObject from 'xxscreeps/game/object.js';
-import { checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
 import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { lookForStructureAt } from 'xxscreeps/mods/structure/structure.js';
@@ -37,13 +36,14 @@ declare module 'xxscreeps/game/runtime.js' {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const harvest = registerHarvestable(Mineral, function(creep) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.WORK),
 		() => checkTarget(this, Mineral),
-		() => checkRange(creep, this, 1),
 		() => {
 			if (this.mineralAmount <= 0) {
 				return C.ERR_NOT_ENOUGH_RESOURCES;
 			}
+		},
+		() => checkRange(creep, this, 1),
+		() => {
 			const extractor = lookForStructureAt(this.room, this.pos, C.STRUCTURE_EXTRACTOR);
 			if (!extractor) {
 				return C.ERR_NOT_FOUND;
@@ -51,7 +51,7 @@ const harvest = registerHarvestable(Mineral, function(creep) {
 				return C.ERR_NOT_OWNER;
 			} else if (!extractor.isActive()) {
 				return C.ERR_RCL_NOT_ENOUGH;
-			} else if (extractor.cooldown !== 0 && extractor.cooldown !== C.EXTRACTOR_COOLDOWN) {
+			} else if (extractor.cooldown > 0 && extractor.cooldown < C.EXTRACTOR_COOLDOWN) {
 				return C.ERR_TIRED;
 			}
 		});

--- a/packages/xxscreeps/mods/mineral/test.ts
+++ b/packages/xxscreeps/mods/mineral/test.ts
@@ -1,0 +1,63 @@
+import type { Mineral } from './mineral.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createExtractor } from 'xxscreeps/mods/mineral/extractor.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+
+describe('Mineral harvest validation', () => {
+	const depletedOutOfRange = simulate({
+		W6N1: room => {
+			const mineral = room.find(C.FIND_MINERALS)[0]!;
+			mineral.mineralAmount = 0;
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, room.name), [ C.WORK, C.CARRY, C.MOVE ], 'harvester', '100'));
+		},
+	});
+
+	test('HARVEST-MINERAL-014:depleted-before-range', () => depletedOutOfRange(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			const mineral = Game.rooms.W6N1?.find(C.FIND_MINERALS)[0];
+			assert.ok(creep);
+			assert.ok(mineral);
+			assert.strictEqual(creep.harvest(mineral), C.ERR_NOT_ENOUGH_RESOURCES);
+		});
+	}));
+
+	const noBodypartInvalidTarget = simulate({
+		W6N1: room => {
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, room.name), [ C.CARRY, C.MOVE ], 'harvester', '100'));
+		},
+	});
+
+	test('HARVEST-MINERAL-014:no-bodypart-before-invalid-target', () => noBodypartInvalidTarget(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			assert.ok(creep);
+			assert.strictEqual(creep.harvest(null as unknown as Mineral), C.ERR_NO_BODYPART);
+		});
+	}));
+
+	const onCooldown = simulate({
+		W6N1: room => {
+			const mineral = room.find(C.FIND_MINERALS)[0]!;
+			const extractor = createExtractor(mineral.pos, '100');
+			extractor['#cooldownTime'] = Game.time + Math.floor(C.EXTRACTOR_COOLDOWN / 2);
+			room['#insertObject'](extractor);
+			room['#insertObject'](createCreep(mineral.pos, [ C.WORK, C.CARRY, C.MOVE ], 'harvester', '100'));
+			room['#level'] = 6;
+			room['#user'] = room.controller!['#user'] = '100';
+		},
+	});
+
+	test('HARVEST-MINERAL-014:cooldown', () => onCooldown(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			const mineral = Game.rooms.W6N1?.find(C.FIND_MINERALS)[0];
+			assert.ok(creep);
+			assert.ok(mineral);
+			assert.strictEqual(creep.harvest(mineral), C.ERR_TIRED);
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/source/game.ts
+++ b/packages/xxscreeps/mods/source/game.ts
@@ -2,7 +2,6 @@ import { registerStruct, registerVariant } from 'xxscreeps/engine/schema/index.j
 import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
-import { checkCommon } from 'xxscreeps/mods/creep/creep.js';
 import { registerHarvestable } from 'xxscreeps/mods/harvestable/index.js';
 import { format as keeperFormat } from './keeper-lair.js';
 import { Source, format } from './source.js';
@@ -41,15 +40,17 @@ declare module 'xxscreeps/game/room/index.js' {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const harvest = registerHarvestable(Source, function(creep) {
 	return chainIntentChecks(
-		() => checkCommon(creep, C.WORK),
 		() => checkTarget(this, Source),
+		() => {
+			if (this.energy <= 0) {
+				return C.ERR_NOT_ENOUGH_RESOURCES;
+			}
+		},
 		() => checkRange(creep, this, 1),
 		() => {
 			const roomUser = this.room['#user'];
 			if (roomUser != null && roomUser !== creep['#user']) {
 				return C.ERR_NOT_OWNER;
-			} else if (this.energy <= 0) {
-				return C.ERR_NOT_ENOUGH_RESOURCES;
 			}
 		});
 });

--- a/packages/xxscreeps/mods/source/index.ts
+++ b/packages/xxscreeps/mods/source/index.ts
@@ -7,5 +7,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/source/test.ts
+++ b/packages/xxscreeps/mods/source/test.ts
@@ -1,0 +1,58 @@
+import type { Source } from './source.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+
+describe('Source harvest validation', () => {
+	const depletedOutOfRange = simulate({
+		W1N1: room => {
+			const source = room.find(C.FIND_SOURCES)[0]!;
+			source.energy = 0;
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, room.name), [ C.WORK, C.CARRY, C.MOVE ], 'harvester', '100'));
+		},
+	});
+
+	test('HARVEST-015:depleted-before-range', () => depletedOutOfRange(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.ok(creep);
+			assert.ok(source);
+			assert.strictEqual(creep.harvest(source), C.ERR_NOT_ENOUGH_RESOURCES);
+		});
+	}));
+
+	const depletedHostileRoom = simulate({
+		W1N1: room => {
+			const source = room.find(C.FIND_SOURCES)[0]!;
+			source.energy = 0;
+			room['#user'] = room.controller!['#user'] = '101';
+			room['#insertObject'](createCreep(new RoomPosition(source.pos.x - 1, source.pos.y, room.name), [ C.WORK, C.CARRY, C.MOVE ], 'harvester', '100'));
+		},
+	});
+
+	test('HARVEST-015:depleted-before-hostile-room', () => depletedHostileRoom(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.ok(creep);
+			assert.ok(source);
+			assert.strictEqual(creep.harvest(source), C.ERR_NOT_ENOUGH_RESOURCES);
+		});
+	}));
+
+	const noBodypartInvalidTarget = simulate({
+		W1N1: room => {
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, room.name), [ C.CARRY, C.MOVE ], 'harvester', '100'));
+		},
+	});
+
+	test('HARVEST-015:no-bodypart-before-invalid-target', () => noBodypartInvalidTarget(async ({ player }) => {
+		await player('100', Game => {
+			const creep = Game.creeps.harvester;
+			assert.ok(creep);
+			assert.strictEqual(creep.harvest(null as unknown as Source), C.ERR_NO_BODYPART);
+		});
+	}));
+});


### PR DESCRIPTION
## Summary

Three precedence shifts in `Creep.harvest`, all matching the order in
`screeps/engine` `src/game/creeps.js` `Creep.prototype.harvest`:

1. Hoist the WORK bodypart gate from the per-target inner chains
   (`mods/source/game.ts`, `mods/mineral/mineral.ts`, `mods/deposit/deposit.ts`)
   into the outer `checkHarvest` (`mods/harvestable/creep.ts`), so an
   invalid target with a creep missing WORK returns ERR_NO_BODYPART
   instead of ERR_INVALID_TARGET.
2. Move source `energy <= 0` and mineral `mineralAmount <= 0` ahead of
   `checkRange`, and (for source) ahead of the hostile-room
   ERR_NOT_OWNER branch.
3. Narrow the mineral ERR_TIRED gate from `cooldown !== 0 && cooldown
   !== EXTRACTOR_COOLDOWN` to `cooldown > 0 && cooldown <
   EXTRACTOR_COOLDOWN`. The previous form admitted only the exact
   EXTRACTOR_COOLDOWN seed value; the new form fires only inside the
   live post-harvest decrement window.

Part of #117.

## Validation

- New regression tests in `mods/source/test.ts` and `mods/mineral/test.ts`
  pin `depleted-before-range`, `depleted-before-hostile-room`,
  `no-bodypart-before-invalid-target`, and `cooldown` cases.
- `npm run build`
- `npm test -- "Source harvest validation"` (3 passed)
- `npm test -- "Mineral harvest validation"` (3 passed)
- `npm test -- "Deposit"` (4 passed)
- Verified against screeps-ok: six matrix cases flip from expected-fail
  to pass, no new regressions.
  - `HARVEST-015:noBodypartBeforeInvalidTarget`
  - `HARVEST-015:depletedBeforeRange`
  - `HARVEST-015:depletedBeforeHostileRoom`
  - `HARVEST-MINERAL-014:noBodypartBeforeInvalidTarget`
  - `HARVEST-MINERAL-014:depletedBeforeRange`
  - `HARVEST-MINERAL-014:cooldown`