### PR TITLE
Reject indestructible dismantle targets

### DIFF
--- a/.changeset/dismantle-validation-precedence.md
+++ b/.changeset/dismantle-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reject indestructible structures from `Creep.dismantle` with `ERR_INVALID_TARGET` before range.

--- a/packages/xxscreeps/mods/construction/creep.ts
+++ b/packages/xxscreeps/mods/construction/creep.ts
@@ -78,6 +78,7 @@ export function checkDismantle(creep: Creep, target: Structure) {
 	return chainIntentChecks(
 		() => checkCommon(creep, C.WORK),
 		() => checkTarget(target, Structure),
+		() => target.structureType in C.CONSTRUCTION_COST ? C.OK : C.ERR_INVALID_TARGET,
 		() => checkRange(creep, target, 1),
 		() => checkSafeMode(creep.room, C.ERR_NO_BODYPART));
 }

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -329,4 +329,30 @@ describe('Construction', () => {
 			});
 		}));
 	});
+
+	describe('dismantle validation', () => {
+		// W1N1 controller in test fixtures sits at (42, 22).
+		const controllerSim = simulate({
+			W1N1: room => {
+				room['#level'] = 1;
+				room['#user'] = room.controller!['#user'] = '100';
+				room['#insertObject'](createCreep(new RoomPosition(43, 22, 'W1N1'), [ C.WORK, C.MOVE ], 'near', '100'));
+				room['#insertObject'](createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.MOVE ], 'far', '100'));
+			},
+		});
+
+		test('dismantle(controller) returns ERR_INVALID_TARGET', () => controllerSim(async ({ player }) => {
+			await player('100', Game => {
+				const controller = Game.rooms.W1N1!.controller!;
+				assert.strictEqual(Game.creeps.near?.dismantle(controller), C.ERR_INVALID_TARGET);
+			});
+		}));
+
+		test('dismantle(controller) returns ERR_INVALID_TARGET before ERR_NOT_IN_RANGE', () => controllerSim(async ({ player }) => {
+			await player('100', Game => {
+				const controller = Game.rooms.W1N1!.controller!;
+				assert.strictEqual(Game.creeps.far?.dismantle(controller), C.ERR_INVALID_TARGET);
+			});
+		}));
+	});
 });

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -331,13 +331,13 @@ describe('Construction', () => {
 	});
 
 	describe('dismantle validation', () => {
-		// W1N1 controller in test fixtures sits at (42, 22).
 		const controllerSim = simulate({
 			W1N1: room => {
 				room['#level'] = 1;
 				room['#user'] = room.controller!['#user'] = '100';
-				room['#insertObject'](createCreep(new RoomPosition(43, 22, 'W1N1'), [ C.WORK, C.MOVE ], 'near', '100'));
-				room['#insertObject'](createCreep(new RoomPosition(10, 10, 'W1N1'), [ C.WORK, C.MOVE ], 'far', '100'));
+				const controllerPos = room.controller!.pos;
+				room['#insertObject'](createCreep(new RoomPosition(controllerPos.x - 1, controllerPos.y, 'W1N1'), [ C.WORK ], 'near', '100'));
+				room['#insertObject'](createCreep(new RoomPosition(1, 1, 'W1N1'), [ C.WORK ], 'far', '100'));
 			},
 		});
 


### PR DESCRIPTION
## Summary

One dismantle target-validation gap, matching the order in `screeps/engine` `src/game/creeps.js` `Creep.prototype.dismantle`: reject targets whose `structureType` is absent from `CONSTRUCTION_COST` (controllers, portals, keeperLairs, invader cores, etc.) with `ERR_INVALID_TARGET` before the range check, so `creep.dismantle(controller)` returns `ERR_INVALID_TARGET` instead of `OK` (adjacent) or `ERR_NOT_IN_RANGE` (far).

Part of #117.

## Validation

- New regression tests in `mods/construction/test.ts` pin `DISMANTLE-009:invalidTarget` and `DISMANTLE-009:invalidTargetBeforeRange` using a controller as target both adjacent and out of range.
- Verified against local `screeps-engine/src/game/creeps.js`: `Creep.prototype.dismantle` rejects targets without a `CONSTRUCTION_COST[structureType]` entry as `ERR_INVALID_TARGET` before the `isNearTo` range check; the fortify/invulnerability `ERR_INVALID_TARGET` clause that follows is left for the effects substrate.
- `npm run build`
- `npm test` (228 passed)
- Verified against screeps-ok: the focused dismantle matrix flips the registered gap from expected-fail to pass, no new regressions.
  - `DISMANTLE-009:invalidTarget`, `DISMANTLE-009:invalidTargetBeforeRange`