### PR TITLE
Reorder link transferEnergy validation precedence

### DIFF
--- a/.changeset/link-transfer-energy-precedence.md
+++ b/.changeset/link-transfer-energy-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder link transferEnergy validation precedence

--- a/packages/xxscreeps/mods/logistics/link.ts
+++ b/packages/xxscreeps/mods/logistics/link.ts
@@ -39,11 +39,11 @@ export class StructureLink extends withOverlay(OwnedStructure, shape) {
 	 */
 	transferEnergy(target: StructureLink, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
-			(amount === undefined || amount === 0)
-				? Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!)
-				: amount);
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			amount || Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
 		return chainIntentChecks(
-			() => checkTransferEnergy(this, target, amount, intentAmount),
+			() => amount !== undefined && amount < 0 ? C.ERR_INVALID_ARGS : C.OK,
+			() => checkTransferEnergy(this, target, intentAmount),
 			() => intents.save(this, 'transferEnergy', target.id, intentAmount));
 	}
 }
@@ -69,11 +69,8 @@ registerBuildableStructure(C.STRUCTURE_LINK, {
 	},
 });
 
-export function checkTransferEnergy(
-	link: StructureLink, target: StructureLink, amount: number | undefined, intentAmount: number = amount ?? NaN,
-) {
+export function checkTransferEnergy(link: StructureLink, target: StructureLink, amount: number) {
 	return chainIntentChecks(
-		() => amount !== undefined && amount < 0 ? C.ERR_INVALID_ARGS : C.OK,
 		() => checkTarget(target, StructureLink),
 		() => target === link ? C.ERR_INVALID_TARGET : C.OK,
 		() => {
@@ -84,8 +81,8 @@ export function checkTransferEnergy(
 		() => checkMyStructure(link, StructureLink),
 		() => link.cooldown ? C.ERR_TIRED : C.OK,
 		() => checkIsActive(link),
-		() => checkHasResource(link, C.RESOURCE_ENERGY, intentAmount),
-		() => checkHasCapacity(target, C.RESOURCE_ENERGY, intentAmount),
+		() => checkHasResource(link, C.RESOURCE_ENERGY, amount),
+		() => checkHasCapacity(target, C.RESOURCE_ENERGY, amount),
 		() => checkSameRoom(link, target),
 	);
 }

--- a/packages/xxscreeps/mods/logistics/link.ts
+++ b/packages/xxscreeps/mods/logistics/link.ts
@@ -39,10 +39,11 @@ export class StructureLink extends withOverlay(OwnedStructure, shape) {
 	 */
 	transferEnergy(target: StructureLink, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-			amount || Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
+			(amount === undefined || amount === 0)
+				? Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!)
+				: amount);
 		return chainIntentChecks(
-			() => checkTransferEnergy(this, target, intentAmount),
+			() => checkTransferEnergy(this, target, amount, intentAmount),
 			() => intents.save(this, 'transferEnergy', target.id, intentAmount));
 	}
 }
@@ -68,10 +69,11 @@ registerBuildableStructure(C.STRUCTURE_LINK, {
 	},
 });
 
