### PR TITLE
Fix lookForAtArea/lookAtArea cell shape when asArray=false

### DIFF
--- a/.changeset/look-for-at-area-asarray-false.md
+++ b/.changeset/look-for-at-area-asarray-false.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `Room.lookForAtArea` and `Room.lookAtArea` cell shape when `asArray` is `false`.

--- a/packages/xxscreeps/game/room/look.ts
+++ b/packages/xxscreeps/game/room/look.ts
@@ -138,7 +138,8 @@ extend(Room, {
 			mapArea(top, left, bottom, right, (x, y) =>
 				({ x, y, type: 'terrain', terrain: terrainMaskToString[terrain.get(x, y)] })),
 		]);
-		return withAsArray(results, top, left, bottom, right, asArray, true) as never;
+		return withAsArray(results, top, left, bottom, right, asArray, true,
+			({ x: _x, y: _y, ...rest }) => rest) as never;
 	},
 
 	lookForAt(type: LookConstants, ...rest: PositionParameter) {
@@ -159,10 +160,13 @@ extend(Room, {
 
 	lookForAtArea(type: LookConstants, top: number, left: number, bottom: number, right: number, asArray = false) {
 		const size = (bottom - top + 1) * (right - left + 1);
+		type Wrapper = { [k: string]: unknown; x: number; y: number };
+		let extract: (value: Wrapper) => unknown;
 		const results = (() => {
 			if (type === C.LOOK_TERRAIN) {
 				// Simply return terrain data
 				const terrain = this.getTerrain();
+				extract = value => value.terrain;
 				return mapArea(top, left, bottom, right, (x, y) =>
 					({ x, y, terrain: terrainMaskToString[terrain.get(x, y)] }));
 			} else {
@@ -182,10 +186,11 @@ extend(Room, {
 					}
 				})();
 				// Add position and type information
+				extract = value => value[type];
 				return Fn.map(objects, object => ({ x: object.pos.x, y: object.pos.y, [type]: object }));
 			}
 		})();
-		return withAsArray(results, top, left, bottom, right, asArray, false) as never;
+		return withAsArray(results, top, left, bottom, right, asArray, false, extract!) as never;
 	},
 
 	getPositionAt(xx: number, yy: number) {
@@ -223,7 +228,12 @@ function *lookAtAreaEntries(object: AnyRoomObject): Iterable<LookAreaEntry> {
 	yield { x: object.pos.x, y: object.pos.y, type, [type]: object };
 }
 
-function withAsArray(values: Iterable<{ x: number; y: number }>, top: number, left: number, bottom: number, right: number, asArray: boolean, nest: boolean) {
+function withAsArray<T extends { x: number; y: number }>(
+	values: Iterable<T>,
+	top: number, left: number, bottom: number, right: number,
+	asArray: boolean, nest: boolean,
+	extract: (value: T) => any,
+) {
 	if (asArray) {
 		return [ ...values ];
 	} else {
@@ -237,7 +247,7 @@ function withAsArray(values: Iterable<{ x: number; y: number }>, top: number, le
 			}
 		}
 		for (const value of values) {
-			results[value.y]![value.x]!.push(value);
+			((results[value.y]!)[value.x] ??= []).push(extract(value));
 		}
 		return results;
 	}

--- a/packages/xxscreeps/game/room/look.ts
+++ b/packages/xxscreeps/game/room/look.ts
@@ -29,7 +29,8 @@ type LookAtResult<Type extends LookConstants> = Record<LookConstants, TypeOfLook
 };
 
 // Helpers for `room.lookAtArea` and `room.lookForAtArea`
-type LookAsArray<Type> = (Type & { x: number; y: number })[];
+interface LookArrayPos { x: number; y: number }
+type LookAsArray<Type> = (Type & LookArrayPos)[];
 type LookAtArea<Type> = Record<number, Record<number, Type[]>>;
 
 // Result of `room.lookForAtArea`. This is the same as `LookAtResult` but without `type`
@@ -160,37 +161,32 @@ extend(Room, {
 
 	lookForAtArea(type: LookConstants, top: number, left: number, bottom: number, right: number, asArray = false) {
 		const size = (bottom - top + 1) * (right - left + 1);
-		type Wrapper = { [k: string]: unknown; x: number; y: number };
-		let extract: (value: Wrapper) => unknown;
-		const results = (() => {
-			if (type === C.LOOK_TERRAIN) {
-				// Simply return terrain data
-				const terrain = this.getTerrain();
-				extract = value => value.terrain;
-				return mapArea(top, left, bottom, right, (x, y) =>
-					({ x, y, terrain: terrainMaskToString[terrain.get(x, y)] }));
-			} else {
-				const objects = (() => {
-					const objects = this['#lookFor'](type);
-					if (size < objects.length) {
-						// Iterate all objects by type
-						return Fn.filter(objects, object =>
-							object.pos.x >= left && object.pos.x <= right &&
-							object.pos.y >= top && object.pos.y <= bottom);
-					} else {
-						// Filter on spatial index
-						return Fn.pipe(
-							iterateArea(this.name, top, left, bottom, right),
-							$$ => Fn.transform($$, pos => this['#lookAt'](pos)),
-							$$ => Fn.filter($$, object => lookMatches(type, object)));
-					}
-				})();
-				// Add position and type information
-				extract = value => value[type];
-				return Fn.map(objects, object => ({ x: object.pos.x, y: object.pos.y, [type]: object }));
-			}
-		})();
-		return withAsArray(results, top, left, bottom, right, asArray, false, extract!) as never;
+		if (type === C.LOOK_TERRAIN) {
+			// Simply return terrain data
+			const terrain = this.getTerrain();
+			const results = mapArea(top, left, bottom, right, (x, y) =>
+				({ x, y, terrain: terrainMaskToString[terrain.get(x, y)] }));
+			return withAsArray(results, top, left, bottom, right, asArray, false, value => value.terrain) as never;
+		} else {
+			const objects = (() => {
+				const objects = this['#lookFor'](type);
+				if (size < objects.length) {
+					// Iterate all objects by type
+					return Fn.filter(objects, object =>
+						object.pos.x >= left && object.pos.x <= right &&
+						object.pos.y >= top && object.pos.y <= bottom);
+				} else {
+					// Filter on spatial index
+					return Fn.pipe(
+						iterateArea(this.name, top, left, bottom, right),
+						$$ => Fn.transform($$, pos => this['#lookAt'](pos)),
+						$$ => Fn.filter($$, object => lookMatches(type, object)));
+				}
+			})();
+			// Add position and type information
+			const results = Fn.map(objects, object => ({ x: object.pos.x, y: object.pos.y, [type]: object }));
+			return withAsArray(results, top, left, bottom, right, asArray, false, value => value[type]) as never;
+		}
 	},
 
 	getPositionAt(xx: number, yy: number) {
@@ -228,7 +224,7 @@ function *lookAtAreaEntries(object: AnyRoomObject): Iterable<LookAreaEntry> {
 	yield { x: object.pos.x, y: object.pos.y, type, [type]: object };
 }
 
-function withAsArray<T extends { x: number; y: number }>(
+function withAsArray<T extends LookArrayPos>(
 	values: Iterable<T>,
 	top: number, left: number, bottom: number, right: number,
 	asArray: boolean, nest: boolean,
@@ -246,8 +242,14 @@ function withAsArray<T extends { x: number; y: number }>(
 				}
 			}
 		}
-		for (const value of values) {
-			((results[value.y]!)[value.x] ??= []).push(extract(value));
+		if (nest) {
+			for (const value of values) {
+				results[value.y]![value.x]!.push(extract(value));
+			}
+		} else {
+			for (const value of values) {
+				(results[value.y]![value.x] ??= []).push(extract(value));
+			}
 		}
 		return results;
 	}

--- a/packages/xxscreeps/mods/road/test.ts
+++ b/packages/xxscreeps/mods/road/test.ts
@@ -1,3 +1,4 @@
+import { LOOK_TERRAIN } from 'xxscreeps/game/constants/find.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createExtension } from 'xxscreeps/mods/spawn/extension.js';
 import { LOOK_STRUCTURES } from 'xxscreeps/mods/structure/constants.js';
@@ -43,15 +44,35 @@ describe('Room.lookForAtArea', () => {
 			room['#insertObject'](create(new RoomPosition(25, 25, 'W0N0')));
 		},
 	})(({ peekRoom }) => peekRoom('W0N0', room => {
-		type CellMap = Record<number, Record<number, { structureType: string }[]>>;
-		const result = room.lookForAtArea(LOOK_STRUCTURES, 24, 24, 26, 26) as unknown as CellMap;
-		const row24 = result[24];
-		assert.ok(row24, 'rows pre-initialized for every y in range');
-		assert.strictEqual(row24[24], undefined, 'cells without matches stay undefined');
-		const cell = result[25]![25]!;
-		assert.strictEqual(cell.length, 1);
-		const entry = cell[0]!;
-		assert.strictEqual(entry.structureType, 'road');
-		assert.strictEqual(LOOK_STRUCTURES in entry, false, 'no wrapper key');
+		const result = room.lookForAtArea(LOOK_STRUCTURES, 24, 24, 26, 26) as unknown as
+			Record<number, Record<number, { structureType: string }[]>>;
+		assert.ok(result[24], 'rows pre-initialized for every y in range');
+		assert.strictEqual(result[24][24], undefined, 'cells without matches stay undefined');
+		const matches = result[25]![25]!;
+		assert.deepStrictEqual(matches.map(structure => structure.structureType), [ 'road' ]);
+		assert.strictEqual(LOOK_STRUCTURES in matches[0]!, false, 'cells hold raw objects, no wrapper key');
+	})));
+
+	test('asArray=false LOOK_TERRAIN extracts the terrain string into the cell', () => simulate({})(({ peekRoom }) => peekRoom('W0N0', room => {
+		const result = room.lookForAtArea(LOOK_TERRAIN, 10, 10, 10, 10) as unknown as
+			Record<number, Record<number, string[]>>;
+		assert.strictEqual(result[10]![10]!.length, 1);
+		assert.ok([ 'plain', 'swamp', 'wall' ].includes(result[10]![10]![0]!));
+	})));
+});
+
+describe('Room.lookAtArea', () => {
+	test('asArray=false cells wrap entries without spurious x/y keys', () => simulate({
+		W0N0: room => {
+			room['#insertObject'](create(new RoomPosition(25, 25, 'W0N0')));
+		},
+	})(({ peekRoom }) => peekRoom('W0N0', room => {
+		const cell = (room.lookAtArea(25, 25, 25, 25) as unknown as
+			Record<number, Record<number, { type: string }[]>>)[25]![25]!;
+		assert.deepStrictEqual(cell.map(entry => entry.type).sort(), [ 'structure', 'terrain' ]);
+		for (const entry of cell) {
+			assert.strictEqual('x' in entry, false);
+			assert.strictEqual('y' in entry, false);
+		}
 	})));
 });

--- a/packages/xxscreeps/mods/road/test.ts
+++ b/packages/xxscreeps/mods/road/test.ts
@@ -48,16 +48,16 @@ describe('Room.lookForAtArea', () => {
 			Record<number, Record<number, { structureType: string }[]>>;
 		assert.ok(result[24], 'rows pre-initialized for every y in range');
 		assert.strictEqual(result[24][24], undefined, 'cells without matches stay undefined');
-		const matches = result[25]![25]!;
-		assert.deepStrictEqual(matches.map(structure => structure.structureType), [ 'road' ]);
+		const matches = result[25]?.[25];
+		assert.deepStrictEqual(matches?.map(structure => structure.structureType), [ 'road' ]);
 		assert.strictEqual(LOOK_STRUCTURES in matches[0]!, false, 'cells hold raw objects, no wrapper key');
 	})));
 
 	test('asArray=false LOOK_TERRAIN extracts the terrain string into the cell', () => simulate({})(({ peekRoom }) => peekRoom('W0N0', room => {
 		const result = room.lookForAtArea(LOOK_TERRAIN, 10, 10, 10, 10) as unknown as
 			Record<number, Record<number, string[]>>;
-		assert.strictEqual(result[10]![10]!.length, 1);
-		assert.ok([ 'plain', 'swamp', 'wall' ].includes(result[10]![10]![0]!));
+		assert.strictEqual(result[10]?.[10]?.length, 1);
+		assert.ok([ 'plain', 'swamp', 'wall' ].includes(result[10][10][0]!));
 	})));
 });
 

