### PR TITLE
pathfinder: explain missing-binary error

### DIFF
--- a/.changeset/pathfinder-binary-error.md
+++ b/.changeset/pathfinder-binary-error.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/pathfinder": patch
+---
+
+Replace generic `MODULE_NOT_FOUND` with a guided message when the per-triplet binary can't be resolved (unsupported platform or missing optionalDependencies).

--- a/.changeset/pathfinder-binary-error.md
+++ b/.changeset/pathfinder-binary-error.md
@@ -2,4 +2,4 @@
 "@xxscreeps/pathfinder": patch
 ---
 
-Replace generic `MODULE_NOT_FOUND` with a guided message when the per-triplet binary can't be resolved (unsupported platform or missing optionalDependencies).
+Replace MODULE_NOT_FOUND with a guided message naming the missing optional dep.

--- a/packages/pathfinder/module/index.js
+++ b/packages/pathfinder/module/index.js
@@ -1,7 +1,18 @@
 const triplet = require('./triplet.js');
 
 const name = `@xxscreeps/pathfinder-${triplet}/pf.${triplet}.node`;
-const path = require.resolve(name);
+let path;
+try {
+	path = require.resolve(name);
+} catch (cause) {
+	if (cause.code !== 'MODULE_NOT_FOUND') throw cause;
+	throw new Error(
+		`Native pathfinder binary missing for ${triplet}. ` +
+		`Install the optional dependency \`@xxscreeps/pathfinder-${triplet}\` ` +
+		`(some package managers skip optionalDependencies; ` +
+		`re-run install with \`--include=optional\` or check that ${triplet} is in the supported matrix).`,
+		{ cause });
+}
 module.exports = require(path);
 module.exports.path = path;
 if (module.exports.version !== 11) {

--- a/packages/pathfinder/module/index.js
+++ b/packages/pathfinder/module/index.js
@@ -1,18 +1,17 @@
 const triplet = require('./triplet.js');
 
 const name = `@xxscreeps/pathfinder-${triplet}/pf.${triplet}.node`;
-let path;
-try {
-	path = require.resolve(name);
-} catch (cause) {
-	if (cause.code !== 'MODULE_NOT_FOUND') throw cause;
-	throw new Error(
-		`Native pathfinder binary missing for ${triplet}. ` +
-		`Install the optional dependency \`@xxscreeps/pathfinder-${triplet}\` ` +
-		`(some package managers skip optionalDependencies; ` +
-		`re-run install with \`--include=optional\` or check that ${triplet} is in the supported matrix).`,
-		{ cause });
-}
+const path = function() {
+	try {
+		return require.resolve(name);
+	} catch (cause) {
+		if (cause.code !== 'MODULE_NOT_FOUND') throw cause;
+		throw new Error(
+			`Native pathfinder binary missing for ${triplet}. ` +
+			`Install \`@xxscreeps/pathfinder-${triplet}\`; some package managers skip optionalDependencies.`,
+			{ cause });
+	}
+}();
 module.exports = require(path);
 module.exports.path = path;
 if (module.exports.version !== 11) {


### PR DESCRIPTION
## Summary
- Wrap `require.resolve` in `module/index.js` so `MODULE_NOT_FOUND` turns into a guided error naming the optional dep that wasn't installed.
- Other resolve errors propagate unchanged; original error preserved as `cause`.
- Motivation: Docker/CI setups that skip `optionalDependencies` (`pnpm fetch`, `--no-optional`, `--omit=optional`) currently get a cryptic "Cannot find module './out/.../pf.node'" — the new message names the package to install.

## Validation
- Faked the triplet to one whose binary package isn't installed; new error fires, original `MODULE_NOT_FOUND` retained as `[cause]`.
- Happy path unchanged: `require(path)` and `module.exports.path` work as before.

## Follow-up
A larger change could mirror `isolated-vm`'s install pattern (`prebuild-install || node-gyp rebuild`) — try the prebuilt, fall back to a source build when the per-triplet optional dep isn't resolvable.