### PR TITLE
engine: pass current time to inter-room finalize phase

### DIFF
--- a/.changeset/inter-room-finalize-time.md
+++ b/.changeset/inter-room-finalize-time.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix processor crash when finalizing inter-room intent target rooms.

--- a/packages/xxscreeps/engine/processor/finalize-extra.ts
+++ b/packages/xxscreeps/engine/processor/finalize-extra.ts
@@ -1,0 +1,21 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { World } from 'xxscreeps/game/map.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
+import { consumeSet } from 'xxscreeps/engine/db/async.js';
+import { finalizeExtraRoomsSetKey } from './model.js';
+import { RoomProcessor } from './room.js';
+
+// Drain finalizeExtraRoomsSetKey(time) and run process+finalize for each
+// inter-room-intent target that wasn't already in the tick's process queue.
+export async function *finalizeExtraRooms(
+	shard: Shard, world: World, time: number,
+	resolveRoom: (name: string) => Promise<Room>,
+): AsyncGenerator<readonly [string, Room]> {
+	for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
+		const room = await resolveRoom(roomName);
+		const context = new RoomProcessor(shard, world, room, time);
+		await context.process(true);
+		await context.finalize(true);
+		yield [ roomName, room ] as const;
+	}
+}

--- a/packages/xxscreeps/engine/processor/test.ts
+++ b/packages/xxscreeps/engine/processor/test.ts
@@ -1,0 +1,33 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createObserver } from 'xxscreeps/mods/observer/observer.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+
+describe('Inter-room finalize', () => {
+	const simulation = simulate({
+		W1N1: room => {
+			room['#insertObject'](createObserver(new RoomPosition(25, 25, 'W1N1'), '100'));
+			room['#level'] = 8;
+			room['#user'] =
+				room.controller!['#user'] = '100';
+		},
+	});
+
+	test('intent into non-processed room saves at next tick', () => simulation(async ({ peekRoom, player, shard, tick }) => {
+		const startTime = shard.time;
+		await player('100', Game => {
+			const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
+			const result = observer?.observeRoom('W2N2');
+			assert.strictEqual(result, C.OK);
+		});
+		await tick();
+		assert.strictEqual(shard.time, startTime + 1);
+		await peekRoom('W2N2', room => {
+			assert.ok(
+				room['#objects'].some(object => object.constructor.name === 'ObserverSpy'),
+				'inter-room intent should have landed an ObserverSpy in W2N2',
+			);
+		});
+	}));
+});

--- a/packages/xxscreeps/engine/processor/worker.ts
+++ b/packages/xxscreeps/engine/processor/worker.ts
@@ -2,10 +2,10 @@ import type { Room } from 'xxscreeps/game/room/room.js';
 import config from 'xxscreeps/config/index.js';
 import { importMods } from 'xxscreeps/config/mods/index.js';
 import { loadTerrain } from 'xxscreeps/driver/pathfinder.js';
-import { consumeSet } from 'xxscreeps/engine/db/async.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { finalizeExtraRooms } from 'xxscreeps/engine/processor/finalize-extra.js';
 import { initializeIntentConstraints } from 'xxscreeps/engine/processor/index.js';
-import { acquireIntentsForRoom, finalizeExtraRoomsSetKey, roomsDidFinalize, updateUserRoomRelationships } from 'xxscreeps/engine/processor/model.js';
+import { acquireIntentsForRoom, roomsDidFinalize, updateUserRoomRelationships } from 'xxscreeps/engine/processor/model.js';
 import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
 import { hooks } from 'xxscreeps/engine/processor/symbols.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -120,11 +120,7 @@ await makeBasicResponderHost<ProcessorRequest>(import.meta.url, async message =>
 			await Promise.all(Fn.map(processedRooms.values(), context => context.finalize(false)));
 			let count = processedRooms.size;
 			// Also finalize rooms which were sent inter-room intents
-			for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
-				const room = await shard.loadRoom(roomName, time);
-				const context = new RoomProcessor(shard, world, room, time + 1);
-				await context.process(true);
-				await context.finalize(true);
+			for await (const [ roomName, room ] of finalizeExtraRooms(shard, world, time, name => shard.loadRoom(name, time))) {
 				nextRoomCache.set(roomName, room);
 				++count;
 			}

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -3,6 +3,7 @@ import { flush, summary } from './context.js';
 import './import.js';
 import 'xxscreeps/cli/test.js';
 import 'xxscreeps/engine/db/storage/local/test.js';
+import 'xxscreeps/engine/processor/test.js';
 import 'xxscreeps/game/test.js';
 
 await importMods('driver');

--- a/packages/xxscreeps/test/simulate.ts
+++ b/packages/xxscreeps/test/simulate.ts
@@ -8,11 +8,12 @@ import type { RawMemory } from 'xxscreeps/mods/memory/memory.js';
 import * as assert from 'node:assert';
 import config from 'xxscreeps/config/index.js';
 import { importMods } from 'xxscreeps/config/mods/index.js';
-import { consumeSet, consumeSortedSet } from 'xxscreeps/engine/db/async.js';
+import { consumeSortedSet } from 'xxscreeps/engine/db/async.js';
 import * as Code from 'xxscreeps/engine/db/user/code.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
+import { finalizeExtraRooms } from 'xxscreeps/engine/processor/finalize-extra.js';
 import { initializeIntentConstraints } from 'xxscreeps/engine/processor/index.js';
-import { begetRoomProcessQueue, finalizeExtraRoomsSetKey, processRoomsSetKey, updateUserRoomRelationships, userToIntentRoomsSetKey, userToVisibleRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
+import { begetRoomProcessQueue, processRoomsSetKey, updateUserRoomRelationships, userToIntentRoomsSetKey, userToVisibleRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
 import { runShardTickProcessors } from 'xxscreeps/engine/processor/shard.js';
 import { PlayerInstance } from 'xxscreeps/engine/runner/instance.js';
@@ -224,11 +225,10 @@ export function simulate(rooms: Record<string, (room: Room) => void>) {
 
 					// Second phase
 					await Promise.all(Fn.map(contexts.values(), context => context.finalize(false)));
-					for await (const roomName of consumeSet(shard.scratch, finalizeExtraRoomsSetKey(time))) {
-						const room = roomInstances.get(roomName) ?? await shard.loadRoom(roomName);
-						const context = new RoomProcessor(shard, world, room, time);
-						await context.process(true);
-						await context.finalize(true);
+					for await (const [ roomName, room ] of finalizeExtraRooms(
+						shard, world, time,
+						async name => roomInstances.get(name) ?? await shard.loadRoom(name),
+					)) {
 						nextRoomInstances.set(roomName, room);
 					}
 


### PR DESCRIPTION
## Summary
- `worker.ts:125` constructed the inter-room finalize `RoomProcessor` with `time + 1`, so `finalize` saved the target room at `shard.time + 2` while `shard.time` was still T. Live engine crashed with `Invalid time: T+2 [current: T]` whenever an inter-room intent (observer, terminal, nuke, room-crossing creep) landed on a room with no other processing this tick.
- Extracted the inter-room finalize loop into `engine/processor/finalize-extra.ts`; both `worker.ts` and `test/simulate.ts` now call it so production and the test harness exercise the same code path.

## Validation
- `pnpm run build` clean.
- `npx xxscreeps test`: 365 pass (was 364; +1 regression test).
- New `Inter-room finalize > intent into non-processed room saves at next tick` test reproduces the live `Invalid time: T+2 [current: T]` stack against the pre-fix helper, and passes against the fix.
- `npx eslint` on the changed files: zero new warnings.