-export function checkTransferEnergy(link: StructureLink, target: StructureLink, amount: number) {
+export function checkTransferEnergy(
+	link: StructureLink, target: StructureLink, amount: number | undefined, intentAmount: number = amount ?? NaN,
+) {
 	return chainIntentChecks(
-		() => checkMyStructure(link, StructureLink),
-		() => checkIsActive(link),
+		() => amount !== undefined && amount < 0 ? C.ERR_INVALID_ARGS : C.OK,
 		() => checkTarget(target, StructureLink),
 		() => target === link ? C.ERR_INVALID_TARGET : C.OK,
 		() => {
@@ -79,15 +81,11 @@ export function checkTransferEnergy(link: StructureLink, target: StructureLink, 
 				return C.ERR_NOT_OWNER;
 			}
 		},
-		() => checkHasResource(link, C.RESOURCE_ENERGY, amount),
-		() => checkHasCapacity(target, C.RESOURCE_ENERGY, amount),
+		() => checkMyStructure(link, StructureLink),
+		() => link.cooldown ? C.ERR_TIRED : C.OK,
+		() => checkIsActive(link),
+		() => checkHasResource(link, C.RESOURCE_ENERGY, intentAmount),
+		() => checkHasCapacity(target, C.RESOURCE_ENERGY, intentAmount),
 		() => checkSameRoom(link, target),
-		() => {
-			if (link.cooldown) {
-				return C.ERR_TIRED;
-			} else if (link.room !== target.room) {
-				return C.ERR_NOT_IN_RANGE;
-			}
-		},
 	);
 }

--- a/packages/xxscreeps/mods/logistics/link.ts
+++ b/packages/xxscreeps/mods/logistics/link.ts
@@ -42,7 +42,7 @@ export class StructureLink extends withOverlay(OwnedStructure, shape) {
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 			amount || Math.min(this.store[C.RESOURCE_ENERGY], target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
 		return chainIntentChecks(
-			() => amount !== undefined && amount < 0 ? C.ERR_INVALID_ARGS : C.OK,
+			() => checkAmount(amount),
 			() => checkTransferEnergy(this, target, intentAmount),
 			() => intents.save(this, 'transferEnergy', target.id, intentAmount));
 	}
@@ -69,17 +69,29 @@ registerBuildableStructure(C.STRUCTURE_LINK, {
 	},
 });
 
+function checkAmount(amount: number | undefined) {
+	return amount !== undefined && amount < 0 ? C.ERR_INVALID_ARGS : C.OK;
+}
+
+function checkNotSelf(source: StructureLink, target: StructureLink) {
+	return source === target ? C.ERR_INVALID_TARGET : C.OK;
+}
+
+function checkTargetOwner(target: StructureLink) {
+	return target.my ? C.OK : C.ERR_NOT_OWNER;
+}
+
+function checkCooldown(link: StructureLink) {
+	return link.cooldown ? C.ERR_TIRED : C.OK;
+}
+
 export function checkTransferEnergy(link: StructureLink, target: StructureLink, amount: number) {
 	return chainIntentChecks(
 		() => checkTarget(target, StructureLink),
-		() => target === link ? C.ERR_INVALID_TARGET : C.OK,
-		() => {
-			if (!target.my) {
-				return C.ERR_NOT_OWNER;
-			}
-		},
+		() => checkNotSelf(link, target),
+		() => checkTargetOwner(target),
 		() => checkMyStructure(link, StructureLink),
-		() => link.cooldown ? C.ERR_TIRED : C.OK,
+		() => checkCooldown(link),
 		() => checkIsActive(link),
 		() => checkHasResource(link, C.RESOURCE_ENERGY, amount),
 		() => checkHasCapacity(target, C.RESOURCE_ENERGY, amount),

--- a/packages/xxscreeps/mods/logistics/test.ts
+++ b/packages/xxscreeps/mods/logistics/test.ts
@@ -34,54 +34,28 @@ describe('Link', () => {
 		},
 	});
 
+	// Layout shared across precedence tests:
+	//   25,25  source link, owned '100', 800 energy
+	//   27,25  friendly target link, owned '100', empty
+	//   29,25  hostile link, owned '101', empty
+	// W1N1 is RCL 5 (links active), W1N3 is RCL 4 (links inactive).
+	// W2N1 / W2N2 form a cross-room pair for the range test.
 	const precedence = simulate({
 		W1N1: room => {
 			own(room, 5);
 			insertLink(room, 25, 25, '100', 800);
 			insertLink(room, 27, 25, '100');
-		},
-		W1N2: room => {
-			own(room, 5);
-			insertLink(room, 25, 25, '100', 800);
-			insertLink(room, 27, 25, '101');
+			insertLink(room, 29, 25, '101');
 		},
 		W1N3: room => {
 			own(room, 4);
 			insertLink(room, 25, 25, '100', 800);
 			insertLink(room, 27, 25, '100');
-		},
-		W1N4: room => {
-			own(room, 4);
-			insertLink(room, 25, 25, '100', 800);
-			insertLink(room, 27, 25, '101');
-		},
-		W1N5: room => {
-			own(room, 5);
-			insertLink(room, 25, 25, '101', 800);
-			insertLink(room, 27, 25, '100');
-		},
-		W1N6: room => {
-			own(room, 4);
-			const source = insertLink(room, 25, 25, '100', 800);
-			source['#cooldownTime'] = 100;
-			insertLink(room, 27, 25, '100');
-		},
-		W1N7: room => {
-			own(room, 5);
-			const source = insertLink(room, 25, 25, '100');
-			source['#cooldownTime'] = 100;
-			insertLink(room, 27, 25, '100');
-		},
-		W1N8: room => {
-			own(room, 5);
-			const source = insertLink(room, 25, 25, '100', 800);
-			source['#cooldownTime'] = 100;
-			insertLink(room, 27, 25, '100', 800);
+			insertLink(room, 29, 25, '101');
 		},
 		W2N1: room => {
 			own(room, 5);
-			const source = insertLink(room, 25, 25, '100', 800);
-			source['#cooldownTime'] = 100;
+			insertLink(room, 25, 25, '100', 800);
 		},
 		W2N2: room => {
 			own(room, 5);
@@ -112,8 +86,9 @@ describe('Link', () => {
 
 	test('LINK-014:cooldown-before-rcl', () => precedence(async ({ player }) => {
 		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N6, 25, 25);
-			const target = getLink(Game.rooms.W1N6, 27, 25);
+			const source = getLink(Game.rooms.W1N3, 25, 25);
+			const target = getLink(Game.rooms.W1N3, 27, 25);
+			source['#cooldownTime'] = Game.time + 100;
 			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
 		});
 	}));
@@ -122,22 +97,27 @@ describe('Link', () => {
 		await player('100', Game => {
 			const source = getLink(Game.rooms.W2N1, 25, 25);
 			const target = getLink(Game.rooms.W2N2, 27, 25);
+			source['#cooldownTime'] = Game.time + 100;
 			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
 		});
 	}));
 
 	test('cooldown-before-not-enough', () => precedence(async ({ player }) => {
 		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N7, 25, 25);
-			const target = getLink(Game.rooms.W1N7, 27, 25);
+			const source = getLink(Game.rooms.W1N1, 25, 25);
+			const target = getLink(Game.rooms.W1N1, 27, 25);
+			source.store['#subtract'](C.RESOURCE_ENERGY, source.store[C.RESOURCE_ENERGY]);
+			source['#cooldownTime'] = Game.time + 100;
 			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
 		});
 	}));
 
 	test('cooldown-before-full', () => precedence(async ({ player }) => {
 		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N8, 25, 25);
-			const target = getLink(Game.rooms.W1N8, 27, 25);
+			const source = getLink(Game.rooms.W1N1, 25, 25);
+			const target = getLink(Game.rooms.W1N1, 27, 25);
+			target.store['#add'](C.RESOURCE_ENERGY, target.store.getFreeCapacity(C.RESOURCE_ENERGY)!);
+			source['#cooldownTime'] = Game.time + 100;
 			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
 		});
 	}));
