### PR TITLE
Add live REPL to xxscreeps cli

### DIFF
--- a/.changeset/cli-live-repl.md
+++ b/.changeset/cli-live-repl.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": minor
+---
+
+Add `xxscreeps cli` launcher-RPC live REPL with provider-aware auto-detection; drain async eval tails on EOF.

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ If you want to use your bot script, use `npx xxscreeps import --overwrite-code .
 
 ## Operator CLI
 
-`xxscreeps cli` opens a JavaScript REPL in the CLI process's host realm, and
-`xxscreeps eval` runs one-shot scripts with `-e`, `--file`, or `--stdin`, plus
-an optional `--json` envelope mode for tooling. See
-[packages/xxscreeps/cli/README.md](packages/xxscreeps/cli/README.md) for flags
-and the JSON envelope schema.
+`xxscreeps cli` opens a JavaScript REPL that auto-detects a running launcher
+and forwards over its RPC socket when available, falling back to a host-realm
+REPL otherwise. `xxscreeps eval` runs one-shot scripts with `-e`, `--file`, or
+`--stdin`. See [packages/xxscreeps/cli/README.md](packages/xxscreeps/cli/README.md)
+for flags and launcher-mode details.
 
 ## Docker
 

--- a/packages/xxscreeps/cli/README.md
+++ b/packages/xxscreeps/cli/README.md
@@ -1,24 +1,34 @@
 # xxscreeps CLI
 
-Operator-facing JavaScript REPL and one-shot evaluator. Both run inside the CLI process's host realm
-— operator typing has the same access the launcher does. There is no `vm.Context`, no curated
-globals list.
+Operator-facing JavaScript REPL and one-shot evaluator.
+
+- `xxscreeps cli` evaluates each line against the launcher's `db`/`shard` when the launcher's RPC
+  socket is reachable (**launcher mode**), or in the CLI's own process otherwise (**direct mode**).
+- `xxscreeps eval` always runs in the CLI's own process.
 
 ## Commands
 
 ### `xxscreeps cli`
 
-Interactive REPL backed by `node:repl`. Bare `xxscreeps` (no subcommand) is an alias.
+Interactive REPL backed by `node:repl`. Bare `xxscreeps` (no subcommand) is an alias. No flags — the
+backend is picked at startup by inspecting the configured storage provider, then probing the
+launcher RPC socket if the provider is local. The banner names the chosen mode (`connected to
+launcher RPC at …` or `… running direct REPL`) and the prompt is `xxscreeps live>` or `xxscreeps>`
+accordingly.
 
-- Variables persist across turns: `var x = 1; x` then `x + 1` works.
+- Top-level declarations (`let`, `const`, `var`) persist across turns, including on the same line as
+  `await` — `let user = await db.users.findByName('foo')` then `user.name` works. The hoist
+  rewrites them as `var`, so `const` immutability isn't preserved and class/function declarations
+  don't persist; bind via `let C = class { … }` if you need a class to survive turns.
 - Top-level `await` works at the prompt.
 - Multi-line input is recoverable: typing `if (x) {` reprompts until the block closes.
-- `node:repl` defaults are unchanged — meta-commands (`.help`, `.exit`, `.load`, `.save`, `.editor`,
-  `.clear`) work as in plain `node`.
+- `node:repl` meta-commands (`.help`, `.exit`, `.load`, `.save`, `.editor`, `.clear`) work as in
+  plain `node`.
 
 ### `xxscreeps eval`
 
-One-shot evaluator. Source comes from exactly one of `-e/--expression`, `--file`, or `--stdin`.
+One-shot evaluator. Always runs in the host realm. Source comes from exactly one of
+`-e/--expression`, `--file`, or `--stdin`.
 
 | Flag | Description |
 |---|---|
@@ -28,7 +38,44 @@ One-shot evaluator. Source comes from exactly one of `-e/--expression`, `--file`
 | `-- arg …` | Trailing positionals exposed inside the script as `argv: string[]` |
 
 
-## Realm
+## Modes
+
+Launcher and direct describe *where* code runs, not whether the engine is running. With a networked
+storage provider the engine may well be live; the CLI just reaches it through storage rather than
+sharing a process.
+
+| | Launcher | Direct |
+|---|---|---|
+| Process | Inside the running launcher, one `vm.Context` per connection | The CLI's own process, host realm |
+| `db` / `shard` | Pre-bound to the launcher's instances | Not bound — construct your own if needed |
+| Pre-flush in-memory state | Visible | Not visible (storage only) |
+| Concurrent sessions | Isolated per connection | Each runs in its own process |
+| When picked | Local provider + launcher up | Networked provider, or no launcher up |
+
+### Launcher
+
+When `xxscreeps start` is running against a local provider it listens on a Unix socket (or Windows
+named pipe) at `screeps/cli.sock` next to `.screepsrc.yaml`. `xxscreeps cli` auto-detects that
+socket and forwards each REPL line over a persistent connection.
+
+Each connection gets its own `node:vm` context, retained for the connection's lifetime. Bindings:
+
+| Helper | Source |
+|---|---|
+| `db` | The launcher's `Database` instance |
+| `shard` | The launcher's default `Shard` instance |
+| `console` | Each request's output drains into that request's response |
+| `print` | Alias for `console.log` |
+| `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval` | Node timer intrinsics |
+
+Nothing else — `Game`, `Memory`, `rooms`, `users` aren't bound; those land with the domain commands
+that need them. Vars persist across turns on a single connection; two parallel `xxscreeps cli`
+sessions to the same launcher each get an isolated context.
+
+Pass `--no-launcher-rpc` to `xxscreeps start` to launch without the RPC socket; the CLI then always
+falls back to direct mode.
+
+### Direct
 
 Operator code runs in the CLI process's host realm. `process`, `require`, dynamic `import()`,
 `Buffer`, `__dirname`, `__filename`, every node built-in, and every npm dependency the launcher
@@ -37,6 +84,32 @@ a security boundary.
 
 `argv` (eval only) is exposed as a global populated from trailing positionals.
 
-No engine state is exposed: `Game`, `Memory`, `shard`, and `db` are absent because the engine is not
-running. A live-mode bridge that runs eval on the engine side and exposes that state through a Unix
-socket is a planned follow-up.
+`db` and `shard` aren't pre-bound. Construct them yourself if you need them — for a networked
+provider this connects to the same data the launcher is reading and writing, so direct mode against
+a running Redis is "live state, separate process," not offline. For a local provider with no
+launcher up you're touching the files directly; doing that against a running launcher is unsafe
+because the local provider isn't designed for concurrent writers.
+
+## Mode selection
+
+`xxscreeps cli` picks its mode by inspecting `config.database.data`:
+
+- Networked providers (`redis:`, future `postgres:`) → direct mode. No RPC probe; there's no
+  in-process state to share, and storage is already the rendezvous point.
+- Local file-backed providers (`file:`, `local:`) → probe the launcher RPC socket. On `connect`
+  success the REPL goes launcher; on failure (no launcher, refused, stale inode), fall back to
+  direct mode and print why.
+
+## Limitations
+
+- **No async runaway timeout.** `vm.Script` covers sync runaways only; an async loop
+  (`while(true) await new Promise(r => setTimeout(r, 0))`) can hang a REPL turn until the operator
+  interrupts the launcher. Launcher shutdown also waits for any in-flight RPC eval to finish.
+- **One RPC per config.** A second `xxscreeps start` for the same config refuses to launch on
+  socket-in-use.
+- **No multi-shard handshake.** The launcher RPC serves the launcher's default shard. Deferred to a
+  later slice.
+- **Unix permissions.** Socket file `0o600`, parent directory `0o700`. The RPC socket is reachable
+  only to the launcher's UID.
+- **Windows.** Named pipes don't carry Unix permissions; the pipe is reachable by any local-machine
+  user. Run on Unix for deployments where that matters.

--- a/packages/xxscreeps/cli/cli.ts
+++ b/packages/xxscreeps/cli/cli.ts
@@ -119,31 +119,39 @@ function renderRpcResponse(response: LauncherRpcResponse): void {
 function startHostRealmRepl(mode: HostMode): void {
 	process.stderr.write(`xxscreeps cli: ${mode.reason}; running direct REPL\n`);
 	installHostShims();
+	// `repl` fires 'exit' before queued eval callbacks; drain so piped input doesn't lose its tail.
+	const inFlight = new Set<Promise<unknown>>();
 	const server = repl.start({
-		eval: hostRealmEval,
+		eval: createHostRealmEvaluator(inFlight),
 		prompt: 'xxscreeps> ',
 		useGlobal: true,
 	});
-	server.on('exit', () => process.exit(0));
+	server.on('exit', () => {
+		void Promise.allSettled(inFlight).finally(() => process.exit(0));
+	});
 }
 
-function hostRealmEval(
-	cmd: string,
-	_context: vm.Context,
-	_filename: string,
-	callback: (err: Error | null, result?: unknown) => void,
-) {
-	if (cmd.trim() === '') {
-		callback(null, undefined);
-		return;
-	}
-	const result = makeUnsafeGlobalEvaluator(cmd);
-	if (typeof result === 'function') {
-		result().then(
+function createHostRealmEvaluator(inFlight: Set<Promise<unknown>>) {
+	return (
+		cmd: string,
+		_context: vm.Context,
+		_filename: string,
+		callback: (err: Error | null, result?: unknown) => void,
+	) => {
+		if (cmd.trim() === '') {
+			callback(null, undefined);
+			return;
+		}
+		const result = makeUnsafeGlobalEvaluator(cmd);
+		if (typeof result !== 'function') {
+			callback(new repl.Recoverable(result));
+			return;
+		}
+		const pending = result().then(
 			value => callback(null, value),
 			err => callback(err instanceof Error ? err : new Error(String(err))),
 		);
-	} else {
-		callback(new repl.Recoverable(result));
-	}
+		inFlight.add(pending);
+		void pending.finally(() => inFlight.delete(pending));
+	};
 }

--- a/packages/xxscreeps/cli/cli.ts
+++ b/packages/xxscreeps/cli/cli.ts
@@ -1,18 +1,133 @@
+import type { LauncherRpcClient, LauncherRpcResponse } from './socket.js';
 import type * as vm from 'node:vm';
 import * as repl from 'node:repl';
 import { ArgumentParser } from 'argparse';
+import config from 'xxscreeps/config/index.js';
+import { configPath } from 'xxscreeps/config/raw.js';
 import { installHostShims } from './eval-offline.js';
+import { connectLauncherRpc, socketPathFor } from './socket.js';
 import { makeUnsafeGlobalEvaluator } from './unsafe.js';
 
+interface LauncherMode {
+	readonly kind: 'launcher';
+	readonly client: LauncherRpcClient;
+	readonly socketPath: string;
+}
+interface HostMode {
+	readonly kind: 'host';
+	readonly reason: string;
+}
+type Mode = LauncherMode | HostMode;
+
+// Schemes whose backing storage is in-process; networked providers need their own daemon, not a Unix socket probe.
+const localProviderSchemes = new Set([ 'file:', 'local:' ]);
+
 const parser = new ArgumentParser({
-	description: 'Interactive REPL evaluating in the host JS realm.',
+	description: 'Interactive REPL. Connects to a running launcher via its RPC socket when one is detected; otherwise evaluates in the host JS realm.',
 	prog: 'xxscreeps cli',
 });
 parser.parse_args();
 
-installHostShims();
+const mode = await detectMode();
+if (mode.kind === 'launcher') {
+	startLauncherRepl(mode);
+} else {
+	startHostRealmRepl(mode);
+}
 
-function customEval(
+// TODO(slice 3): per-command transport routing (Manifest.commands +
+// requiresLauncher, issue 168) probes the launcher RPC lazily on its own
+// path; this detection covers REPL-eval transport only.
+async function detectMode(): Promise<Mode> {
+	const dataUrl = new URL(config.database.data, configPath);
+	if (!localProviderSchemes.has(dataUrl.protocol)) {
+		const scheme = dataUrl.protocol.replace(/:$/, '');
+		return { kind: 'host', reason: `database provider '${scheme}' is not local; launcher RPC skipped` };
+	}
+	const socketPath = socketPathFor(configPath);
+	try {
+		const client = await connectLauncherRpc(socketPath);
+		return { kind: 'launcher', client, socketPath };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { kind: 'host', reason: `launcher RPC unavailable at ${socketPath} (${message})` };
+	}
+}
+
+function startLauncherRepl(mode: LauncherMode): void {
+	process.stderr.write(`xxscreeps cli: connected to launcher RPC at ${mode.socketPath}\n`);
+	// `repl` fires 'exit' before queued eval callbacks; drain so piped input doesn't lose its tail.
+	const inFlight = new Set<Promise<unknown>>();
+	let intentionalShutdown = false as boolean;
+	const server = repl.start({
+		prompt: 'xxscreeps live> ',
+		eval: createRpcEvaluator(mode.client, inFlight),
+	});
+	server.on('exit', () => {
+		intentionalShutdown = true;
+		void Promise.allSettled(inFlight)
+			.then(() => mode.client.close())
+			.finally(() => process.exit(0));
+	});
+	void mode.client.closed.then(() => {
+		if (intentionalShutdown) return;
+		process.stderr.write('xxscreeps cli: launcher RPC closed, exiting\n');
+		process.exit(1);
+	});
+}
+
+function createRpcEvaluator(client: LauncherRpcClient, inFlight: Set<Promise<unknown>>) {
+	return (
+		cmd: string,
+		_context: vm.Context,
+		_filename: string,
+		callback: (err: Error | null, result?: unknown) => void,
+	) => {
+		if (cmd.trim() === '') {
+			callback(null, undefined);
+			return;
+		}
+		// Local parse only surfaces `repl.Recoverable`; the source never runs in this realm.
+		const probe = makeUnsafeGlobalEvaluator(cmd);
+		if (typeof probe !== 'function') {
+			callback(new repl.Recoverable(probe));
+			return;
+		}
+		const pending = client.send({ expression: cmd }).then(response => {
+			renderRpcResponse(response);
+			callback(null, undefined);
+		}, (err: unknown) => {
+			const message = err instanceof Error ? err.message : String(err);
+			process.stderr.write(`xxscreeps cli: launcher RPC request failed: ${message}\n`);
+			callback(null, undefined);
+		});
+		inFlight.add(pending);
+		void pending.finally(() => inFlight.delete(pending));
+	};
+}
+
+function renderRpcResponse(response: LauncherRpcResponse): void {
+	if (response.stdout) process.stdout.write(response.stdout);
+	if (response.stderr) process.stderr.write(response.stderr);
+	if (response.ok) {
+		process.stdout.write(`${response.output}\n`);
+	} else {
+		process.stderr.write(`${response.output}\n`);
+	}
+}
+
+function startHostRealmRepl(mode: HostMode): void {
+	process.stderr.write(`xxscreeps cli: ${mode.reason}; running direct REPL\n`);
+	installHostShims();
+	const server = repl.start({
+		eval: hostRealmEval,
+		prompt: 'xxscreeps> ',
+		useGlobal: true,
+	});
+	server.on('exit', () => process.exit(0));
+}
+
+function hostRealmEval(
 	cmd: string,
 	_context: vm.Context,
 	_filename: string,
@@ -32,11 +147,3 @@ function customEval(
 		callback(new repl.Recoverable(result));
 	}
 }
-
-const server = repl.start({
-	eval: customEval,
-	prompt: 'xxscreeps> ',
-	useGlobal: true,
-});
-
-server.on('exit', () => process.exit(0));

--- a/packages/xxscreeps/cli/eval-offline.ts
+++ b/packages/xxscreeps/cli/eval-offline.ts
@@ -3,17 +3,27 @@ import * as path from 'node:path';
 import * as util from 'node:util';
 import { evaluateUnsafeGlobal } from './unsafe.js';
 
-export function installHostShims(): void {
+export function installHostShims(): Disposable {
 	const globals = globalThis as Record<string, unknown>;
 	const cwd = process.cwd();
 	const syntheticFile = path.join(cwd, '[eval]');
-	globals.require ??= createRequire(syntheticFile);
-	globals.__filename ??= syntheticFile;
-	globals.__dirname ??= cwd;
+	const setRequire = !('require' in globals);
+	const setFilename = !('__filename' in globals);
+	const setDirname = !('__dirname' in globals);
+	if (setRequire) globals.require = createRequire(syntheticFile);
+	if (setFilename) globals.__filename = syntheticFile;
+	if (setDirname) globals.__dirname = cwd;
+	return {
+		[Symbol.dispose]() {
+			if (setRequire) delete globals.require;
+			if (setFilename) delete globals.__filename;
+			if (setDirname) delete globals.__dirname;
+		},
+	};
 }
 
 function shareGlobals(argv: readonly string[]) {
-	installHostShims();
+	const shims = installHostShims();
 	const globals = globalThis as Record<string, unknown>;
 	const previousConsole = globals.console;
 	const hadArgv = 'argv' in globals;
@@ -27,6 +37,7 @@ function shareGlobals(argv: readonly string[]) {
 			} else {
 				delete globals.argv;
 			}
+			shims[Symbol.dispose]();
 		},
 	};
 }

--- a/packages/xxscreeps/cli/launcher-rpc.ts
+++ b/packages/xxscreeps/cli/launcher-rpc.ts
@@ -1,0 +1,128 @@
+import type { LauncherRpcRequest, LauncherRpcResponse } from './socket.js';
+import type { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import * as fs from 'node:fs';
+import * as util from 'node:util';
+import * as vm from 'node:vm';
+import { configPath } from 'xxscreeps/config/raw.js';
+import { listenLauncherRpc, probeSocketPath, socketPathFor } from './socket.js';
+import { makeUnsafeEvaluator } from './unsafe.js';
+
+interface StartLauncherRpcServerOptions {
+	readonly socketPath?: string;
+}
+
+export async function startLauncherRpcServer(
+	db: Database,
+	shard: Shard,
+	options: StartLauncherRpcServerOptions = {},
+): Promise<() => Promise<void>> {
+	const socketPath = options.socketPath ?? socketPathFor(configPath);
+	if (await probeSocketPath(socketPath) === 'in-use') {
+		throw new Error(`xxscreeps launcher RPC already listening on ${socketPath}`);
+	}
+	const listener = await listenLauncherRpc(socketPath, () => createSessionHandler(db, shard));
+	let cleanupPromise: Promise<void> | undefined;
+	return () => {
+		cleanupPromise ??= cleanup(listener, socketPath);
+		return cleanupPromise;
+	};
+}
+
+async function cleanup(listener: { close: () => Promise<void> }, socketPath: string): Promise<void> {
+	await listener.close();
+	if (process.platform !== 'win32') {
+		try { fs.unlinkSync(socketPath); } catch {}
+	}
+}
+
+interface DrainedSink {
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+interface ConsoleSink {
+	log: (...args: unknown[]) => void;
+	info: (...args: unknown[]) => void;
+	warn: (...args: unknown[]) => void;
+	error: (...args: unknown[]) => void;
+}
+
+interface RecordedConsole extends ConsoleSink {
+	drain: () => DrainedSink;
+}
+
+function createRecordedConsole(): RecordedConsole {
+	const stdoutChunks: string[] = [];
+	const stderrChunks: string[] = [];
+	const append = (chunks: string[]) => (...args: unknown[]) => {
+		chunks.push(`${util.formatWithOptions({ colors: false }, ...args)}\n`);
+	};
+	return {
+		error: append(stderrChunks),
+		info: append(stdoutChunks),
+		log: append(stdoutChunks),
+		warn: append(stderrChunks),
+		drain: () => ({
+			stdout: stdoutChunks.join(''),
+			stderr: stderrChunks.join(''),
+		}),
+	};
+}
+
+// One `vm.Context` per connection; the `console` proxy routes via ALS so late async logs land in their originating turn's drained sink.
+function createSessionHandler(db: Database, shard: Shard) {
+	const sinkStore = new AsyncLocalStorage<RecordedConsole>();
+	const consoleProxy: ConsoleSink = {
+		log: (...args) => sinkStore.getStore()?.log(...args),
+		info: (...args) => sinkStore.getStore()?.info(...args),
+		warn: (...args) => sinkStore.getStore()?.warn(...args),
+		error: (...args) => sinkStore.getStore()?.error(...args),
+	};
+	const context = vm.createContext({
+		clearInterval, clearTimeout,
+		console: consoleProxy,
+		db, shard,
+		print: consoleProxy.log,
+		setInterval, setTimeout,
+	}, { name: 'xxscreeps cli' });
+	return (request: LauncherRpcRequest) => {
+		const sink = createRecordedConsole();
+		return sinkStore.run(sink, () => evaluate(context, request, sink));
+	};
+}
+
+async function evaluate(
+	context: vm.Context,
+	request: LauncherRpcRequest,
+	sink: RecordedConsole,
+): Promise<LauncherRpcResponse> {
+	try {
+		const evaluator = makeUnsafeEvaluator(request.expression, { context });
+		if (typeof evaluator !== 'function') throw evaluator;
+		const result = await evaluator();
+		const { stdout, stderr } = sink.drain();
+		return { ok: true, stdout, stderr, output: util.inspect(result, { colors: false }) };
+	} catch (thrown) {
+		const { stdout, stderr } = sink.drain();
+		return { ok: false, stdout, stderr, output: formatThrown(thrown) };
+	}
+}
+
+// Cross-realm Errors don't satisfy `instanceof Error`; duck-type stack / name / message.
+interface ErrorLike {
+	readonly name?: unknown;
+	readonly message?: unknown;
+	readonly stack?: unknown;
+}
+
+function formatThrown(thrown: unknown): string {
+	if (typeof thrown === 'object' && thrown !== null) {
+		const fields = thrown as ErrorLike;
+		if (typeof fields.stack === 'string' && fields.stack !== '') return fields.stack;
+		const name = typeof fields.name === 'string' ? fields.name : 'Error';
+		const message = typeof fields.message === 'string' ? fields.message : util.inspect(thrown, { colors: false });
+		return `${name}: ${message}`;
+	}
+	return String(thrown);
+}

--- a/packages/xxscreeps/cli/socket.ts
+++ b/packages/xxscreeps/cli/socket.ts
@@ -1,0 +1,301 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const maxBufferSize = 1 << 20;
+
+export interface LauncherRpcRequest {
+	readonly expression: string;
+}
+
+export interface LauncherRpcResponse {
+	readonly ok: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly output: string;
+}
+
+export function socketPathFor(configUrl: URL): string {
+	if (process.platform === 'win32') {
+		return `\\\\.\\pipe\\xxscreeps-${crypto.createHash('md5').update(configUrl.href).digest('hex').slice(0, 8)}`;
+	}
+	return fileURLToPath(new URL('screeps/cli.sock', configUrl));
+}
+
+export async function probeSocketPath(socketPath: string): Promise<'available' | 'in-use'> {
+	if (process.platform === 'win32') return 'available';
+	const decided = Promise.withResolvers<'available' | 'in-use'>();
+	const probe = net.connect({ path: socketPath }, () => {
+		probe.destroy();
+		decided.resolve('in-use');
+	});
+	probe.on('error', (err: NodeJS.ErrnoException) => {
+		if (err.code === 'ENOENT') {
+			decided.resolve('available');
+		} else if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
+			try {
+				fs.unlinkSync(socketPath);
+			} catch (unlinkErr) {
+				decided.reject(unlinkErr instanceof Error ? unlinkErr : new Error(String(unlinkErr)));
+				return;
+			}
+			decided.resolve('available');
+		} else {
+			decided.reject(err);
+		}
+	});
+	return decided.promise;
+}
+
+type RequestHandler = (request: LauncherRpcRequest) => Promise<LauncherRpcResponse>;
+
+function findNewline(chunks: readonly Buffer[]): { chunkIndex: number; offset: number } | undefined {
+	for (let index = 0; index < chunks.length; index++) {
+		const offset = chunks[index]!.indexOf(0x0a);
+		if (offset !== -1) return { chunkIndex: index, offset };
+	}
+	return undefined;
+}
+
+function takeLine(chunks: Buffer[], chunkIndex: number, offset: number): string {
+	const prefix = chunks.slice(0, chunkIndex);
+	prefix.push(chunks[chunkIndex]!.subarray(0, offset));
+	return Buffer.concat(prefix).toString('utf8');
+}
+
+export async function listenLauncherRpc(
+	socketPath: string,
+	setupConnection: () => (request: LauncherRpcRequest) => Promise<LauncherRpcResponse>,
+): Promise<{ close: () => Promise<void> }> {
+	if (process.platform !== 'win32') {
+		// Birth the parent dir at 0o700 to avoid a window where it's reachable to other UIDs.
+		await fs.promises.mkdir(path.dirname(socketPath), { mode: 0o700, recursive: true });
+	}
+	const connections = new Set<net.Socket>();
+	const pending = new Set<Promise<void>>();
+	let dataEpoch = 0;
+	const server = net.createServer(socket => {
+		connections.add(socket);
+		const handle = setupConnection();
+		const chunks: Buffer[] = [];
+		let bufferLength = 0;
+		let aborted = false as boolean;
+		// Per-connection serialization: each line chains onto the previous so `var x` resolves before `x + 1`.
+		let chain: Promise<void> = Promise.resolve();
+		socket.on('error', () => socket.destroy());
+		socket.on('close', () => connections.delete(socket));
+		socket.on('data', chunk => {
+			if (aborted) return;
+			dataEpoch++;
+			bufferLength += chunk.length;
+			if (bufferLength > maxBufferSize) {
+				aborted = true;
+				writeResponse(socket, { ok: false, stdout: '', stderr: '', output: 'Launcher RPC request exceeded maximum size' });
+				socket.end();
+				return;
+			}
+			chunks.push(chunk);
+			// A data event may carry multiple newline-delimited requests; drain them all.
+			while (true) {
+				const found = findNewline(chunks);
+				if (found === undefined) return;
+				let consumed = 0;
+				for (let index = 0; index < found.chunkIndex; index++) consumed += chunks[index]!.length;
+				consumed += found.offset + 1;
+				const line = takeLine(chunks, found.chunkIndex, found.offset);
+				chunks.splice(0, found.chunkIndex);
+				const remainder = chunks[0]!.subarray(found.offset + 1);
+				if (remainder.length > 0) {
+					chunks[0] = remainder;
+				} else {
+					chunks.shift();
+				}
+				bufferLength -= consumed;
+				// Catch is intentional: a dispatch crash on a REPL transport shouldn't poison the
+				// per-connection chain and silently drop every later request from this session.
+				const next = chain.then(() => dispatch(line, socket, handle)).catch((err: unknown) => {
+					const detail = err instanceof Error ? err.stack ?? err.message : String(err);
+					process.stderr.write(`xxscreeps launcher RPC: dispatch crashed: ${detail}\n`);
+					writeResponse(socket, { ok: false, stdout: '', stderr: '', output: 'RPC dispatch crashed' });
+				});
+				chain = next;
+				pending.add(next);
+				void next.finally(() => pending.delete(next));
+			}
+		});
+	});
+	const listening = Promise.withResolvers<undefined>();
+	const onError = (err: Error) => listening.reject(err);
+	const onListening = () => listening.resolve(undefined);
+	server.once('error', onError);
+	server.once('listening', onListening);
+	server.listen(socketPath);
+	try {
+		await listening.promise;
+	} finally {
+		server.off('error', onError);
+		server.off('listening', onListening);
+	}
+	if (process.platform !== 'win32') {
+		// Tighten after bind; `net.listen` has no atomic mode option. Parent dir 0o700 is the real gate.
+		fs.chmodSync(socketPath, 0o600);
+	}
+	return {
+		close: async () => {
+			const serverClosed = new Promise<void>(resolve => { server.close(() => resolve()); });
+			// Drain until both `pending` is empty AND no new 'data' events arrived during the
+			// drain — the yield gives any in-flight events a chance to fire before we exit the loop.
+			let prevEpoch: number;
+			do {
+				prevEpoch = dataEpoch;
+				if (pending.size > 0) {
+					await Promise.allSettled([ ...pending ]);
+				}
+				await new Promise<void>(resolve => { setImmediate(resolve); });
+			} while (pending.size > 0 || dataEpoch !== prevEpoch);
+			for (const connection of connections) connection.destroy();
+			await serverClosed;
+		},
+	};
+}
+
+async function dispatch(line: string, socket: net.Socket, handle: RequestHandler) {
+	let request: LauncherRpcRequest;
+	try {
+		request = parseRequest(line);
+	} catch (err) {
+		// Protocol-level failure: bytes after this can't be trusted to align, so end the connection.
+		const message = err instanceof Error ? err.message : String(err);
+		writeResponse(socket, { ok: false, stdout: '', stderr: '', output: message });
+		socket.end();
+		return;
+	}
+	writeResponse(socket, await handle(request));
+}
+
+function writeResponse(socket: net.Socket, response: LauncherRpcResponse): void {
+	if (!socket.writable) return;
+	socket.write(`${JSON.stringify(response)}\n`);
+}
+
+function parseRequest(line: string): LauncherRpcRequest {
+	const parsed = JSON.parse(line) as unknown;
+	if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error('Invalid CLI request: expected object');
+	}
+	const { expression } = parsed as { expression?: unknown };
+	if (typeof expression !== 'string') {
+		throw new Error('Invalid CLI request: expression must be a string');
+	}
+	return { expression };
+}
+
+function parseResponse(line: string): LauncherRpcResponse {
+	const parsed = JSON.parse(line) as unknown;
+	if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error('Invalid CLI response: expected object');
+	}
+	const { ok, stdout, stderr, output } = parsed as Partial<LauncherRpcResponse>;
+	if (typeof ok !== 'boolean' || typeof stdout !== 'string' ||
+		typeof stderr !== 'string' || typeof output !== 'string') {
+		throw new Error('Invalid CLI response: malformed field');
+	}
+	return { ok, stdout, stderr, output };
+}
+
+export interface LauncherRpcClient {
+	readonly send: (request: LauncherRpcRequest) => Promise<LauncherRpcResponse>;
+	readonly close: () => Promise<void>;
+	readonly closed: Promise<undefined>;
+	readonly [Symbol.asyncDispose]: () => Promise<void>;
+}
+
+export function connectLauncherRpc(socketPath: string): Promise<LauncherRpcClient> {
+	const ready = Promise.withResolvers<LauncherRpcClient>();
+	const closedPromise = Promise.withResolvers<undefined>();
+	const socket = net.connect({ path: socketPath });
+	const chunks: Buffer[] = [];
+	let bufferLength = 0;
+	let state: 'connecting' | 'open' | 'closed' = 'connecting';
+	interface Pending {
+		resolve: (response: LauncherRpcResponse) => void;
+		reject: (err: Error) => void;
+	}
+	const queue: Pending[] = [];
+	const failQueue = (err: Error) => {
+		while (queue.length > 0) queue.shift()!.reject(err);
+	};
+	const close = (): Promise<void> => {
+		if (state === 'closed') return Promise.resolve();
+		const done = Promise.withResolvers<undefined>();
+		socket.once('close', () => done.resolve(undefined));
+		socket.end();
+		return done.promise;
+	};
+	const client: LauncherRpcClient = {
+		send(request) {
+			if (state === 'closed') return Promise.reject(new Error('Launcher RPC connection is closed'));
+			const pending = Promise.withResolvers<LauncherRpcResponse>();
+			queue.push({ resolve: pending.resolve, reject: pending.reject });
+			socket.write(`${JSON.stringify(request)}\n`);
+			return pending.promise;
+		},
+		close,
+		closed: closedPromise.promise,
+		[Symbol.asyncDispose]: close,
+	};
+	socket.on('connect', () => {
+		state = 'open';
+		ready.resolve(client);
+	});
+	socket.on('error', err => {
+		if (state === 'connecting') {
+			ready.reject(err);
+			return;
+		}
+		failQueue(err instanceof Error ? err : new Error(String(err)));
+		socket.destroy();
+	});
+	socket.on('close', () => {
+		state = 'closed';
+		failQueue(new Error('Launcher RPC socket closed without response'));
+		closedPromise.resolve(undefined);
+	});
+	socket.on('data', chunk => {
+		bufferLength += chunk.length;
+		if (bufferLength > maxBufferSize) {
+			socket.destroy(new Error('Launcher RPC response exceeded maximum size'));
+			return;
+		}
+		chunks.push(chunk);
+		while (true) {
+			const found = findNewline(chunks);
+			if (found === undefined) return;
+			let consumed = 0;
+			for (let index = 0; index < found.chunkIndex; index++) consumed += chunks[index]!.length;
+			consumed += found.offset + 1;
+			const line = takeLine(chunks, found.chunkIndex, found.offset);
+			chunks.splice(0, found.chunkIndex);
+			const remainder = chunks[0]!.subarray(found.offset + 1);
+			if (remainder.length > 0) {
+				chunks[0] = remainder;
+			} else {
+				chunks.shift();
+			}
+			bufferLength -= consumed;
+			const pending = queue.shift();
+			if (pending === undefined) {
+				socket.destroy(new Error('Launcher RPC sent response without matching request'));
+				return;
+			}
+			try {
+				pending.resolve(parseResponse(line));
+			} catch (err) {
+				pending.reject(err instanceof Error ? err : new Error(String(err)));
+			}
+		}
+	});
+	return ready.promise;
+}

--- a/packages/xxscreeps/cli/test.ts
+++ b/packages/xxscreeps/cli/test.ts
@@ -6,7 +6,7 @@ import * as fsp from 'node:fs/promises';
 import net from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import * as util from 'node:util';
 import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { assert, describe, test } from 'xxscreeps/test/index.js';
@@ -58,9 +58,15 @@ interface SpawnResult {
 	stderr: string;
 }
 
-function spawnXxscreeps(args: readonly string[], stdin?: string) {
+// Neutralize `FORCE_COLOR` so the child's `util.inspect` / `console.log` don't ANSI-wrap output
+// the assertions match on; dev terminals frequently inherit a non-zero value.
+const childEnv: NodeJS.ProcessEnv = { ...process.env, FORCE_COLOR: '0' };
+
+function spawnXxscreeps(args: readonly string[], stdin?: string, options: { cwd?: string } = {}) {
 	return new Promise<SpawnResult>((resolve, reject) => {
 		const child = spawn(process.execPath, [ xxscreepsBin, ...args ], {
+			cwd: options.cwd,
+			env: childEnv,
 			stdio: [ 'pipe', 'pipe', 'pipe' ],
 		});
 		const stdoutChunks: Buffer[] = [];
@@ -74,6 +80,67 @@ function spawnXxscreeps(args: readonly string[], stdin?: string) {
 			stdout: Buffer.concat(stdoutChunks).toString('utf8'),
 		}));
 		child.stdin.end(stdin ?? '');
+	});
+}
+
+// Per-line stdin so each turn's response renders before the next line lands; `stdin.end(text)`
+// would deliver atomically and race the REPL. The per-line gate waits for any new output (the
+// previous turn's response or banner) plus a short settling window, with a hard timeout.
+function spawnXxscreepsInteractive(
+	args: readonly string[],
+	lines: readonly string[],
+	{ cwd, settleMs = 25, perLineTimeoutMs = 5000 }:
+		{ cwd?: string; settleMs?: number; perLineTimeoutMs?: number } = {},
+) {
+	return new Promise<SpawnResult>((resolve, reject) => {
+		const child = spawn(process.execPath, [ xxscreepsBin, ...args ], {
+			cwd,
+			env: childEnv,
+			stdio: [ 'pipe', 'pipe', 'pipe' ],
+		});
+		const stdoutChunks: Buffer[] = [];
+		const stderrChunks: Buffer[] = [];
+		let outputBytes = 0;
+		child.stdout.on('data', (chunk: Buffer) => {
+			stdoutChunks.push(chunk);
+			outputBytes += chunk.length;
+		});
+		child.stderr.on('data', (chunk: Buffer) => {
+			stderrChunks.push(chunk);
+			outputBytes += chunk.length;
+		});
+		child.on('error', reject);
+		child.on('exit', code => resolve({
+			exitCode: code ?? 1,
+			stderr: Buffer.concat(stderrChunks).toString('utf8'),
+			stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+		}));
+		const waitForOutput = (before: number) => new Promise<void>(resolveWait => {
+			let settleTimer: NodeJS.Timeout | undefined;
+			const cleanup = () => {
+				child.stdout.off('data', onData);
+				child.stderr.off('data', onData);
+				clearTimeout(hardTimer);
+				if (settleTimer) clearTimeout(settleTimer);
+			};
+			const onData = () => {
+				if (outputBytes <= before) return;
+				if (settleTimer) clearTimeout(settleTimer);
+				settleTimer = setTimeout(() => { cleanup(); resolveWait(); }, settleMs);
+			};
+			const hardTimer = setTimeout(() => { cleanup(); resolveWait(); }, perLineTimeoutMs);
+			child.stdout.on('data', onData);
+			child.stderr.on('data', onData);
+			onData();
+		});
+		void (async () => {
+			for (const line of lines) {
+				const before = outputBytes;
+				child.stdin.write(`${line}\n`);
+				await waitForOutput(before);
+			}
+			child.stdin.end();
+		})();
 	});
 }
 
@@ -112,6 +179,49 @@ async function startLauncherRpcHarness(): Promise<LauncherRpcHarness> {
 async function oneShot(socketPath: string, request: LauncherRpcRequest): Promise<LauncherRpcResponse> {
 	await using client = await connectLauncherRpc(socketPath);
 	return await client.send(request);
+}
+
+interface CliHarness extends LauncherRpcHarness {
+	// Spawned CLI's `socketPathFor(cwd/.screepsrc.yaml)` must match the launcher RPC's path.
+	cwd: string;
+}
+
+async function startCliHarness(): Promise<CliHarness> {
+	// `realpathSync` to canonicalize macOS `/var` → `/private/var` so the child finds the socket.
+	// `.screepsrc.yaml` is left empty so the child inherits the parent's mod list — otherwise its
+	// import of `xxscreeps/config/mods/index.js` would rewrite the shared `mods.static/` bundle.
+	const raw = await fsp.mkdtemp(path.join(os.tmpdir(), 'xxsk-'));
+	const cwd = fs.realpathSync(raw);
+	await fsp.writeFile(path.join(cwd, '.screepsrc.yaml'), '{}\n');
+	const configUrl = new URL('.screepsrc.yaml', `${pathToFileURL(cwd).href}/`);
+	const socketPath = fileURLToPath(new URL('screeps/cli.sock', configUrl));
+	const testShard = await instantiateTestShard();
+	const stop = await startLauncherRpcServer(testShard.db, testShard.shard, { socketPath });
+	let stopped = false as boolean;
+	return {
+		cwd,
+		db: testShard.db,
+		shard: testShard.shard,
+		socketPath,
+		[Symbol.asyncDispose]: async () => {
+			if (stopped) return;
+			stopped = true;
+			await stop();
+			testShard[Symbol.dispose]();
+			fs.rmSync(cwd, { force: true, recursive: true });
+		},
+	};
+}
+
+async function withTempCwd<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+	const raw = await fsp.mkdtemp(path.join(os.tmpdir(), 'xxsh-'));
+	const cwd = fs.realpathSync(raw);
+	await fsp.writeFile(path.join(cwd, '.screepsrc.yaml'), '{}\n');
+	try {
+		return await fn(cwd);
+	} finally {
+		fs.rmSync(cwd, { force: true, recursive: true });
+	}
 }
 
 describe('cli', () => {
@@ -184,7 +294,7 @@ describe('cli', () => {
 	});
 
 	test('repl: meta-commands work in a real session', async () => {
-		const result = await spawnXxscreeps([ 'cli' ], '.exit\n');
+		const result = await withTempCwd(async cwd => spawnXxscreeps([ 'cli' ], '.exit\n', { cwd }));
 		assert.strictEqual(result.exitCode, 0);
 	});
 
@@ -235,13 +345,13 @@ describe('cli', () => {
 
 	test('eval: --file reads source from the filesystem', async () => {
 		const file = fileURLToPath(new URL('../../cli/test-data/eval-source.js', import.meta.url));
-		const result = await spawnXxscreeps([ 'eval', '--file', file ]);
+		const result = await withTempCwd(async cwd => spawnXxscreeps([ 'eval', '--file', file ], undefined, { cwd }));
 		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 		assert.match(result.stdout, /from-file/);
 	});
 
 	test('eval: --stdin reads source from stdin', async () => {
-		const result = await spawnXxscreeps([ 'eval', '--stdin' ], '2 + 3');
+		const result = await withTempCwd(async cwd => spawnXxscreeps([ 'eval', '--stdin' ], '2 + 3', { cwd }));
 		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 		assert.match(result.stdout, /^5\n$/);
 	});
@@ -648,5 +758,95 @@ describe('launcher RPC', () => {
 		});
 		assert.strictEqual(response.ok, true, `output: ${response.output}`);
 		assert.strictEqual(response.output, `'${process.platform}'`);
+	});
+});
+
+describe('cli live', () => {
+	test('detects the launcher RPC and evaluates over it', async () => {
+		await using harness = await startCliHarness();
+		const result = await spawnXxscreeps([ 'cli' ], '1 + 1\n', { cwd: harness.cwd });
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}\nstdout: ${result.stdout}`);
+		assert.match(result.stderr, /connected to launcher RPC/);
+		assert.match(result.stdout, /\b2\b/);
+	});
+
+	test('drains in-flight RPC responses before EOF tears down the socket', async () => {
+		// `node:repl` fires 'exit' on stdin EOF before queued eval callbacks fire; atomic stdin.end
+		// races line 2's response against socket teardown, so without cli.ts's drain `42` is lost.
+		await using harness = await startCliHarness();
+		const result = await spawnXxscreeps(
+			[ 'cli' ], 'var x = 41\nx + 1\n', { cwd: harness.cwd });
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+		assert.match(result.stdout, /\b42\b/);
+	});
+
+	test('streams console.log to stdout and the result follows', async () => {
+		await using harness = await startCliHarness();
+		const result = await spawnXxscreeps(
+			[ 'cli' ], 'console.log("hi"); 42\n', { cwd: harness.cwd });
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+		assert.match(result.stdout, /hi/);
+		assert.match(result.stdout, /\b42\b/);
+	});
+
+	test('thrown error prints to stderr without ending the session', async () => {
+		await using harness = await startCliHarness();
+		const result = await spawnXxscreepsInteractive(
+			[ 'cli' ], [ 'throw new Error("zap")', '1 + 1' ], { cwd: harness.cwd });
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+		assert.match(result.stderr, /zap/);
+		assert.match(result.stdout, /\b2\b/);
+	});
+
+	test('multi-line input recovers until the block closes', async () => {
+		await using harness = await startCliHarness();
+		const result = await spawnXxscreeps(
+			[ 'cli' ], 'if (true) {\n  1 + 2\n}\n', { cwd: harness.cwd });
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+		assert.match(result.stdout, /\b3\b/);
+	});
+
+	test('falls back to host-realm REPL when no launcher RPC is present', async () => {
+		const result = await withTempCwd(async cwd => spawnXxscreepsInteractive(
+			[ 'cli' ], [ '1 + 1' ], { cwd }));
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}\nstdout: ${result.stdout}`);
+		assert.match(result.stderr, /launcher RPC unavailable/);
+		assert.match(result.stderr, /running direct REPL/);
+		assert.match(result.stdout, /\b2\b/);
+	});
+
+	test('skips the RPC probe entirely on networked providers', async () => {
+		const raw = await fsp.mkdtemp(path.join(os.tmpdir(), 'xxsn-'));
+		const cwd = fs.realpathSync(raw);
+		try {
+			// Only `data` matters here; the rest are dummies for the merged-schema required block.
+			await fsp.writeFile(path.join(cwd, '.screepsrc.yaml'), [
+				'database:',
+				'  data: redis://localhost/0',
+				'  pubsub: redis://localhost/0',
+				'  lock: ./screeps/.lock',
+				'  saveInterval: 2',
+				'',
+			].join('\n'));
+			const result = await spawnXxscreepsInteractive([ 'cli' ], [ '1 + 1' ], { cwd });
+			assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}\nstdout: ${result.stdout}`);
+			assert.match(result.stderr, /database provider 'redis' is not local/);
+			assert.match(result.stderr, /running direct REPL/);
+			assert.match(result.stdout, /\b2\b/);
+		} finally {
+			fs.rmSync(cwd, { force: true, recursive: true });
+		}
+	});
+
+	test('two parallel REPLs against the same launcher have isolated globals', async () => {
+		await using harness = await startCliHarness();
+		const [ first, second ] = await Promise.all([
+			spawnXxscreeps([ 'cli' ], 'var iso = "first"; iso\n', { cwd: harness.cwd }),
+			spawnXxscreeps([ 'cli' ], 'typeof iso\n', { cwd: harness.cwd }),
+		]);
+		assert.strictEqual(first.exitCode, 0, `stderr: ${first.stderr}`);
+		assert.strictEqual(second.exitCode, 0, `stderr: ${second.stderr}`);
+		assert.match(first.stdout, /'first'/);
+		assert.match(second.stdout, /'undefined'/);
 	});
 });

