### PR TITLE
redis: require Redis >= 8.2 and probe version at connect

### DIFF
--- a/.changeset/redis-min-version.md
+++ b/.changeset/redis-min-version.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/redis": patch
+---
+
+Require Redis >= 8.2 (mutex uses `SET ... IFEQ`); probe version at connect.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -1,6 +1,12 @@
 # @xxscreeps/redis
 
-Sample configuration:
+## Requirements
+
+Redis >= 8.2. The mutex uses `SET ... IFEQ` (compare-and-set), which was
+introduced in Redis 8.2; older servers fail at startup with a clear version
+error.
+
+## Sample configuration
 
 ```yaml
 mods:

--- a/packages/redis/client.ts
+++ b/packages/redis/client.ts
@@ -29,5 +29,15 @@ export async function acquireRedisClient(url: URL, blob = false): Promise<RedisC
 		}
 	}();
 	await client.connect();
+	await assertMinimumVersion(client);
 	return client;
+}
+
+async function assertMinimumVersion(client: RedisClient | RedisBlobClient) {
+	const match = /^redis_version:(\d+)\.(\d+)/m.exec(String(await client.info('server')));
+	if (!match) throw new Error('@xxscreeps/redis: could not read redis_version from INFO server');
+	const [ , major, minor ] = match;
+	if (Number(major) < 8 || (Number(major) === 8 && Number(minor) < 2)) {
+		throw new Error(`@xxscreeps/redis requires Redis >= 8.2 (found ${major}.${minor})`);
+	}
 }

--- a/packages/redis/client.ts
+++ b/packages/redis/client.ts
@@ -29,15 +29,14 @@ export async function acquireRedisClient(url: URL, blob = false): Promise<RedisC
 		}
 	}();
 	await client.connect();
-	await assertMinimumVersion(client);
-	return client;
-}
 
-async function assertMinimumVersion(client: RedisClient | RedisBlobClient) {
-	const match = /^redis_version:(\d+)\.(\d+)/m.exec(String(await client.info('server')));
+	// check required version
+	const match = /^redis_version:(?<major>\d+)\.(?<minor>\d+)/m.exec(String(await client.info('server')));
 	if (!match) throw new Error('@xxscreeps/redis: could not read redis_version from INFO server');
-	const [ , major, minor ] = match;
+	const { major, minor } = match.groups ?? {};
 	if (Number(major) < 8 || (Number(major) === 8 && Number(minor) < 2)) {
 		throw new Error(`@xxscreeps/redis requires Redis >= 8.2 (found ${major}.${minor})`);
 	}
+
+	return client;
 }

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -17,6 +17,9 @@
   "peerDependencies": {
     "xxscreeps": "workspace:~"
   },
+  "engines": {
+    "redis": ">=8.2"
+  },
   "homepage": "https://github.com/laverdet/xxscreeps/blob/main/packages/redis/README.md",
   "repository": {
     "type": "git",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -17,9 +17,6 @@
   "peerDependencies": {
     "xxscreeps": "workspace:~"
   },
-  "engines": {
-    "redis": ">=8.2"
-  },
   "homepage": "https://github.com/laverdet/xxscreeps/blob/main/packages/redis/README.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- `@xxscreeps/redis` started using `SET ... IFEQ` in the mutex (`packages/redis/keyval.ts:115,160`), which is a Redis 8.2 feature. On older servers the first mutex lease renewal returns `ERR syntax error` and crashes the launcher at a non-deterministic tick (reproduced on 7.4.9: tick 264).
- Add a connect-time `INFO server` probe in `acquireRedisClient` so older servers fail fast at startup with `@xxscreeps/redis requires Redis >= 8.2 (found <x.y>)` instead of a cryptic decoder error hours later.
- Document the requirement in `packages/redis/README.md` and add an informational `engines.redis: ">=8.2"` to the package manifest.

## Validation

- `pnpm run build` — clean.
- `npx eslint --max-warnings 0 packages/redis/client.ts` — clean.
- Spun up `redis:7-alpine` (7.4.9) on a side port; `acquireRedisClient` threw `@xxscreeps/redis requires Redis >= 8.2 (found 7.4)` at connect, as expected.
- Spun up `redis:8-alpine` (8.6.3); engine launched and ran 2374 ticks past the prior 264 crash point, then shut down cleanly on SIGINT.