--- a/packages/xxscreeps/mods/road/test.ts
+++ b/packages/xxscreeps/mods/road/test.ts
@@ -1,5 +1,6 @@
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createExtension } from 'xxscreeps/mods/spawn/extension.js';
+import { LOOK_STRUCTURES } from 'xxscreeps/mods/structure/constants.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create } from './road.js';
 
@@ -33,5 +34,24 @@ describe('Roads', () => {
 		// Don't care about roads
 		const path3 = room.findPath(new RoomPosition(21, 22, 'W0N0'), new RoomPosition(25, 26, 'W0N0'), { ignoreRoads: true });
 		assert.strictEqual(path3.length, 4);
+	})));
+});
+
+describe('Room.lookForAtArea', () => {
+	test('asArray=false returns sparse map of raw objects (vanilla shape)', () => simulate({
+		W0N0: room => {
+			room['#insertObject'](create(new RoomPosition(25, 25, 'W0N0')));
+		},
+	})(({ peekRoom }) => peekRoom('W0N0', room => {
+		type CellMap = Record<number, Record<number, { structureType: string }[]>>;
+		const result = room.lookForAtArea(LOOK_STRUCTURES, 24, 24, 26, 26) as unknown as CellMap;
+		const row24 = result[24];
+		assert.ok(row24, 'rows pre-initialized for every y in range');
+		assert.strictEqual(row24[24], undefined, 'cells without matches stay undefined');
+		const cell = result[25]![25]!;
+		assert.strictEqual(cell.length, 1);
+		const entry = cell[0]!;
+		assert.strictEqual(entry.structureType, 'road');
+		assert.strictEqual(LOOK_STRUCTURES in entry, false, 'no wrapper key');
 	})));
 });