@@ -161,25 +141,27 @@ describe('Link', () => {
 
 	test('target-not-owner-before-rcl', () => precedence(async ({ player }) => {
 		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N4, 25, 25);
-			const target = getLink(Game.rooms.W1N4, 27, 25);
+			const source = getLink(Game.rooms.W1N3, 25, 25);
+			const target = getLink(Game.rooms.W1N3, 29, 25);
 			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_NOT_OWNER);
 		});
 	}));
 
+	// Player '101' owns only the hostile link at 29,25 in W1N1, so the source at 25,25
+	// is hostile from their perspective. INVALID_ARGS / INVALID_TARGET must still win.
 	test('invalid-args-before-source-not-owner', () => precedence(async ({ player }) => {
-		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N5, 25, 25);
-			const target = getLink(Game.rooms.W1N5, 27, 25);
+		await player('101', Game => {
+			const source = getLink(Game.rooms.W1N1, 25, 25);
+			const target = getLink(Game.rooms.W1N1, 29, 25);
 			assert.strictEqual(source.transferEnergy(target, -1), C.ERR_INVALID_ARGS);
 		});
 	}));
 
 	test('invalid-target-before-source-not-owner', () => precedence(async ({ player }) => {
-		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N5, 25, 25);
+		await player('101', Game => {
+			const source = getLink(Game.rooms.W1N1, 25, 25);
 			assert.strictEqual(
-				source.transferEnergy(Game.rooms.W1N5!.controller as unknown as StructureLink, 1),
+				source.transferEnergy(Game.rooms.W1N1!.controller as unknown as StructureLink, 1),
 				C.ERR_INVALID_TARGET);
 		});
 	}));
