### PR TITLE
combat: restore rangedMassAttack 3-tile radius and target filter

### DIFF
--- a/.changeset/ranged-mass-attack-range-and-filter.md
+++ b/.changeset/ranged-mass-attack-range-and-filter.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Restore `rangedMassAttack` 3-tile radius and own/unowned target filter.

--- a/packages/xxscreeps/mods/combat/processor.ts
+++ b/packages/xxscreeps/mods/combat/processor.ts
@@ -71,12 +71,12 @@ const intents = [
 	}, (creep, context) => {
 		if (checkRangedMassAttack(creep) === C.OK) {
 			const basePower = calculatePower(creep, C.RANGED_ATTACK, C.RANGED_ATTACK_POWER, 'rangedMassAttack');
-			for (const pos of positionsInRangeTo(creep.pos, 2)) {
+			for (const pos of positionsInRangeTo(creep.pos, 3)) {
 				const power = basePower * (kRangedMassAttackPower[creep.pos.getRangeTo(pos)] ?? 0);
 				const objects = Fn.pipe(
 					creep.room['#lookAt'](pos),
 					$$ => Fn.reject($$, object =>
-						object['#layer'] === undefined || object.hits === undefined),
+						object['#layer'] === undefined || object.hits === undefined || object.my !== false),
 					$$ => [ ...$$ ],
 					$$ => $$.sort(mappedComparator(invertedNumericComparator, object => object['#layer']!)));
 				walkLayers(objects, power, (object, layerPower) => {

--- a/packages/xxscreeps/mods/combat/test.ts
+++ b/packages/xxscreeps/mods/combat/test.ts
@@ -479,26 +479,11 @@ describe('rangedMassAttack', () => {
 		W1N1: room => {
 			room['#level'] = 7;
 			room['#user'] = room.controller!['#user'] = '100';
-			room['#insertObject'](createCreep(
-				new RoomPosition(25, 25, 'W1N1'),
-				[ C.RANGED_ATTACK ],
-				'attacker', '101'));
-			room['#insertObject'](createCreep(
-				new RoomPosition(26, 25, 'W1N1'),
-				[ C.MOVE ],
-				'enemyR1', '100'));
-			room['#insertObject'](createCreep(
-				new RoomPosition(27, 25, 'W1N1'),
-				[ C.MOVE ],
-				'enemyR2', '100'));
-			room['#insertObject'](createCreep(
-				new RoomPosition(28, 25, 'W1N1'),
-				[ C.MOVE ],
-				'enemyR3', '100'));
-			room['#insertObject'](createCreep(
-				new RoomPosition(25, 26, 'W1N1'),
-				[ C.MOVE ],
-				'ally', '101'));
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, 'W1N1'), [ C.RANGED_ATTACK ], 'attacker', '101'));
+			room['#insertObject'](createCreep(new RoomPosition(26, 25, 'W1N1'), [ C.MOVE ], 'enemyR1', '100'));
+			room['#insertObject'](createCreep(new RoomPosition(27, 25, 'W1N1'), [ C.MOVE ], 'enemyR2', '100'));
+			room['#insertObject'](createCreep(new RoomPosition(28, 25, 'W1N1'), [ C.MOVE ], 'enemyR3', '100'));
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.MOVE ], 'ally', '101'));
 			room['#insertObject'](createContainer(new RoomPosition(24, 25, 'W1N1')));
 			room['#insertObject'](createLab(new RoomPosition(25, 24, 'W1N1'), '100'));
 		},

--- a/packages/xxscreeps/mods/combat/test.ts
+++ b/packages/xxscreeps/mods/combat/test.ts
@@ -4,6 +4,7 @@ import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createLab } from 'xxscreeps/mods/chemistry/lab.js';
 import { createLabWithResources } from 'xxscreeps/mods/chemistry/test.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createContainer } from 'xxscreeps/mods/resource/container.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
