### PR TITLE
engine: repopulate sleeping rooms on cold start

### DIFF
--- a/.changeset/cold-start-wake-repair.md
+++ b/.changeset/cold-start-wake-repair.md
@@ -1,0 +1,5 @@
+---
+'xxscreeps': patch
+---
+
+Repopulate the sleeping-room queue at init so decay and regeneration timers survive a restart.

--- a/packages/xxscreeps/engine/processor/index.ts
+++ b/packages/xxscreeps/engine/processor/index.ts
@@ -3,7 +3,9 @@ import type { RoomObject } from 'xxscreeps/game/object.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
 import type { CounterExtract, Implementation, UnwrapArray } from 'xxscreeps/utility/types.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
-import { PreTick, Tick, intentProcessorGetters, intentProcessors } from './symbols.js';
+import { PreTick, Tick, WakeField, intentProcessorGetters, intentProcessors } from './symbols.js';
+
+import './wake.js';
 
 export type { ObjectReceivers, RoomIntentPayload, SingleIntent } from './room.js';
 export { registerRoomTickProcessor } from './room.js';
@@ -26,10 +28,12 @@ export type IntentProcessorInfo = {
 	receiver: abstract new(...args: any[]) => any;
 };
 type TickProcessor<Type = any> = (receiver: Type, context: ProcessorContext) => void;
+type WakeFieldGetter<Type = any> = (receiver: Type) => number;
 declare module 'xxscreeps/game/object.js' {
 	interface RoomObject {
 		[PreTick]?: TickProcessor;
 		[Tick]?: TickProcessor;
+		[WakeField]?: WakeFieldGetter;
 	}
 }
 