@@ -195,8 +177,8 @@ describe('Link', () => {
 
 	test('invalid-args-before-target-not-owner', () => precedence(async ({ player }) => {
 		await player('100', Game => {
-			const source = getLink(Game.rooms.W1N2, 25, 25);
-			const target = getLink(Game.rooms.W1N2, 27, 25);
+			const source = getLink(Game.rooms.W1N1, 25, 25);
+			const target = getLink(Game.rooms.W1N1, 29, 25);
 			assert.strictEqual(source.transferEnergy(target, -1), C.ERR_INVALID_ARGS);
 		});
 	}));

--- a/packages/xxscreeps/mods/logistics/test.ts
+++ b/packages/xxscreeps/mods/logistics/test.ts
@@ -1,18 +1,91 @@
+import type { StructureLink } from './link.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create as createLink } from './link.js';
 
+function own(room: Room, level: number) {
+	room['#level'] = level;
+	room['#user'] = room.controller!['#user'] = '100';
+}
+
+function insertLink(room: Room, xx: number, yy: number, owner: string, energy = 0) {
+	const link = createLink(new RoomPosition(xx, yy, room.name), owner);
+	link.store['#add'](C.RESOURCE_ENERGY, energy);
+	room['#insertObject'](link);
+	return link;
+}
+
+function getLink(room: Room | undefined, xx: number, yy: number) {
+	const link = lookForStructures(room, C.STRUCTURE_LINK)
+		.find(link => link.pos.x === xx && link.pos.y === yy);
+	assert.ok(link, `expected link at ${xx},${yy}`);
+	return link;
+}
+
 describe('Link', () => {
 	const sim = simulate({
 		W1N1: room => {
-			room['#level'] = 5;
-			room['#user'] = room.controller!['#user'] = '100';
-			const sender = createLink(new RoomPosition(25, 25, 'W1N1'), '100');
-			sender.store['#add'](C.RESOURCE_ENERGY, 800);
-			room['#insertObject'](sender);
-			room['#insertObject'](createLink(new RoomPosition(27, 25, 'W1N1'), '100'));
+			own(room, 5);
+			insertLink(room, 25, 25, '100', 800);
+			insertLink(room, 27, 25, '100');
+		},
+	});
+
+	const precedence = simulate({
+		W1N1: room => {
+			own(room, 5);
+			insertLink(room, 25, 25, '100', 800);
+			insertLink(room, 27, 25, '100');
+		},
+		W1N2: room => {
+			own(room, 5);
+			insertLink(room, 25, 25, '100', 800);
+			insertLink(room, 27, 25, '101');
+		},
+		W1N3: room => {
+			own(room, 4);
+			insertLink(room, 25, 25, '100', 800);
+			insertLink(room, 27, 25, '100');
+		},
+		W1N4: room => {
+			own(room, 4);
+			insertLink(room, 25, 25, '100', 800);
+			insertLink(room, 27, 25, '101');
+		},
+		W1N5: room => {
+			own(room, 5);
+			insertLink(room, 25, 25, '101', 800);
+			insertLink(room, 27, 25, '100');
+		},
+		W1N6: room => {
+			own(room, 4);
+			const source = insertLink(room, 25, 25, '100', 800);
+			source['#cooldownTime'] = 100;
+			insertLink(room, 27, 25, '100');
+		},
+		W1N7: room => {
+			own(room, 5);
+			const source = insertLink(room, 25, 25, '100');
+			source['#cooldownTime'] = 100;
+			insertLink(room, 27, 25, '100');
+		},
+		W1N8: room => {
+			own(room, 5);
+			const source = insertLink(room, 25, 25, '100', 800);
+			source['#cooldownTime'] = 100;
+			insertLink(room, 27, 25, '100', 800);
+		},
+		W2N1: room => {
+			own(room, 5);
+			const source = insertLink(room, 25, 25, '100', 800);
+			source['#cooldownTime'] = 100;
+		},
+		W2N2: room => {
+			own(room, 5);
+			insertLink(room, 27, 25, '100');
 		},
 	});
 
@@ -34,6 +107,97 @@ describe('Link', () => {
 			assert.strictEqual(transfer.data.resourceType, C.RESOURCE_ENERGY);
 			assert.strictEqual(transfer.data.amount, 400);
 			assert.strictEqual(receiver?.store[C.RESOURCE_ENERGY], Math.floor(400 * (1 - C.LINK_LOSS_RATIO)));
+		});
+	}));
+
+	test('LINK-014:cooldown-before-rcl', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N6, 25, 25);
+			const target = getLink(Game.rooms.W1N6, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
+		});
+	}));
+
+	test('cooldown-before-range', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W2N1, 25, 25);
+			const target = getLink(Game.rooms.W2N2, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
+		});
+	}));
+
+	test('cooldown-before-not-enough', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N7, 25, 25);
+			const target = getLink(Game.rooms.W1N7, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
+		});
+	}));
+
+	test('cooldown-before-full', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N8, 25, 25);
+			const target = getLink(Game.rooms.W1N8, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_TIRED);
+		});
+	}));
+
+	test('invalid-args-before-rcl', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N3, 25, 25);
+			const target = getLink(Game.rooms.W1N3, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, -1), C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('invalid-target-before-rcl', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N3, 25, 25);
+			assert.strictEqual(
+				source.transferEnergy(Game.rooms.W1N3!.controller as unknown as StructureLink, 1),
+				C.ERR_INVALID_TARGET);
+		});
+	}));
+
+	test('target-not-owner-before-rcl', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N4, 25, 25);
+			const target = getLink(Game.rooms.W1N4, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, 1), C.ERR_NOT_OWNER);
+		});
+	}));
+
+	test('invalid-args-before-source-not-owner', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N5, 25, 25);
+			const target = getLink(Game.rooms.W1N5, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, -1), C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('invalid-target-before-source-not-owner', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N5, 25, 25);
+			assert.strictEqual(
+				source.transferEnergy(Game.rooms.W1N5!.controller as unknown as StructureLink, 1),
+				C.ERR_INVALID_TARGET);
+		});
+	}));
+
+	test('invalid-args-before-invalid-target', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N1, 25, 25);
+			assert.strictEqual(
+				source.transferEnergy(Game.rooms.W1N1!.controller as unknown as StructureLink, -1),
+				C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('invalid-args-before-target-not-owner', () => precedence(async ({ player }) => {
+		await player('100', Game => {
+			const source = getLink(Game.rooms.W1N2, 25, 25);
+			const target = getLink(Game.rooms.W1N2, 27, 25);
+			assert.strictEqual(source.transferEnergy(target, -1), C.ERR_INVALID_ARGS);
 		});
 	}));
 });