@@ -462,6 +463,114 @@ describe('TOUGH damage reduction', () => {
 			assert.strictEqual(Game.creeps.defender?.hits,
 				afterPreDmg - effectiveDmg + healAmount,
 				'TOUGH reduction must apply even when raw damage equals healing');
+		});
+	}));
+});
+
+// =========================================================================
+// rangedMassAttack range and target filter
+// =========================================================================
+
+describe('rangedMassAttack', () => {
+	// Attacker at (25,25) is player '101' with one RANGED_ATTACK part (base
+	// power 10). Targets surround at ranges 1/2/3 and varied ownership; the
+	// range rates 1/0.4/0.1 yield 10/4/1 damage.
+	const sim = simulate({
+		W1N1: room => {
+			room['#level'] = 7;
+			room['#user'] = room.controller!['#user'] = '100';
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 25, 'W1N1'),
+				[ C.RANGED_ATTACK ],
+				'attacker', '101'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(26, 25, 'W1N1'),
+				[ C.MOVE ],
+				'enemyR1', '100'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(27, 25, 'W1N1'),
+				[ C.MOVE ],
+				'enemyR2', '100'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(28, 25, 'W1N1'),
+				[ C.MOVE ],
+				'enemyR3', '100'));
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 26, 'W1N1'),
+				[ C.MOVE ],
+				'ally', '101'));
+			room['#insertObject'](createContainer(new RoomPosition(24, 25, 'W1N1')));
+			room['#insertObject'](createLab(new RoomPosition(25, 24, 'W1N1'), '100'));
+		},
+	});
+
+	const HITS_PER_PART = 100;
+
+	test('hostile creep at range 1 takes 10 damage', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			assert.strictEqual(Game.creeps.attacker?.rangedMassAttack(), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.enemyR1?.hits, HITS_PER_PART - 10,
+				'range-1 hostile creep should take 10 damage');
+		});
+	}));
+
+	test('hostile creep at range 2 takes 4 damage', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			Game.creeps.attacker?.rangedMassAttack();
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.enemyR2?.hits, HITS_PER_PART - 4,
+				'range-2 hostile creep should take 4 damage');
+		});
+	}));
+
+	test('hostile creep at range 3 takes 1 damage', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			Game.creeps.attacker?.rangedMassAttack();
+		});
+		await tick();
+		await player('100', Game => {
+			assert.strictEqual(Game.creeps.enemyR3?.hits, HITS_PER_PART - 1,
+				'range-3 hostile creep should take 1 damage');
+		});
+	}));
+
+	test('own creep is not damaged', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			Game.creeps.attacker?.rangedMassAttack();
+		});
+		await tick();
+		await player('101', Game => {
+			assert.strictEqual(Game.creeps.ally?.hits, HITS_PER_PART,
+				'own creep must not be damaged by rangedMassAttack');
+		});
+	}));
+
+	test('unowned structure is not damaged', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			Game.creeps.attacker?.rangedMassAttack();
+		});
+		await tick();
+		await player('100', Game => {
+			const container = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_CONTAINER)[0]!;
+			assert.strictEqual(container.hits, C.CONTAINER_HITS,
+				'unowned container must not be damaged');
+		});
+	}));
+
+	test('hostile owned structure is damaged', () => sim(async ({ player, tick }) => {
+		await player('101', Game => {
+			Game.creeps.attacker?.rangedMassAttack();
+		});
+		await tick();
+		await player('100', Game => {
+			const lab = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_LAB)[0]!;
+			assert.strictEqual(lab.hits, lab.hitsMax - 10,
+				'range-1 hostile lab should take 10 damage');
 		});
 	}));
 });


### PR DESCRIPTION
## Summary

Restore `rangedMassAttack` to its full 3-tile radius and re-add the ownership filter that the recent mass-attack helper extraction (`e0436f05`) dropped. The processor was sweeping only range 2 via `positionsInRangeTo(creep.pos, 2)`, and the new reject predicate omitted `object.my !== false`, so range-3 targets were skipped while own creeps and unowned/neutral structures could take damage.

## Validation

- `pnpm run build && npx xxscreeps test` → 370/370 pass (6 new `rangedMassAttack` cases in `mods/combat/test.ts` covering range 1/2/3 damage scaling, own-creep skip, unowned-structure skip, and hostile creep + structure hits).
- `npx eslint packages/xxscreeps/mods/combat/processor.ts packages/xxscreeps/mods/combat/test.ts` → 0 warnings.
- screeps-ok against this branch via `XXSCREEPS_LOCAL`:
  - `COMBAT-RMA-002` [range=1, 2, 3]
  - `COMBAT-RMA-003` (own creeps + unowned structures not damaged)
  - `ROOM-EVENTLOG-016` (one `EVENT_ATTACK_TYPE_RANGED_MASS` entry per damaged target, distance-scaled damage)
  - `INTENT-SIMULT-001` (move + rangedMassAttack + heal in the same tick)