### PR TITLE
Hoist checkUnboostCreep target ownership above the active-structure gate

### DIFF
--- a/.changeset/unboost-target-owner-precedence.md
+++ b/.changeset/unboost-target-owner-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Hoist checkUnboostCreep target ownership above the active-structure gate.

--- a/packages/xxscreeps/mods/chemistry/lab.ts
+++ b/packages/xxscreeps/mods/chemistry/lab.ts
@@ -192,12 +192,12 @@ export function checkUnboostCreep(lab: StructureLab, creep: Creep | null | undef
 	return chainIntentChecks(
 		() => checkTarget(creep, Creep),
 		() => checkMyStructure(lab, StructureLab),
-		() => checkIsActive(lab),
 		() => {
 			if (!creep!.my) {
 				return C.ERR_NOT_OWNER;
 			}
 		},
+		() => checkIsActive(lab),
 		() => {
 			if (lab.cooldown) {
 				return C.ERR_TIRED;

--- a/packages/xxscreeps/mods/chemistry/test.ts
+++ b/packages/xxscreeps/mods/chemistry/test.ts
@@ -501,6 +501,27 @@ describe('Chemistry', () => {
 			});
 		}));
 
+		test('unboostCreep returns ERR_NOT_OWNER for foreign creep before checkIsActive', () => simulate({
+			W1N1: room => {
+				room['#insertObject'](createLab(new RoomPosition(25, 25, 'W1N1'), '100'));
+				room['#insertObject'](createCreep(
+					new RoomPosition(25, 26, 'W1N1'),
+					[ C.TOUGH ],
+					'foreign', '101'));
+				// Lab needs RCL 6 to be active; place at 5 so checkIsActive would otherwise gate first.
+				room['#level'] = 5;
+				room['#user'] =
+					room.controller!['#user'] = '100';
+			},
+		})(async ({ player }) => {
+			await player('100', Game => {
+				const room = Game.rooms.W1N1!;
+				const lab = lookForStructures(room, C.STRUCTURE_LAB)[0]!;
+				const foreign = room.find(C.FIND_HOSTILE_CREEPS)[0]!;
+				assert.strictEqual(lab.unboostCreep(foreign), C.ERR_NOT_OWNER);
+			});
+		}));
+
 		test('unboostCreep fails out of range', () => unboostSim(async ({ player, tick, poke }) => {
 			// Boost the creep first
 			await player('100', Game => {


### PR DESCRIPTION
## Summary

Hoist the target-ownership branch in `checkUnboostCreep` above `checkIsActive` so a foreign creep on an inactive lab returns `ERR_NOT_OWNER` instead of `ERR_RCL_NOT_ENOUGH`, matching the order in `screeps/engine` `src/game/structures.js` `StructureLab.prototype.unboostCreep`.

Part of #117.

## Validation

- New regression test in `mods/chemistry/test.ts` pins the foreign-target / inactive-lab case to `ERR_NOT_OWNER`.
- Verified against local `screeps-engine/src/game/structures.js`: `unboostCreep` evaluates `!this.my || !target.my` for `ERR_NOT_OWNER` before the `checkStructureAgainstController` RCL gate.
- `npm run build`
- `npm test -- Chemistry` (30 passed)
- Verified against screeps-ok: the focused unboost matrix flips the registered gap from expected-fail to pass, no new regressions.
  - `UNBOOST-006:creepNotOwnerBeforeRcl`