--- a/packages/xxscreeps/cli/test.ts
+++ b/packages/xxscreeps/cli/test.ts
@@ -85,20 +85,30 @@ describe('cli', () => {
 	});
 
 	test('repl: statement with top-level await falls through to async-block', async () => {
-		// Indirect eval rejects await; expression wrap rejects let-statement;
-		// only the async-block wrap parses and runs.
+		// Only the async-block wrap parses this; block form has no completion value, so the IIFE returns undefined.
 		using console = new TestConsole();
-		const result = await evaluateUnsafeGlobal('let y = await Promise.resolve(99); console.log(y)');
-		assert.strictEqual(result, undefined);
-		assert.deepStrictEqual(console.logs, '99');
+		try {
+			const result = await evaluateUnsafeGlobal('let __cliReplY = await Promise.resolve(99); console.log(__cliReplY)');
+			assert.strictEqual(result, undefined);
+			assert.deepStrictEqual(console.logs, '99');
+		} finally {
+			delete (globalThis as Record<string, unknown>).__cliReplY;
+		}
+	});
+
+	test('repl: let + await declarations persist across turns', async () => {
+		try {
+			const first = await evaluateUnsafeGlobal('let __cliReplAsync = await Promise.resolve(41); __cliReplAsync');
+			assert.strictEqual(first, undefined);
+			const second = await evaluateUnsafeGlobal('__cliReplAsync + 1');
+			assert.strictEqual(second, 42);
+		} finally {
+			delete (globalThis as Record<string, unknown>).__cliReplAsync;
+		}
 	});
 
 	test('repl: top-level await whose awaited callback throws SyntaxError runs source once', async () => {
-		// Regression for the wrap-retry double-execution shape: indirect eval rejects
-		// for top-level await, so `evaluateOffline` falls through to the AsyncFunction
-		// wrap. If that wrap parses but the awaited callback throws a SyntaxError at
-		// runtime, the error must propagate — not trigger a wrapBlock retry that
-		// re-runs the side effect.
+		// A runtime SyntaxError from inside the wrap must propagate, not retrigger a wrap retry.
 		using console = new TestConsole();
 		await assert.rejects(
 			() => evaluateUnsafeGlobal(
@@ -108,16 +118,12 @@ describe('cli', () => {
 	});
 
 	test('repl: parenthesised top-level await falls through to async wrap', async () => {
-		// In script mode `await` lexes as an identifier, so `(await Promise...)` errors
-		// on the next token ("Unexpected identifier 'Promise'") instead of "await is only
-		// valid". The cascade must still retry through the async wrap.
+		// In script mode `await` lexes as an identifier; the cascade must still retry through the async wrap.
 		const value = await evaluateUnsafeGlobal('(await Promise.resolve(99)).valueOf()');
 		assert.strictEqual(value, 99);
 	});
 
 	test('repl: SyntaxError unrelated to top-level await still rejects', async () => {
-		// Guard that the cascade doesn't swallow real syntax errors: both async wraps
-		// will fail to parse this too, and the final error must propagate.
 		await assert.rejects(
 			() => evaluateUnsafeGlobal('1 + )'),
 			(err: unknown) => err instanceof SyntaxError);
@@ -136,11 +142,7 @@ describe('cli', () => {
 	});
 
 	test('eval: runtime SyntaxError does not retrigger console.log', async () => {
-		// Regression for the candidate-retry double-execution shape laverdet flagged
-		// on an earlier revision: when the source parses cleanly but throws a runtime
-		// SyntaxError (here `JSON.parse("}")`), the eval primitive must not mistake
-		// the runtime throw for a parse failure and re-execute the source. `1` must
-		// log exactly once, not 3-4 times.
+		// A runtime SyntaxError must not be mistaken for a parse failure and re-execute the source.
 		using console = new TestConsole();
 		const exitCode = await runEval({
 			argv: [],

--- a/packages/xxscreeps/cli/test.ts
+++ b/packages/xxscreeps/cli/test.ts
@@ -298,6 +298,18 @@ describe('cli', () => {
 		assert.strictEqual(result.exitCode, 0);
 	});
 
+	test('repl: direct-mode async eval result survives piped-stdin EOF', async () => {
+		// Piped stdin closes immediately, so node:repl fires 'exit' before the awaited callback
+		// fires. The host-realm REPL must drain in-flight evals before `process.exit(0)`.
+		const result = await withTempCwd(async cwd => spawnXxscreeps(
+			[ 'cli' ],
+			'await new Promise(r => setTimeout(() => r("delayed-result"), 50))\n',
+			{ cwd }));
+		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
+		assert.match(result.stderr, /running direct REPL/);
+		assert.match(result.stdout, /delayed-result/);
+	});
+
 	test('eval: runtime SyntaxError does not retrigger console.log', async () => {
 		// A runtime SyntaxError must not be mistaken for a parse failure and re-execute the source.
 		using console = new TestConsole();

--- a/packages/xxscreeps/cli/test.ts
+++ b/packages/xxscreeps/cli/test.ts
@@ -1,8 +1,18 @@
+import type { LauncherRpcRequest, LauncherRpcResponse } from './socket.js';
+import type { Database, Shard } from 'xxscreeps/engine/db/index.js';
 import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as util from 'node:util';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { assert, describe, test } from 'xxscreeps/test/index.js';
 import { runEval } from './eval-offline.js';
+import { startLauncherRpcServer } from './launcher-rpc.js';
+import { connectLauncherRpc, listenLauncherRpc, probeSocketPath } from './socket.js';
 import { evaluateUnsafeGlobal, makeUnsafeGlobalEvaluator } from './unsafe.js';
 
 const xxscreepsBin = fileURLToPath(new URL('../../bin/xxscreeps.js', import.meta.url));
@@ -65,6 +75,43 @@ function spawnXxscreeps(args: readonly string[], stdin?: string) {
 		}));
 		child.stdin.end(stdin ?? '');
 	});
+}
+
+let rpcCounter = 0;
+
+function makeTempSocketPath(): string {
+	return path.join(os.tmpdir(), `xxscreeps-cli-test-${process.pid}-${rpcCounter++}`, 'cli.sock');
+}
+
+interface LauncherRpcHarness {
+	db: Database;
+	shard: Shard;
+	socketPath: string;
+	[Symbol.asyncDispose]: () => Promise<void>;
+}
+
+async function startLauncherRpcHarness(): Promise<LauncherRpcHarness> {
+	const testShard = await instantiateTestShard();
+	const socketPath = makeTempSocketPath();
+	const stop = await startLauncherRpcServer(testShard.db, testShard.shard, { socketPath });
+	let stopped = false as boolean;
+	return {
+		db: testShard.db,
+		shard: testShard.shard,
+		socketPath,
+		[Symbol.asyncDispose]: async () => {
+			if (stopped) return;
+			stopped = true;
+			await stop();
+			testShard[Symbol.dispose]();
+			fs.rmSync(path.dirname(socketPath), { force: true, recursive: true });
+		},
+	};
+}
+
+async function oneShot(socketPath: string, request: LauncherRpcRequest): Promise<LauncherRpcResponse> {
+	await using client = await connectLauncherRpc(socketPath);
+	return await client.send(request);
 }
 
 describe('cli', () => {
@@ -197,5 +244,409 @@ describe('cli', () => {
 		const result = await spawnXxscreeps([ 'eval', '--stdin' ], '2 + 3');
 		assert.strictEqual(result.exitCode, 0, `stderr: ${result.stderr}`);
 		assert.match(result.stdout, /^5\n$/);
+	});
+});
+
+describe('launcher RPC', () => {
+	test('1+1 round-trips through the socket', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: '1+1' });
+		assert.deepStrictEqual(response, { ok: true, stdout: '', stderr: '', output: '2' });
+	});
+
+	test('cleanup unlinks the socket file', async () => {
+		const harness = await startLauncherRpcHarness();
+		const { socketPath } = harness;
+		assert.strictEqual((await fsp.stat(socketPath)).isSocket(), true);
+		await harness[Symbol.asyncDispose]();
+		await assert.rejects(() => fsp.stat(socketPath));
+	});
+
+	test('probeSocketPath reports a missing path as available', async () => {
+		if (process.platform === 'win32') return;
+		const socketPath = makeTempSocketPath();
+		assert.strictEqual(await probeSocketPath(socketPath), 'available');
+	});
+
+	test('probeSocketPath unlinks a zero-byte leftover and reports available', async () => {
+		if (process.platform === 'win32') return;
+		const socketPath = makeTempSocketPath();
+		await fsp.mkdir(path.dirname(socketPath), { recursive: true });
+		await fsp.writeFile(socketPath, '');
+		try {
+			assert.strictEqual(await probeSocketPath(socketPath), 'available');
+			await assert.rejects(() => fsp.stat(socketPath));
+		} finally {
+			await fsp.rm(path.dirname(socketPath), { force: true, recursive: true });
+		}
+	});
+
+	test('probeSocketPath reports a live listener as in-use', async () => {
+		if (process.platform === 'win32') return;
+		await using harness = await startLauncherRpcHarness();
+		assert.strictEqual(await probeSocketPath(harness.socketPath), 'in-use');
+	});
+
+	test('starting a second launcher RPC on a live socket rejects with the path', async () => {
+		if (process.platform === 'win32') return;
+		await using harness = await startLauncherRpcHarness();
+		await assert.rejects(
+			() => startLauncherRpcServer(harness.db, harness.shard, { socketPath: harness.socketPath }),
+			(err: Error) => err.message.includes(harness.socketPath));
+	});
+
+	test('unix permissions: socket 0o600, parent dir 0o700', async () => {
+		if (process.platform === 'win32') return;
+		await using harness = await startLauncherRpcHarness();
+		const socketStat = await fsp.stat(harness.socketPath);
+		const dirStat = await fsp.stat(path.dirname(harness.socketPath));
+		assert.strictEqual(socketStat.mode & 0o777, 0o600);
+		assert.strictEqual(dirStat.mode & 0o777, 0o700);
+	});
+
+	test('cleanup waits for an in-flight dispatch before resolving', async () => {
+		// Cleanup must drain pending dispatches so an eval can't mutate state after the launcher's save defer.
+		const harness = await startLauncherRpcHarness();
+		const { socketPath } = harness;
+		const response = oneShot(socketPath, {
+			expression: 'await new Promise(r => setTimeout(() => r(99), 100))',
+		});
+		await new Promise<void>(resolve => { setTimeout(resolve, 25); });
+		await harness[Symbol.asyncDispose]();
+		assert.deepStrictEqual(await response, { ok: true, stdout: '', stderr: '', output: '99' });
+		if (process.platform !== 'win32') {
+			await assert.rejects(() => fsp.stat(socketPath));
+		}
+	});
+
+	test('cleanup destroys connections that never sent a request', async () => {
+		if (process.platform === 'win32') return;
+		const harness = await startLauncherRpcHarness();
+		const socket = net.connect({ path: harness.socketPath });
+		socket.on('error', () => {});
+		const closed = new Promise<void>(resolve => { socket.on('close', () => resolve()); });
+		await new Promise<void>(resolve => { socket.once('connect', () => resolve()); });
+		await harness[Symbol.asyncDispose]();
+		await closed;
+	});
+
+	test('cleanup drains requests that land after pending is snapshotted', async () => {
+		// A follow-up request can chain onto the same connection mid-drain; cleanup must re-snapshot until empty.
+		const harness = await startLauncherRpcHarness();
+		try {
+			const client = await connectLauncherRpc(harness.socketPath);
+			const slow = client.send({
+				expression: 'await new Promise(r => setTimeout(() => r(99), 100))',
+			});
+			await new Promise<void>(resolve => { setTimeout(resolve, 25); });
+			const cleanupP = harness[Symbol.asyncDispose]();
+			const fast = client.send({ expression: '1 + 1' });
+			assert.deepStrictEqual(await slow, { ok: true, stdout: '', stderr: '', output: '99' });
+			assert.deepStrictEqual(await fast, { ok: true, stdout: '', stderr: '', output: '2' });
+			await cleanupP;
+		} finally {
+			await harness[Symbol.asyncDispose]();
+		}
+	});
+
+	test('malformed JSON returns an error response and does not crash', async () => {
+		// Parse failures must surface as an error envelope, not an unhandled rejection.
+		await using harness = await startLauncherRpcHarness();
+		const decided = Promise.withResolvers<string>();
+		const socket = net.connect({ path: harness.socketPath });
+		const chunks: Buffer[] = [];
+		socket.on('data', chunk => chunks.push(chunk));
+		socket.on('end', () => decided.resolve(Buffer.concat(chunks).toString('utf8')));
+		socket.on('error', err => decided.reject(err));
+		socket.on('connect', () => { socket.write('not-json\n'); });
+		const raw = await decided.promise;
+		const response = JSON.parse(raw.trim()) as LauncherRpcResponse;
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /JSON|Unexpected|Invalid/);
+	});
+
+	test('malformed request shape returns an error response', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const decided = Promise.withResolvers<string>();
+		const socket = net.connect({ path: harness.socketPath });
+		const chunks: Buffer[] = [];
+		socket.on('data', chunk => chunks.push(chunk));
+		socket.on('end', () => decided.resolve(Buffer.concat(chunks).toString('utf8')));
+		socket.on('error', err => decided.reject(err));
+		socket.on('connect', () => { socket.write(`${JSON.stringify({ expression: 42 })}\n`); });
+		const raw = await decided.promise;
+		const response = JSON.parse(raw.trim()) as LauncherRpcResponse;
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /expression must be a string/);
+	});
+
+	test('request exceeding the buffer cap returns an error response', async () => {
+		if (process.platform === 'win32') return;
+		await using harness = await startLauncherRpcHarness();
+		const decided = Promise.withResolvers<string>();
+		const socket = net.connect({ path: harness.socketPath });
+		const chunks: Buffer[] = [];
+		socket.on('data', chunk => chunks.push(chunk));
+		socket.on('end', () => decided.resolve(Buffer.concat(chunks).toString('utf8')));
+		socket.on('error', () => {});
+		socket.on('connect', () => { socket.write(Buffer.alloc(2 * 1024 * 1024)); });
+		const raw = await decided.promise;
+		const response = JSON.parse(raw.trim()) as LauncherRpcResponse;
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /exceeded maximum size/);
+	});
+
+	test('multiple newlines on the same connection dispatch in order', async () => {
+		// One data event carrying both lines must dispatch in order, with the second seeing the first's binding.
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		const first = await client.send({ expression: 'var x = 41' });
+		const second = await client.send({ expression: 'x + 1' });
+		assert.deepStrictEqual(first, { ok: true, stdout: '', stderr: '', output: 'undefined' });
+		assert.deepStrictEqual(second, { ok: true, stdout: '', stderr: '', output: '42' });
+	});
+
+	test('let / const / class declarations persist across requests like var', async () => {
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({
+			expression: 'let __replLet = 1; const __replConst = 2; class __ReplClass { ping() { return 3 } }',
+		});
+		const envelope = await client.send({
+			expression: '({ let: typeof __replLet, const: typeof __replConst, klass: new __ReplClass().ping() })',
+		});
+		assert.strictEqual(envelope.ok, true);
+		assert.match(envelope.output, /let: 'number'/);
+		assert.match(envelope.output, /const: 'number'/);
+		assert.match(envelope.output, /klass: 3/);
+	});
+
+	test('separate connections have isolated globals', async () => {
+		await using harness = await startLauncherRpcHarness();
+		await using clientA = await connectLauncherRpc(harness.socketPath);
+		await using clientB = await connectLauncherRpc(harness.socketPath);
+		await clientA.send({ expression: 'var __replIsolation = "A"' });
+		const envelope = await clientB.send({ expression: 'typeof __replIsolation' });
+		assert.deepStrictEqual(envelope, {
+			ok: true, stdout: '', stderr: '', output: "'undefined'",
+		});
+	});
+
+	test('console.log scheduled past response does not bleed into next request', async () => {
+		// The deferred log fires while request 2 is the active sink; ALS routes it to request 1's drained sink.
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({
+			expression: 'setTimeout(() => console.log("leaked"), 25); "first"',
+		});
+		const second = await client.send({
+			expression: 'await new Promise(resolve => setTimeout(() => resolve("second"), 100))',
+		});
+		assert.deepStrictEqual(second, {
+			ok: true, stdout: '', stderr: '', output: "'second'",
+		});
+	});
+
+	test('client rejects when the launcher RPC responds with a malformed envelope', async () => {
+		if (process.platform === 'win32') return;
+		const socketPath = makeTempSocketPath();
+		await fsp.mkdir(path.dirname(socketPath), { recursive: true });
+		const server = net.createServer(socket => {
+			socket.on('data', () => {
+				socket.write(`${JSON.stringify({ ok: 'yes' })}\n`);
+				socket.end();
+			});
+		});
+		await new Promise<void>(resolve => { server.listen(socketPath, () => resolve()); });
+		try {
+			await assert.rejects(
+				() => oneShot(socketPath, { expression: '1' }),
+				/malformed field/);
+		} finally {
+			await new Promise<void>(resolve => { server.close(() => resolve()); });
+			fs.rmSync(path.dirname(socketPath), { force: true, recursive: true });
+		}
+	});
+
+	test('chain survives a dispatch crash and serves the next request', async () => {
+		// A poisoned chain would silently skip every later request; the induced crash logs one line to stderr.
+		const socketPath = makeTempSocketPath();
+		let calls = 0;
+		const listener = await listenLauncherRpc(socketPath, () => _request => {
+			calls += 1;
+			if (calls === 2) return Promise.reject(new Error('induced dispatch crash'));
+			return Promise.resolve({ ok: true, stdout: '', stderr: '', output: `call-${calls}` });
+		});
+		try {
+			await using client = await connectLauncherRpc(socketPath);
+			const first = await client.send({ expression: '1' });
+			const second = await client.send({ expression: '2' });
+			const third = await client.send({ expression: '3' });
+			assert.deepStrictEqual(first, { ok: true, stdout: '', stderr: '', output: 'call-1' });
+			assert.strictEqual(second.ok, false);
+			assert.match(second.output, /RPC dispatch crashed/);
+			assert.deepStrictEqual(third, { ok: true, stdout: '', stderr: '', output: 'call-3' });
+		} finally {
+			await listener.close();
+			if (process.platform !== 'win32') {
+				try { fs.unlinkSync(socketPath); } catch {}
+				fs.rmSync(path.dirname(socketPath), { force: true, recursive: true });
+			}
+		}
+	});
+
+	test('concurrent connections do not bleed logs across contexts', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const make = (label: string) =>
+			`(async () => { console.log(${JSON.stringify(label)}); ` +
+			'await new Promise(resolve => setTimeout(resolve, 50)); ' +
+			`return ${JSON.stringify(label)}; })()`;
+		const [ first, second ] = await Promise.all([
+			oneShot(harness.socketPath, { expression: make('A') }),
+			oneShot(harness.socketPath, { expression: make('B') }),
+		]);
+		assert.deepStrictEqual(first, { ok: true, stdout: 'A\n', stderr: '', output: "'A'" });
+		assert.deepStrictEqual(second, { ok: true, stdout: 'B\n', stderr: '', output: "'B'" });
+	});
+
+	test('throw new Error round-trips with its stack', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: 'throw new Error("boom")' });
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /Error: boom/);
+	});
+
+	test('thrown non-Error objects fall back to util.inspect', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: 'throw { reason: "weird" }' });
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /reason.*weird/);
+	});
+
+	test('cross-realm Error preserves name + message through the stack', async () => {
+		// vm.Context errors fail launcher-realm `instanceof Error`; the boundary duck-types stack/name/message.
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, {
+			expression: 'throw Object.assign(new Error(\'cross\'), { name: \'CrossRealmError\' })',
+		});
+		assert.strictEqual(response.ok, false);
+		assert.match(response.output, /CrossRealmError/);
+		assert.match(response.output, /cross/);
+	});
+
+	test('top-level await composes with setTimeout', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, {
+			expression: 'await new Promise(resolve => setTimeout(() => resolve(\'done\'), 5))',
+		});
+		assert.deepStrictEqual(response, { ok: true, stdout: '', stderr: '', output: "'done'" });
+	});
+
+	test('let + await falls through to the async-block wrap (no completion value)', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, {
+			expression: 'let value = await Promise.resolve(7); console.log(value); value',
+		});
+		assert.deepStrictEqual(response, { ok: true, stdout: '7\n', stderr: '', output: 'undefined' });
+	});
+
+	test('let / const / var + await declarations all persist across requests', async () => {
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({ expression: 'let __asyncLet = await Promise.resolve(1)' });
+		await client.send({ expression: 'const __asyncConst = await Promise.resolve(2)' });
+		await client.send({ expression: 'var __asyncVar = await Promise.resolve(3)' });
+		const result = await client.send({ expression: '[__asyncLet, __asyncConst, __asyncVar]' });
+		assert.deepStrictEqual(result, { ok: true, stdout: '', stderr: '', output: '[ 1, 2, 3 ]' });
+	});
+
+	test('object destructuring + await persists each bound name', async () => {
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({
+			expression: 'let { a: __destA, b: __destB, c: __destC = 3 } = await Promise.resolve({ a: 1, b: 2 })',
+		});
+		const result = await client.send({ expression: '__destA + __destB + __destC' });
+		assert.deepStrictEqual(result, { ok: true, stdout: '', stderr: '', output: '6' });
+	});
+
+	test('array destructuring + await persists each bound name', async () => {
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({
+			expression: 'let [__arrA, ...__arrRest] = await Promise.resolve([10, 20, 30])',
+		});
+		const result = await client.send({ expression: '[__arrA, __arrRest]' });
+		assert.deepStrictEqual(result, { ok: true, stdout: '', stderr: '', output: '[ 10, [ 20, 30 ] ]' });
+	});
+
+	test('class and function declarations in async source do NOT persist', async () => {
+		// Hoist covers only `let`/`const`/`var`; for persistent class/fn use `let C = class { … }`.
+		await using harness = await startLauncherRpcHarness();
+		await using client = await connectLauncherRpc(harness.socketPath);
+		await client.send({
+			expression: 'class __AsyncClass {}\nfunction __asyncFn() {}\nawait Promise.resolve()',
+		});
+		const result = await client.send({
+			expression: '[typeof __AsyncClass, typeof __asyncFn]',
+		});
+		assert.deepStrictEqual(result, { ok: true, stdout: '', stderr: '', output: "[ 'undefined', 'undefined' ]" });
+	});
+
+	test('console.log buffers into stdout while still returning a result', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: 'console.log("x"); 42' });
+		assert.deepStrictEqual(response, { ok: true, stdout: 'x\n', stderr: '', output: '42' });
+	});
+
+	test('console.warn and console.error route into stderr', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: 'console.warn("w"); console.error("e"); 0' });
+		assert.deepStrictEqual(response, { ok: true, stdout: '', stderr: 'w\ne\n', output: '0' });
+	});
+
+	test('helpers: db, shard, print, timers are bound; engine globals are not', async () => {
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, { expression: `({
+			db: typeof db,
+			shard: shard.name,
+			print: typeof print,
+			setTimeout: typeof setTimeout,
+			setInterval: typeof setInterval,
+			clearTimeout: typeof clearTimeout,
+			clearInterval: typeof clearInterval,
+			Game: typeof Game,
+			Memory: typeof Memory,
+			rooms: typeof rooms,
+			users: typeof users,
+			system: typeof system,
+		})` });
+		assert.strictEqual(response.ok, true);
+		assert.match(response.output, /db: 'object'/);
+		assert.match(response.output, new RegExp(`shard: '${harness.shard.name}'`));
+		assert.match(response.output, /print: 'function'/);
+		assert.match(response.output, /setTimeout: 'function'/);
+		assert.match(response.output, /Game: 'undefined'/);
+		assert.match(response.output, /Memory: 'undefined'/);
+	});
+
+	test('dynamic import resolves without crashing the launcher', async () => {
+		// Without `importModuleDynamically` the sandbox import would reject as ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING.
+		await using harness = await startLauncherRpcHarness();
+		const first = await oneShot(harness.socketPath, { expression: 'import("node:fs"); 1' });
+		assert.deepStrictEqual(first, { ok: true, stdout: '', stderr: '', output: '1' });
+		await new Promise<void>(resolve => { setImmediate(resolve); });
+		const second = await oneShot(harness.socketPath, { expression: '1 + 1' });
+		assert.deepStrictEqual(second, { ok: true, stdout: '', stderr: '', output: '2' });
+	});
+
+	test('top-level-await dynamic import resolves through the host loader', async () => {
+		// Async wrap must compile via `vm.Script` with `importModuleDynamically`; `vm.runInContext` drops the option.
+		await using harness = await startLauncherRpcHarness();
+		const response = await oneShot(harness.socketPath, {
+			expression: 'await import("node:os").then(os => os.platform())',
+		});
+		assert.strictEqual(response.ok, true, `output: ${response.output}`);
+		assert.strictEqual(response.output, `'${process.platform}'`);
 	});
 });