### PR DESCRIPTION
## Summary

`checkTransferEnergy` had several precedence inversions vs vanilla:

1. `ERR_NOT_OWNER` from the source link and `ERR_RCL_NOT_ENOUGH` fired before amount, target, and target-owner validation.
2. `ERR_TIRED` needed to precede RCL, energy, capacity, and same-room range checks.
3. `ERR_INVALID_ARGS` for negative `amount` was effectively tied to resource checks, after target validation.
4. A valid-amount/invalid-target call could be polluted by the computed intent amount path, so this keeps original `amount` validation separate from the computed transfer amount.

This PR restores vanilla's chain order.

Part of #117 (`link` row, `StructureLink.transferEnergy`).

## Vanilla precedence

`@screeps/engine/src/game/structures.js` `StructureLink.prototype.transferEnergy` (lines 488-533):

```js
if (amount < 0)                         return ERR_INVALID_ARGS;
if (!target /* or wrong link target */)  return ERR_INVALID_TARGET;
if (!target.my)                         return ERR_NOT_OWNER;
if (source is hostile/rampart-blocked)   return ERR_NOT_OWNER;
if (this.cooldown > 0)                  return ERR_TIRED;
if (!active by controller/RCL)           return ERR_RCL_NOT_ENOUGH;
if (!source energy / amount too high)    return ERR_NOT_ENOUGH_ENERGY;
if (!target capacity)                    return ERR_FULL;
if (target room differs)                 return ERR_NOT_IN_RANGE;
```

Order: INVALID_ARGS -> INVALID_TARGET -> target NOT_OWNER -> source NOT_OWNER -> TIRED -> RCL_NOT_ENOUGH -> NOT_ENOUGH_ENERGY -> FULL -> NOT_IN_RANGE.

Before

```ts
() => checkMyStructure(link, StructureLink),
() => checkIsActive(link),
() => checkTarget(target, StructureLink),
() => target === link ? ERR_INVALID_TARGET : OK,
() => target owner check,
() => checkHasResource(link, ENERGY, amount),
() => checkHasCapacity(target, ENERGY, amount),
() => checkSameRoom(link, target),
() => cooldown/range check,
```

After

```ts
() => validate original amount argument,
() => checkTarget(target, StructureLink),
() => target === link ? ERR_INVALID_TARGET : OK,
() => target owner check,
() => checkMyStructure(link, StructureLink),
() => cooldown check,
() => checkIsActive(link),
() => checkHasResource(link, ENERGY, intentAmount),
() => checkHasCapacity(target, ENERGY, intentAmount),
() => checkSameRoom(link, target),
```

## Validation

- Added focused Link precedence tests in `packages/xxscreeps/mods/logistics/test.ts`.
- `npm run build`
- `npm test -- Link`
- `npx eslint --max-warnings 0 packages/xxscreeps/mods/logistics/link.ts packages/xxscreeps/mods/logistics/test.ts`
- `git diff --check`
- Verified against screeps-ok-pr xxscreeps only:
  - `npm test -- xxscreeps tests/10-structures-energy/10.4-link.test.ts -t LINK-014`
  - 45 LINK-014 matrix cases passed.
  - The 11 expected PR gaps now report as unexpected passes while parity entries remain registered.