### PR DESCRIPTION
## Summary

Two `asArray=false` parity bugs in `Room.lookForAtArea` and `Room.lookAtArea`:

- `lookForAtArea` threw `Cannot read properties of undefined (reading 'push')` on the first match. `withAsArray` pre-initialized rows but not cells for the sparse-cell variant; `cell.push(value)` then crashed on the `undefined` cell.
- `lookAtArea` cells contained `{ x, y, type, [type]: obj }` wrappers instead of `{ type, [type]: obj }`.

Both methods now thread an `extract` callback through `withAsArray`:

- `lookForAtArea` extracts the raw object (or terrain string for `LOOK_TERRAIN`) so cells hold the value directly.
- `lookAtArea` peels off `x`/`y` so the cell entry is just the type wrapper.

Cells are lazy-allocated via `??=`, removing the crash. `withAsArray` is generic over the iterable element type so the extract callback sees the original fields.

## Validation

- `pnpm run build` clean
- `npx xxscreeps test` — 296/296 (3 new tests in `mods/road/test.ts` covering sparse cells of raw objects, `LOOK_TERRAIN` cell extraction, and `lookAtArea` wrapper-shape).
- `pnpm exec eslint` on changed files — 0 new warnings.
- screeps-ok suite `ROOM-LOOK-011 / 012 / 013` (sparse raw-object map, stacked matches in one cell, dense `lookAtArea` + wrapper-shape) all pass against this branch via `XXSCREEPS_LOCAL`.