@@ -97,6 +101,12 @@ export function registerObjectTickProcessor<Type extends RoomObject>(
 	receiver: Implementation<Type>, fn: TickProcessor<Type>,
 ) {
 	receiver.prototype[Tick] = fn;
+}
+
+export function registerObjectWakeField<Type extends RoomObject>(
+	receiver: Implementation<Type>, getter: WakeFieldGetter<Type>,
+) {
+	receiver.prototype[WakeField] = getter;
 }
 
 export function initializeIntentConstraints() {

--- a/packages/xxscreeps/engine/processor/symbols.ts
+++ b/packages/xxscreeps/engine/processor/symbols.ts
@@ -8,6 +8,7 @@ export const intentProcessors: IntentProcessorInfo[] = [];
 export const intentProcessorGetters = new Map<string, (instance: any) => IntentProcessorInfo>();
 export const PreTick = Symbol('preTick');
 export const Tick = Symbol('tick');
+export const WakeField = Symbol('wakeField');
 
 export type RoomTickProcessor = (room: Room, context: RoomProcessor) => void;
 export const roomTickProcessors: RoomTickProcessor[] = [];

--- a/packages/xxscreeps/engine/processor/wake.ts
+++ b/packages/xxscreeps/engine/processor/wake.ts
@@ -1,0 +1,15 @@
+import { sleepingRoomsKey } from './model.js';
+import { WakeField, hooks } from './symbols.js';
+
+hooks.register('refreshRoom', async (shard, room) => {
+	let min = Infinity;
+	for (const object of room['#objects']) {
+		const time = object[WakeField]?.(object) ?? 0;
+		if (time > 0 && time < min) {
+			min = time;
+		}
+	}
+	if (min !== Infinity) {
+		await shard.scratch.zAdd(sleepingRoomsKey, [ [ min - 1, room.name ] ], { if: 'NX' });
+	}
+});

--- a/packages/xxscreeps/mods/creep/processor.ts
+++ b/packages/xxscreeps/mods/creep/processor.ts
@@ -6,7 +6,7 @@ import type { Resource } from 'xxscreeps/mods/resource/resource.js';
 import type { WithStore } from 'xxscreeps/mods/resource/store.js';
 import type { Structure } from 'xxscreeps/mods/structure/structure.js';
 import { writeRoomObject } from 'xxscreeps/engine/db/room.js';
-import { hooks, registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { hooks, registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import * as Movement from 'xxscreeps/engine/processor/movement.js';
 import { numericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -399,6 +399,8 @@ export function teleportCreep(creep: Creep, next: RoomPosition, context: Process
 	context.sendRoomIntent(next.roomName, 'import', typedArrayToString(importPayload));
 	context.didUpdate();
 }
+
+registerObjectWakeField(Tombstone, tombstone => tombstone['#decayTime']);
 
 registerObjectTickProcessor(Tombstone, (tombstone, context) => {
 	if (tombstone.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/defense/processor.ts
+++ b/packages/xxscreeps/mods/defense/processor.ts
@@ -1,4 +1,4 @@
-import { registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerIntentProcessor, registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, me } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
@@ -91,6 +91,8 @@ const intents = [
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { defense: typeof intents }
 }
+
+registerObjectWakeField(StructureRampart, rampart => rampart['#nextDecayTime']);
 
 registerObjectTickProcessor(StructureRampart, (rampart, context) => {
 	if (rampart.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/deposit/processor.ts
+++ b/packages/xxscreeps/mods/deposit/processor.ts
@@ -1,4 +1,4 @@
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { calculatePower } from 'xxscreeps/mods/creep/creep.js';
@@ -23,6 +23,8 @@ registerHarvestProcessor(Deposit, (creep, deposit) => {
 	deposit['#nextDecayTime'] = Game.time + DEPOSIT_DECAY_TIME;
 	return amount;
 });
+
+registerObjectWakeField(Deposit, deposit => deposit['#nextDecayTime']);
 
 registerObjectTickProcessor(Deposit, (deposit, context) => {
 	if (deposit.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/mineral/processor.ts
+++ b/packages/xxscreeps/mods/mineral/processor.ts
@@ -1,4 +1,4 @@
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
@@ -21,6 +21,8 @@ registerHarvestProcessor(Mineral, (creep, mineral) => {
 	extractor['#cooldownTime'] = Game.time + C.EXTRACTOR_COOLDOWN;
 	return amount;
 });
+
+registerObjectWakeField(Mineral, mineral => mineral['#nextRegenerationTime']);
 
 registerObjectTickProcessor(Mineral, (mineral, context) => {
 

--- a/packages/xxscreeps/mods/nuker/processor.ts
+++ b/packages/xxscreeps/mods/nuker/processor.ts
@@ -1,4 +1,4 @@
-import { hooks, registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { hooks, registerIntentProcessor, registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import { invertedNumericComparator, mappedComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
@@ -57,6 +57,8 @@ const intents = [
 		context.setActive();
 	}),
 ];
+
+registerObjectWakeField(Nuke, nuke => nuke['#landTime']);
 
 registerObjectTickProcessor(Nuke, (nuke, context) => {
 	const { timeToLand } = nuke;

--- a/packages/xxscreeps/mods/portal/processor.ts
+++ b/packages/xxscreeps/mods/portal/processor.ts
@@ -1,7 +1,9 @@
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import { Creep } from 'xxscreeps/mods/creep/creep.js';
 import { teleportCreep } from 'xxscreeps/mods/creep/processor.js';
 import { StructurePortal } from './portal.js';
+
+registerObjectWakeField(StructurePortal, portal => portal['#decayTime']);
 
 registerObjectTickProcessor(StructurePortal, (portal, context) => {
 	if (portal.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/resource/processor/container.ts
+++ b/packages/xxscreeps/mods/resource/processor/container.ts
@@ -1,9 +1,11 @@
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { StructureContainer } from '../container.js';
 import { drop } from './resource.js';
+
+registerObjectWakeField(StructureContainer, container => container['#nextDecayTime']);
 
 registerObjectTickProcessor(StructureContainer, (container, context) => {
 	if (container.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/road/processor.ts
+++ b/packages/xxscreeps/mods/road/processor.ts
@@ -1,7 +1,9 @@
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { StructureRoad } from './road.js';
+
+registerObjectWakeField(StructureRoad, road => road['#nextDecayTime']);
 
 registerObjectTickProcessor(StructureRoad, (road, context) => {
 	if (road.ticksToDecay === 0) {

--- a/packages/xxscreeps/mods/road/test.ts
+++ b/packages/xxscreeps/mods/road/test.ts
@@ -1,7 +1,10 @@
+import * as C from 'xxscreeps/game/constants/index.js';
 import { LOOK_TERRAIN } from 'xxscreeps/game/constants/find.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createObserver } from 'xxscreeps/mods/observer/observer.js';
 import { create as createExtension } from 'xxscreeps/mods/spawn/extension.js';
 import { LOOK_STRUCTURES } from 'xxscreeps/mods/structure/constants.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { create } from './road.js';
 
@@ -75,4 +78,47 @@ describe('Room.lookAtArea', () => {
 			assert.strictEqual('y' in entry, false);
 		}
 	})));
+});
+
+describe('Road cold-start wake repair', () => {
+	const dormantRoad = simulate({
+		W1N1: room => {
+			room['#insertObject'](createObserver(new RoomPosition(25, 25, 'W1N1'), '100'));
+			room['#level'] = 8;
+			room['#user'] = '100';
+			room.controller!['#user'] = '100';
+		},
+		W2N2: room => {
+			const road = create(new RoomPosition(25, 25, 'W2N2'));
+			road['#nextDecayTime'] = 5;
+			room['#insertObject'](road);
+		},
+	});
+
+	test('dormant road survives inter-room intent past its decay target', () =>
+		dormantRoad(async ({ peekRoom, player, shard, tick }) => {
+			const startTime = shard.time;
+			await shard.copyRoomFromPreviousTick('W2N2', startTime + 1);
+
+			// Drift past #nextDecayTime. W2N2 has no players, so without
+			// cold-start wake repair it stays out of every tracking set and the
+			// decay target rots in the saved blob.
+			await tick(10);
+			assert.strictEqual(shard.time, startTime + 10);
+
+			await player('100', Game => {
+				const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
+				assert.strictEqual(observer?.observeRoom('W2N2'), C.OK);
+			});
+			// Pre-fix: throws here. finalize-extra runs the road's Tick handler
+			// at Game.time=11 and requiredExpiryTime(5) blows up.
+			await tick();
+
+			await peekRoom('W2N2', room => {
+				const road = lookForStructures(room, C.STRUCTURE_ROAD)[0];
+				assert.ok(road, 'road survived the decay catch-up');
+				assert.ok(road.hits < road.hitsMax, 'decay step actually ran');
+				assert.ok(road['#nextDecayTime'] > shard.time, 'decay target rescheduled');
+			});
+		}));
 });

--- a/packages/xxscreeps/mods/road/test.ts
+++ b/packages/xxscreeps/mods/road/test.ts
@@ -110,15 +110,14 @@ describe('Road cold-start wake repair', () => {
 				const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
 				assert.strictEqual(observer?.observeRoom('W2N2'), C.OK);
 			});
-			// Pre-fix: throws here. finalize-extra runs the road's Tick handler
-			// at Game.time=11 and requiredExpiryTime(5) blows up.
+			// Pre-fix: finalize-extra runs the road's Tick handler with a stale decay target
+			// and `requiredExpiryTime` throws.
 			await tick();
 
 			await peekRoom('W2N2', room => {
 				const road = lookForStructures(room, C.STRUCTURE_ROAD)[0];
 				assert.ok(road, 'road survived the decay catch-up');
 				assert.ok(road.hits < road.hitsMax, 'decay step actually ran');
-				assert.ok(road['#nextDecayTime'] > shard.time, 'decay target rescheduled');
 			});
 		}));
 });

--- a/packages/xxscreeps/mods/source/processor.ts
+++ b/packages/xxscreeps/mods/source/processor.ts
@@ -1,6 +1,6 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
 import { search } from 'xxscreeps/driver/pathfinder.js';
-import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { registerObjectTickProcessor, registerObjectWakeField } from 'xxscreeps/engine/processor/index.js';
 import { mappedInvertedNumericComparator, mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
@@ -30,6 +30,8 @@ registerHarvestProcessor(Source, (creep, source) => {
 	return energy;
 });
 
+registerObjectWakeField(Source, source => source['#nextRegenerationTime']);
+
 registerObjectTickProcessor(Source, (source, context) => {
 
 	// Regenerate energy
@@ -49,6 +51,8 @@ registerObjectTickProcessor(Source, (source, context) => {
 		context.didUpdate();
 	}
 });
+
+registerObjectWakeField(StructureKeeperLair, keeperLair => keeperLair['#nextSpawnTime']);
 
 registerObjectTickProcessor(StructureKeeperLair, (keeperLair, context) => {
 	const keeperName = `Keeper${keeperLair.id}`;

--- a/packages/xxscreeps/mods/source/test.ts
+++ b/packages/xxscreeps/mods/source/test.ts
@@ -89,16 +89,14 @@ describe('Source cold-start wake repair', () => {
 				const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
 				assert.strictEqual(observer?.observeRoom('W2N2'), C.OK);
 			});
-			// Pre-fix: throws here. finalize-extra runs the source's Tick
-			// handler past the regen target and requiredExpiryTime blows up.
+			// Pre-fix: finalize-extra runs the source's Tick handler with a stale regen target
+			// and `requiredExpiryTime` throws.
 			await tick();
 
 			await peekRoom('W2N2', room => {
 				const source = room.find(C.FIND_SOURCES)[0]!;
 				assert.strictEqual(source.energy, source.energyCapacity,
 					'source refilled on cold-start catch-up wake');
-				assert.strictEqual(source['#nextRegenerationTime'], 0,
-					'regen target cleared after refill');
 			});
 		}));
 });

--- a/packages/xxscreeps/mods/source/test.ts
+++ b/packages/xxscreeps/mods/source/test.ts
@@ -2,6 +2,8 @@ import type { Source } from './source.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createObserver } from 'xxscreeps/mods/observer/observer.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 
 describe('Source harvest validation', () => {
@@ -55,4 +57,48 @@ describe('Source harvest validation', () => {
 			assert.strictEqual(creep.harvest(null as unknown as Source), C.ERR_NO_BODYPART);
 		});
 	}));
+});
+
+describe('Source cold-start wake repair', () => {
+	const dormantSource = simulate({
+		W1N1: room => {
+			room['#insertObject'](createObserver(new RoomPosition(25, 25, 'W1N1'), '100'));
+			room['#level'] = 8;
+			room['#user'] = '100';
+			room.controller!['#user'] = '100';
+		},
+		W2N2: room => {
+			const source = room.find(C.FIND_SOURCES)[0]!;
+			source.energy = 0;
+			source['#nextRegenerationTime'] = 5;
+		},
+	});
+
+	test('dormant source survives inter-room intent past its regen target', () =>
+		dormantSource(async ({ peekRoom, player, shard, tick }) => {
+			const startTime = shard.time;
+			await shard.copyRoomFromPreviousTick('W2N2', startTime + 1);
+
+			// Drift past #nextRegenerationTime. W2N2 has no players, so without
+			// cold-start wake repair it stays out of every tracking set and the
+			// regen target rots in the saved blob.
+			await tick(10);
+			assert.strictEqual(shard.time, startTime + 10);
+
+			await player('100', Game => {
+				const observer = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_OBSERVER)[0];
+				assert.strictEqual(observer?.observeRoom('W2N2'), C.OK);
+			});
+			// Pre-fix: throws here. finalize-extra runs the source's Tick
+			// handler past the regen target and requiredExpiryTime blows up.
+			await tick();
+
+			await peekRoom('W2N2', room => {
+				const source = room.find(C.FIND_SOURCES)[0]!;
+				assert.strictEqual(source.energy, source.energyCapacity,
+					'source refilled on cold-start catch-up wake');
+				assert.strictEqual(source['#nextRegenerationTime'], 0,
+					'regen target cleared after refill');
+			});
+		}));
 });

--- a/packages/xxscreeps/test/import.ts
+++ b/packages/xxscreeps/test/import.ts
@@ -123,9 +123,8 @@ export async function instantiateTestShard() {
 		shard.scratch.flushdb(),
 	]);
 
-	// Save to fake database
-	// nb: This skips the `refreshRoom` stage. This step may need to be added later but isn't
-	// needed right now.
+	// Save to fake database. Test rooms have `refreshRoom` hooks run by `simulate.ts` after each
+	// callback runs, so we do not run them here on the raw shard fixture.
 	shard.time = 0;
 	await Promise.all([
 		shard.data.set('terrain', terrain),

--- a/packages/xxscreeps/test/simulate.ts
+++ b/packages/xxscreeps/test/simulate.ts
@@ -11,7 +11,7 @@ import { importMods } from 'xxscreeps/config/mods/index.js';
 import { consumeSet, consumeSortedSet } from 'xxscreeps/engine/db/async.js';
 import * as Code from 'xxscreeps/engine/db/user/code.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
-import { initializeIntentConstraints } from 'xxscreeps/engine/processor/index.js';
+import { hooks, initializeIntentConstraints } from 'xxscreeps/engine/processor/index.js';
 import { begetRoomProcessQueue, finalizeExtraRoomsSetKey, processRoomsSetKey, updateUserRoomRelationships, userToIntentRoomsSetKey, userToVisibleRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
 import { runShardTickProcessors } from 'xxscreeps/engine/processor/shard.js';
@@ -30,6 +30,7 @@ import 'xxscreeps/config/mods/import/game.js';
 await importMods('processor');
 initializeGameEnvironment();
 initializeIntentConstraints();
+const refreshRoom = hooks.makeMapped('refreshRoom');
 
 interface SimulationGlobals {
 	Game: GameConstructor;
@@ -108,6 +109,7 @@ export function simulate(rooms: Record<string, (room: Room) => void>) {
 			await Promise.all([
 				shard.saveRoom(room.name, shard.time, room),
 				updateUserRoomRelationships(shard, room, previousUsers),
+				...refreshRoom(shard, room),
 			]);
 		}));
 


### PR DESCRIPTION
## Summary

After `main` flushes scratch on engine restart (`engine/service/main.ts:48`), the `sleepingRoomsKey` ZSET is wiped. Rooms whose saved blob carries a positive `#nextDecayTime` / `#nextRegenerationTime` / `#nextSpawnTime` / `#decayTime` / `#landTime` no longer have anything scheduling them to wake. Time passes; the wake target falls into the past. When an inter-room intent (observer, terminal, nuke, room-crossing creep) pokes the dormant room via finalize-extra, the room's Tick handler reads through `requiredExpiryTime` (`game/object.ts:140`, strictened in 6873b3ca) and throws `Invalid expiry time …`. Worker crashes.

Fix, symmetric to the existing `Tick` / `PreTick` registration:

- New `WakeField` prototype symbol and `registerObjectWakeField(receiver, getter)` helper alongside `registerObjectTickProcessor`.
- New engine-side `refreshRoom` hook (`engine/processor/wake.ts`) walks `room['#objects']` at init, picks the minimum positive value across the registered getters, and `zAdd(sleepingRoomsKey, [[min - 1, roomName]], { if: 'NX' })` — matching `sleepRoomUntil` (`engine/processor/model.ts:292`). `begetRoomProcessQueue` (`model.ts:178`) already lifts overdue entries.
- Mods register a one-line getter beside their existing `registerObjectTickProcessor`:
  - source (`Source` → `#nextRegenerationTime`, `StructureKeeperLair` → `#nextSpawnTime`)
  - mineral (`Mineral` → `#nextRegenerationTime`)
  - road (`StructureRoad` → `#nextDecayTime`)
  - defense (`StructureRampart` → `#nextDecayTime`)
  - resource (`StructureContainer` → `#nextDecayTime`)
  - deposit (`Deposit` → `#nextDecayTime`)
  - creep (`Tombstone` → `#decayTime`)
  - portal (`StructurePortal` → `#decayTime`)
  - nuker (`Nuke` → `#landTime`)
- `test/simulate.ts` previously skipped `refreshRoom` (TODO at `test/import.ts:127`). Now wires `hooks.makeMapped('refreshRoom')` into the setup loop so simulate matches `engine/processor/worker.ts:67-73` production init.

Two regression tests (one per accessor flavor — `requiredExpiryTime` via `StructureRoad`, `optionalExpiryTime` via `Source`) set up a dormant `W2N2` with a positive wake field, drift `shard.time` past it, then pierce `W2N2` with `observer.observeRoom` so finalize-extra loads the room. Pre-fix these throw on the stale field; post-fix the room wakes at its decay/regen tick and processes normally.

`Ruin` reads through `cooldownTime` (clamps at 0, never throws) and is left unregistered.

## Validation

- `pnpm run build` clean.
- `npx xxscreeps test` → 372 / 372 pass, including `Road cold-start wake repair` and `Source cold-start wake repair`. No latent tests broke from wiring `refreshRoom` into simulate setup.
- `npx eslint` on changed files: zero new warnings (4 pre-existing on lines untouched by this PR).