### PR TITLE
Reject reaction lab self-reagents

### DIFF
--- a/.changeset/lab-reagent-validation-precedence.md
+++ b/.changeset/lab-reagent-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": minor
+---
+
+Reject reaction labs passed as their own reagent inputs.

--- a/packages/xxscreeps/mods/chemistry/lab.ts
+++ b/packages/xxscreeps/mods/chemistry/lab.ts
@@ -159,6 +159,11 @@ export function checkReverseReaction(lab: StructureLab, lab1: StructureLab | nul
 		() => checkIsActive(lab),
 		() => checkTarget(lab1, StructureLab),
 		() => checkTarget(lab2, StructureLab),
+		() => {
+			if (lab1!.id === lab.id || lab2!.id === lab.id) {
+				return C.ERR_INVALID_TARGET;
+			}
+		},
 		() => checkRange(lab, lab1!, 2),
 		() => checkRange(lab, lab2!, 2),
 		() => {
@@ -238,6 +243,11 @@ export function checkRunReaction(lab: StructureLab, left: StructureLab, right: S
 		() => checkIsActive(lab),
 		() => checkTarget(left, StructureLab),
 		() => checkTarget(right, StructureLab),
+		() => {
+			if (left.id === lab.id || right.id === lab.id) {
+				return C.ERR_INVALID_TARGET;
+			}
+		},
 		() => checkRange(lab, left, 2),
 		() => checkRange(lab, right, 2),
 		() => {

--- a/packages/xxscreeps/mods/chemistry/test.ts
+++ b/packages/xxscreeps/mods/chemistry/test.ts
@@ -141,6 +141,15 @@ describe('Chemistry', () => {
 				assert.strictEqual(output?.runReaction(labH, labO), C.ERR_TIRED);
 			});
 		}));
+
+		test('LAB-RUN-013:invalid-target-before-not-enough-reagent', () => reactionSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const output = labs.find(lab => !lab.mineralType)!;
+				const labO = labs.find(lab => lab.mineralType === C.RESOURCE_OXYGEN)!;
+				assert.strictEqual(output.runReaction(output, labO), C.ERR_INVALID_TARGET);
+			});
+		}));
 	});
 
 	// =========================================================================
@@ -366,6 +375,14 @@ describe('Chemistry', () => {
 				const empty = labs.find(lab => !lab.mineralType)!;
 				const result = labOH?.reverseReaction(empty, empty);
 				assert.strictEqual(result, C.ERR_INVALID_ARGS);
+			});
+		}));
+
+		test('LAB-REVERSE-013:invalid-target-before-same-lab', () => reverseSim(async ({ player }) => {
+			await player('100', Game => {
+				const labs = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB);
+				const labOH = labs.find(lab => lab.mineralType === C.RESOURCE_HYDROXIDE)!;
+				assert.strictEqual(labOH.reverseReaction(labOH, labOH), C.ERR_INVALID_TARGET);
 			});
 		}));
 


### PR DESCRIPTION
## Summary

Two lab reagent validation shifts, both matching the order in `screeps/engine` `src/game/structures.js` `StructureLab.prototype.runReaction` and `StructureLab.prototype.reverseReaction`:

1. Reject the reaction lab itself when passed as `lab1` or `lab2` in `checkReverseReaction`, so `reverseReaction(source, source, source)` returns `ERR_INVALID_TARGET` before the later same-lab `ERR_INVALID_ARGS` branch.
2. Mirror the same self-as-reagent `ERR_INVALID_TARGET` guard in `checkRunReaction`.

Part of #117.

## Validation

- New regression tests in `mods/chemistry/test.ts` pin `LAB-REVERSE-013:invalid-target-before-same-lab` plus analogous `runReaction` coverage.
- Verified against local `screeps-engine/src/game/structures.js`: both `runReaction` and `reverseReaction` reject `lab1.id == this.id` / `lab2.id == this.id` during target validation, before range checks; the `reverseReaction` `lab1 == lab2` `ERR_INVALID_ARGS` branch comes later.
- `npm run build`
- `npm test -- Chemistry` (31 passed)
- Verified against screeps-ok: the focused lab matrix flips the registered gap from expected-fail to pass, no new regressions.
  - `LAB-REVERSE-013:invalidTargetBeforeSameLab`