--- a/packages/xxscreeps/cli/unsafe.ts
+++ b/packages/xxscreeps/cli/unsafe.ts
@@ -1,7 +1,7 @@
+import { createRequire } from 'node:module';
 import * as vm from 'node:vm';
 
-const AsyncFunction =
-	(async () => {}).constructor satisfies object as new (body: string) => () => Promise<unknown>;
+const Acorn = createRequire(import.meta.url)('acorn') as typeof import('acorn');
 
 const context = vm.createContext(globalThis);
 const importModuleDynamically = (specifier: string) => import(specifier);
@@ -20,7 +20,7 @@ function parseSyncSource(source: string) {
 }
 
 function parseAsyncSource(source: string) {
-	// Parse plain source with `SourceTextModule`.
+	// `SourceTextModule` is parse-only here: it validates top-level await and rejects static imports.
 	const module = function() {
 		try {
 			return new vm.SourceTextModule(source, { context, importModuleDynamically });
@@ -41,13 +41,143 @@ function parseAsyncSource(source: string) {
 	} else if (module.moduleRequests.length !== 0) {
 		throw new SyntaxError('Try dynamic `import()` instead.');
 	}
-	// `SourceTextModule` doesn't provide the "last" expression, for example `;1`, like `Script` does.
-	// So `AsyncFunction` is used instead to fake it for single statements. The disadvantage is that
-	// `;await 1` will not return the result without doing something crazy.
+	// Expression form keeps the IIFE's completion value; statements fall through to the block form.
 	try {
-		return new AsyncFunction(`"use strict"; return ${source}`);
-	} catch {
-		return new AsyncFunction(`"use strict"; ${source}`);
+		const script = new vm.Script(`(async () => (${source}\n))()`, { importModuleDynamically });
+		return async (): Promise<unknown> => script.runInContext(context) as Promise<unknown>;
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+	}
+	// Block form: hoist top-level `let`/`const`/`var` out of the arrow so bindings survive the turn.
+	const { hoisted, body } = hoistTopLevelDeclarations(source);
+	const script = new vm.Script(
+		`${hoisted}(async () => { ${body}\n })()`,
+		{ importModuleDynamically },
+	);
+	return async (): Promise<unknown> => script.runInContext(context) as Promise<unknown>;
+}
+
+// Acorn's `.d.ts` only exports the base `Node`; estree shapes redeclared for the few we read.
+interface AstNode {
+	readonly type: string;
+	readonly start: number;
+	readonly end: number;
+}
+interface AstIdentifier extends AstNode {
+	readonly type: 'Identifier';
+	readonly name: string;
+}
+interface AstObjectPattern extends AstNode {
+	readonly type: 'ObjectPattern';
+	readonly properties: readonly AstObjectPart[];
+}
+interface AstObjectProperty extends AstNode {
+	readonly type: 'Property';
+	readonly value: AstPattern;
+}
+interface AstArrayPattern extends AstNode {
+	readonly type: 'ArrayPattern';
+	readonly elements: readonly (AstPattern | null)[];
+}
+interface AstRestElement extends AstNode {
+	readonly type: 'RestElement';
+	readonly argument: AstPattern;
+}
+interface AstAssignmentPattern extends AstNode {
+	readonly type: 'AssignmentPattern';
+	readonly left: AstPattern;
+}
+type AstPattern = AstIdentifier | AstObjectPattern | AstArrayPattern | AstRestElement | AstAssignmentPattern;
+type AstObjectPart = AstObjectProperty | AstRestElement;
+interface AstVariableDeclarator extends AstNode {
+	readonly id: AstPattern;
+	readonly init: AstNode | null;
+}
+interface AstVariableDeclaration extends AstNode {
+	readonly type: 'VariableDeclaration';
+	readonly declarations: readonly AstVariableDeclarator[];
+}
+interface AstProgram extends AstNode {
+	readonly body: readonly AstNode[];
+}
+
+interface HoistedSource {
+	readonly hoisted: string;
+	readonly body: string;
+}
+
+interface SourceEdit {
+	readonly start: number;
+	readonly end: number;
+	readonly text: string;
+}
+
+function isVariableDeclaration(node: AstNode): node is AstVariableDeclaration {
+	return node.type === 'VariableDeclaration';
+}
+
+function hoistTopLevelDeclarations(source: string): HoistedSource {
+	// Syntax errors fall through unmodified; `vm.Script` will surface v8's error.
+	let root: AstProgram;
+	try {
+		root = Acorn.parse(source, {
+			ecmaVersion: 'latest',
+			sourceType: 'module',
+			allowAwaitOutsideFunction: true,
+			allowImportExportEverywhere: true,
+		}) as unknown as AstProgram;
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+		return { hoisted: '', body: source };
+	}
+	const names: string[] = [];
+	const edits: SourceEdit[] = [];
+	for (const stmt of root.body) {
+		if (!isVariableDeclaration(stmt)) continue;
+		const assigns: string[] = [];
+		for (const declarator of stmt.declarations) {
+			collectBindings(declarator.id, names);
+			if (declarator.init !== null) {
+				const lhs = source.slice(declarator.id.start, declarator.id.end);
+				const rhs = source.slice(declarator.init.start, declarator.init.end);
+				// Parens prevent an `ObjectPattern` at statement start parsing as a block.
+				assigns.push(`(${lhs} = ${rhs});`);
+			}
+		}
+		edits.push({ start: stmt.start, end: stmt.end, text: assigns.join(' ') });
+	}
+	if (names.length === 0) return { hoisted: '', body: source };
+	// Apply edits back-to-front so earlier-segment offsets stay valid.
+	const sorted = [ ...edits ].sort((left, right) => right.start - left.start);
+	let body = source;
+	for (const edit of sorted) {
+		body = body.slice(0, edit.start) + edit.text + body.slice(edit.end);
+	}
+	return { hoisted: `var ${names.join(', ')};\n`, body };
+}
+
+function collectBindings(node: AstPattern, out: string[]): void {
+	switch (node.type) {
+		case 'Identifier':
+			out.push(node.name);
+			break;
+		case 'ObjectPattern':
+			for (const prop of node.properties) {
+				if (prop.type === 'RestElement') collectBindings(prop.argument, out);
+				else collectBindings(prop.value, out);
+			}
+			break;
+		case 'ArrayPattern':
+			for (const elem of node.elements) {
+				if (elem !== null) collectBindings(elem, out);
+			}
+			break;
+		case 'RestElement':
+			collectBindings(node.argument, out);
+			break;
+		case 'AssignmentPattern':
+			collectBindings(node.left, out);
+			break;
 	}
 }
 

--- a/packages/xxscreeps/cli/unsafe.ts
+++ b/packages/xxscreeps/cli/unsafe.ts
@@ -3,27 +3,34 @@ import * as vm from 'node:vm';
 
 const Acorn = createRequire(import.meta.url)('acorn') as typeof import('acorn');
 
-const context = vm.createContext(globalThis);
 const importModuleDynamically = (specifier: string) => import(specifier);
 
 const isRecoverableSyntaxError = (error: unknown): error is SyntaxError =>
 	error instanceof SyntaxError && error.message === 'Unexpected end of input';
 
-function parseSyncSource(source: string) {
+interface UnsafeEvaluatorTarget {
+	readonly context: vm.Context;
+}
+
+const globalTarget: UnsafeEvaluatorTarget = {
+	context: vm.createContext(globalThis),
+};
+
+function parseSyncSource(source: string, target: UnsafeEvaluatorTarget) {
 	// Parse plain for clear error messages
 	// eslint-disable-next-line no-new
 	new vm.Script(source);
 	// Parse again w/ "use strict"
 	const script = new vm.Script(`"use strict"; undefined; ${source}`, { importModuleDynamically });
 	// eslint-disable-next-line @typescript-eslint/require-await
-	return async (): Promise<unknown> => script.runInContext(context);
+	return async (): Promise<unknown> => script.runInContext(target.context);
 }
 
-function parseAsyncSource(source: string) {
+function parseAsyncSource(source: string, target: UnsafeEvaluatorTarget) {
 	// `SourceTextModule` is parse-only here: it validates top-level await and rejects static imports.
 	const module = function() {
 		try {
-			return new vm.SourceTextModule(source, { context, importModuleDynamically });
+			return new vm.SourceTextModule(source, { context: target.context, importModuleDynamically });
 		} catch (error) {
 			// `SourceTextModule` throws foreign realm `SyntaxError` instances, I guess
 			// @ts-expect-error
@@ -44,7 +51,7 @@ function parseAsyncSource(source: string) {
 	// Expression form keeps the IIFE's completion value; statements fall through to the block form.
 	try {
 		const script = new vm.Script(`(async () => (${source}\n))()`, { importModuleDynamically });
-		return async (): Promise<unknown> => script.runInContext(context) as Promise<unknown>;
+		return async (): Promise<unknown> => script.runInContext(target.context) as Promise<unknown>;
 	} catch (error) {
 		if (!(error instanceof SyntaxError)) throw error;
 	}
@@ -54,7 +61,7 @@ function parseAsyncSource(source: string) {
 		`${hoisted}(async () => { ${body}\n })()`,
 		{ importModuleDynamically },
 	);
-	return async (): Promise<unknown> => script.runInContext(context) as Promise<unknown>;
+	return async (): Promise<unknown> => script.runInContext(target.context) as Promise<unknown>;
 }
 
 // Acorn's `.d.ts` only exports the base `Node`; estree shapes redeclared for the few we read.
@@ -198,13 +205,15 @@ function parseRecoverable<Fn extends () => unknown>(
 
 // Returns a `Function` (may be invoked) or `SyntaxError` (recoverable). Throws on unrecoverable
 // syntax errors.
-export function makeUnsafeGlobalEvaluator(source: string) {
+export function makeUnsafeEvaluator(source: string, target: UnsafeEvaluatorTarget = globalTarget) {
 	try {
-		return parseRecoverable(source, parseSyncSource);
+		return parseRecoverable(source, src => parseSyncSource(src, target));
 	} catch {
-		return parseRecoverable(source, parseAsyncSource);
+		return parseRecoverable(source, src => parseAsyncSource(src, target));
 	}
 }
+
+export const makeUnsafeGlobalEvaluator = (source: string) => makeUnsafeEvaluator(source);
 
 // Evaluates the given source text and returns the "last" expression. Globals dump out into the
 // current context.

--- a/packages/xxscreeps/engine/service/launcher.ts
+++ b/packages/xxscreeps/engine/service/launcher.ts
@@ -1,3 +1,4 @@
+import { startLauncherRpcServer } from 'xxscreeps/cli/launcher-rpc.js';
 import { checkArguments } from 'xxscreeps/config/arguments.js';
 import config from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
@@ -9,7 +10,7 @@ import { handleInterruptSignal } from './signal.js';
 import { getServiceChannel } from './index.js';
 
 const argv = checkArguments({
-	boolean: [ 'no-backend', 'no-processor', 'no-runner' ] as const,
+	boolean: [ 'no-backend', 'no-launcher-rpc', 'no-processor', 'no-runner' ] as const,
 	string: [ 'attach-console' ] as const,
 });
 
@@ -25,6 +26,12 @@ disposable.defer(async () => {
 	await Promise.all([ db.save(), shard.save()	]);
 	console.log('💾 Engine shut down successfully.');
 });
+
+// Registered after the save defer; LIFO disposal means RPC drain runs first so in-flight
+// requests can't mutate state between the flush and shutdown.
+if (!argv['no-launcher-rpc']) {
+	disposable.defer(await startLauncherRpcServer(db, shard));
+}
 
 // Attach console for given user
 if (argv['attach-console'] !== undefined) {


### PR DESCRIPTION
## Summary

Adds a live REPL to `xxscreeps cli`. With a local provider + launcher up, the REPL forwards each input over the launcher's RPC socket, sharing the launcher's in-process `db`/`shard` and persisting `let`/`const`/`var` across turns within a connection. With a networked provider (`redis:`) the REPL runs in the CLI's own process — storage is the rendezvous, so it still reaches the live engine state the launcher is writing. Local-without-launcher falls back to a host-realm REPL with no engine state pre-bound. `xxscreeps eval` stays host-realm only.

Slice 2 of #168.

## Design

**Auto-detect, no flags.** `xxscreeps cli` inspects `config.database.data`. Local schemes (`file:`, `local:`) probe the launcher RPC socket; networked schemes (`redis:`) skip the probe outright — there's no in-process state to share, and the live data is already reachable through storage. The banner names the chosen mode on stderr; the prompt is `xxscreeps live>` vs `xxscreeps>`.

**Launcher RPC = Unix socket / Windows named pipe at `screeps/cli.sock`** next to `.screepsrc.yaml`. The name says what it is — a server location with a call/return protocol shape. Unix permissions `0o600` socket / `0o700` parent; same-UID is the trust boundary, not the sandbox.

**Per-connection `vm.Context`.** Each connection allocates one context that lives for the connection's lifetime, so `var x = 41` from one turn is visible to `x + 1` in the next. Requests within a connection serialize through a promise chain so the context never observes a half-applied declaration. Parallel sessions get isolated contexts.

**Console proxy via AsyncLocalStorage.** `console` in the per-connection context is a stable proxy; each request runs inside `sinkStore.run(sink, …)`. A late `setTimeout` callback inherits the async context of the request that scheduled it, so its log lands in that request's drained sink rather than bleeding into a later request's envelope.

**Top-level declarations hoisted in the async wrap.** `let x = await …` previously vanished after the IIFE returned. Acorn parses the source, hoists top-level `let`/`const`/`var` (including destructuring) as `var x;` at script scope, and rewrites the declaration to an assignment in the arrow body. Same shape Node's REPL uses for `--experimental-repl-await`. Class/function declarations don't persist; bind via `let C = class { … }`.

**Drain on shutdown.** Launcher RPC cleanup is `disposable.defer`'d after the save defer; LIFO disposal means RPC drain runs first, so an in-flight eval can't mutate state between flush and shutdown.

**`xxscreeps eval` stays host-realm.** Never RPC-routed.

**Opt-out.** `xxscreeps start --no-launcher-rpc` runs the launcher without the socket; CLI falls back to direct mode.

## Out of scope

- Per-command transport routing (`Manifest.commands` + `requiresLauncher`) — slice 3; `detectMode` carries a TODO marking this detection as REPL-eval-transport only.
- Provider capability flag instead of the hardcoded scheme list — deferred per #168.
- Multi-shard handshake — launcher RPC serves the launcher's default shard.

## Validation

- `pnpm run build` clean.
- `npx eslint` on `packages/xxscreeps/cli/` — zero warnings introduced.
- `npx xxscreeps test` — 387/387 pass; new describes: `cli` (15), `launcher RPC` (30), `cli live` (8) all green.
