### PR TITLE
Fix creep overkill damage settlement

### DIFF
--- a/packages/xxscreeps/mods/combat/test.ts
+++ b/packages/xxscreeps/mods/combat/test.ts
@@ -45,6 +45,44 @@ describe('Combat', () => {
 				`expected 1 ruin at lab position, got ${labRuins.length}`);
 		});
 	}));
+
+	const overkillHealSim = simulate({
+		W1N1: room => {
+			room['#level'] = 7;
+			room['#user'] = room.controller!['#user'] = '100';
+			const target = createCreep(
+				new RoomPosition(25, 25, 'W1N1'),
+				[ C.MOVE, C.HEAL ],
+				'target',
+				'100',
+			);
+			target.hits = 12;
+			target.body[0]!.hits = 0;
+			target.body[1]!.hits = 12;
+			room['#insertObject'](target);
+			room['#insertObject'](createCreep(
+				new RoomPosition(26, 25, 'W1N1'),
+				[ C.ATTACK, C.MOVE ],
+				'attacker',
+				'101',
+			));
+		},
+	});
+
+	test('lethal overkill kills creep after same-tick healing', () => overkillHealSim(async ({ player, tick }) => {
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.target?.heal(Game.creeps.target), C.OK);
+		});
+		await player('101', Game => {
+			const target = Game.rooms.W1N1!.find(C.FIND_HOSTILE_CREEPS)[0]!;
+			assert.strictEqual(Game.creeps.attacker?.attack(target), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.target, undefined);
+			assert.strictEqual(Game.rooms.W1N1?.find(C.FIND_TOMBSTONES).length, 1);
+		});
+	}));
 });
 
 describe('getEventLog', () => {

--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -49,33 +49,34 @@ export function flushActionLog(actionLog: ActionLog, context: ProcessorContext) 
 }
 
 /**
- * Calculates effective HP lost after TOUGH boost damage reduction.
+ * Calculates effective damage for hit settlement after TOUGH boost reduction.
  * Walks body parts front-to-back: boosted TOUGH parts absorb more incoming
  * damage per HP lost (each point of incoming damage costs only `multiplier` HP).
- * Non-TOUGH and unboosted parts take damage at 1:1.
+ * Non-TOUGH and unboosted parts take damage at 1:1. Damage left after all live
+ * parts are exhausted is still lethal overkill for creep hits.
  */
 function calculateEffectiveDamage(creep: Creep, totalDamage: number) {
-	let remaining = totalDamage;
-	let hitsLost = 0;
+	let remainingDamage = totalDamage;
+	let effectiveDamage = 0;
 	for (const part of creep.body) {
-		if (remaining <= 0) break;
+		if (remainingDamage <= 0) break;
 		if (part.hits <= 0) continue;
 		if (part.type === C.TOUGH && part.boost) {
 			const multiplier = (C.BOOSTS as CreepLib.BoostsLookup)[C.TOUGH]?.[part.boost]?.damage;
 			if (multiplier) {
 				// This part can absorb part.hits/multiplier incoming damage
-				const absorbed = Math.min(remaining, part.hits / multiplier);
-				hitsLost += absorbed * multiplier;
-				remaining -= absorbed;
+				const rawDamageToPart = Math.min(remainingDamage, part.hits / multiplier);
+				remainingDamage -= rawDamageToPart;
+				effectiveDamage += rawDamageToPart * multiplier;
 				continue;
 			}
 		}
 		// Non-TOUGH or unboosted: 1:1
-		const absorbed = Math.min(remaining, part.hits);
-		hitsLost += absorbed;
-		remaining -= absorbed;
+		const rawDamageToPart = Math.min(remainingDamage, part.hits);
+		remainingDamage -= rawDamageToPart;
+		effectiveDamage += rawDamageToPart;
 	}
-	return hitsLost;
+	return effectiveDamage + remainingDamage;
 }
 
 export function dropOverflowResources(creep: Creep) {


### PR DESCRIPTION
## Summary

- Preserve lethal overkill after TOUGH damage reduction exhausts all live creep body parts.
- Add a regression for same-tick self-heal plus lethal melee damage on a creep with only a damaged HEAL part still alive.
- Cleaned up language to make it clearer.

Fixes #201.

## Verification

- `npm run build`
- `npm test -- "Combat" "lethal overkill kills creep after same-tick healing"`
- `npm test -- "Combat"`
- `npm test -- "TOUGH damage reduction"`
- `npm test -- "getEventLog"`
- `npm test -- "getEventLog missing events"`
- `COMBAT-SIMULT-004` now passes as the expected Issue 201 parity fix)
