### PR TITLE
Fix local zUnionStore to apply WEIGHTS to single-set members

### DIFF
--- a/.changeset/local-zunionstore-weights.md
+++ b/.changeset/local-zunionstore-weights.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix local `zUnionStore` to apply WEIGHTS to members present in only one input set.

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -636,7 +636,9 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 				[ options.weights![index] ?? 1, this.data.get(key) ]);
 			const sets = Fn.filter(maybeSets, entry => entry[1]);
 			for (const [ weight, set ] of sets) {
-				out.insert(set.entries(), (left, right) => left + right * weight);
+				const weighted = Fn.map(set.entries(), ([ score, member ]): [ number, string ] =>
+					[ score * weight, member ]);
+				out.insert(weighted, (left, right) => left + right);
 			}
 		} else {
 			// Without WEIGHTS insert can happen at once

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -416,12 +416,11 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 					default: return members;
 				}
 			}();
-			const up = function() {
-				// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+			const up = function(): (left: number | undefined, right: number) => number {
 				switch (options?.up) {
-					case 'GT': return Math.max;
-					case 'LT': return Math.min;
-					default: return (left: unknown, right: number) => right;
+					case 'GT': return (left, right) => left === undefined ? right : Math.max(left, right);
+					case 'LT': return (left, right) => left === undefined ? right : Math.min(left, right);
+					case undefined: return (left, right) => right;
 				}
 			}();
 
@@ -629,28 +628,27 @@ export class LocalKeyValResponder implements MaybePromises<P.KeyValProvider> {
 	}
 
 	zUnionStore(key: string, keys: string[], options?: P.ZAggregate) {
-		const out = new SortedSet();
-		if (options?.weights) {
-			// With WEIGHTS each set needs to be applied one at a time
-			const maybeSets = Fn.map(keys.entries(), ([ index, key ]): [number, SortedSet] =>
-				[ options.weights![index] ?? 1, this.data.get(key) ]);
-			const sets = Fn.filter(maybeSets, entry => entry[1]);
-			for (const [ weight, set ] of sets) {
-				const weighted = Fn.map(set.entries(), ([ score, member ]): [ number, string ] =>
-					[ score * weight, member ]);
-				out.insert(weighted, (left, right) => left + right);
+		const out = new SortedSet((() => {
+			if (options?.weights) {
+				// With WEIGHTS each set needs to be applied one at a time
+				const { weights } = options;
+				return Fn.pipe(
+					keys.entries(),
+					$$ => Fn.map($$, ([ index, key ]) =>
+						[ weights[index] ?? 1, this.data.get(key) as SortedSet | undefined ] as const),
+					$$ => Fn.filter($$, (entry): entry is [ number, SortedSet ] => Boolean(entry[1])),
+					$$ => Fn.transform($$, ([ weight, set ]) =>
+						Fn.map(set.entries(), ([ score, member ]) => [ score * weight, member ] as const)));
+			} else {
+				// Without WEIGHTS insert can happen at once
+				return Fn.pipe(
+					keys,
+					$$ => Fn.map($$, key => this.data.get(key) as SortedSet),
+					$$ => Fn.filter($$),
+					$$ => [ ...$$ ],
+					$$ => Fn.transform($$, set => set.entries()));
 			}
-		} else {
-			// Without WEIGHTS insert can happen at once
-			const entries = Fn.pipe(
-				keys,
-				$$ => Fn.map($$, (key): SortedSet => this.data.get(key)),
-				$$ => Fn.filter($$),
-				$$ => [ ...$$ ],
-				$$ => Fn.map($$, set => set.entries()),
-				$$ => Fn.concat($$));
-			out.insert(entries);
-		}
+		})());
 		if (out.size === 0) {
 			this.data.delete(key);
 		} else {

--- a/packages/xxscreeps/engine/db/storage/local/sorted-set.ts
+++ b/packages/xxscreeps/engine/db/storage/local/sorted-set.ts
@@ -63,13 +63,13 @@ export class SortedSet {
 		return this.#scores.has(member);
 	}
 
-	insert(entries: Iterable<[ number, string ]>, accumulator = (left: number, right: number) => left + right) {
+	insert(entries: Iterable<readonly [ number, string ]>, accumulator = (left: number | undefined, right: number) => (left ?? 0) + right) {
 		let count = 0;
 		for (const [ score, member ] of entries) {
 			const currentScore = this.#scores.get(member);
 			if (currentScore === undefined) {
 				this.#members.push(member);
-				this.#scores.set(member, score);
+				this.#scores.set(member, accumulator(undefined, score));
 				++count;
 			} else {
 				this.#scores.set(member, accumulator(currentScore, score));

--- a/packages/xxscreeps/engine/db/storage/local/test.ts
+++ b/packages/xxscreeps/engine/db/storage/local/test.ts
@@ -1,0 +1,16 @@
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+
+describe('LocalKeyValResponder', () => {
+	test('zUnionStore applies WEIGHTS to single-set members', async () => {
+		using testShard = await instantiateTestShard();
+		const { scratch } = testShard.shard;
+		await Promise.all([
+			scratch.zAdd('a', [ [ 5, 'only-a' ] ]),
+			scratch.zAdd('b', [ [ 7, 'only-b' ] ]),
+		]);
+		await scratch.zUnionStore('out', [ 'a', 'b' ], { weights: [ 2, 3 ] });
+		assert.strictEqual(await scratch.zScore('out', 'only-a'), 10);
+		assert.strictEqual(await scratch.zScore('out', 'only-b'), 21);
+	});
+});

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -2,6 +2,7 @@ import { importMods } from 'xxscreeps/config/mods/index.js';
 import { flush, summary } from './context.js';
 import './import.js';
 import 'xxscreeps/cli/test.js';
+import 'xxscreeps/engine/db/storage/local/test.js';
 import 'xxscreeps/game/test.js';
 
 await importMods('test');


### PR DESCRIPTION
## Summary

`LocalKeyValResponder.zUnionStore` drops the WEIGHTS factor on members
present in only one input set: `SortedSet.insert` stores new members at
their literal score and only invokes the accumulator on existing ones,
but the multiplication lives inside the accumulator.

`engine/processor/model.ts` uses
`zUnionStore(processSet, [activeRoomsKey, tmpKey], { weights: [1, 0] })`
to merge waking rooms into the processing queue at score `0`. Under the
local provider, waking rooms instead landed at their raw wake-time score
(~1.5M), never got consumed, and tripped `intentAbandonTimeout` — 5s
tick stalls and `"Abandoning intents in rooms"` warnings.

Pre-multiply scores by weight before `insert`.

## Validation

- `pnpm run build` clean
- `npx xxscreeps test` — 343/343 passing, including the new
  `LocalKeyValResponder` regression test
- Confirmed the new test fails on `main` and passes with the fix