### PR TITLE
engine: fix processor hang on SIGINT in idle gap between ticks

### DIFF
--- a/.changeset/processor-shutdown-race.md
+++ b/.changeset/processor-shutdown-race.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix engine hang on SIGINT during the idle gap between ticks

--- a/packages/xxscreeps/engine/service/processor.ts
+++ b/packages/xxscreeps/engine/service/processor.ts
@@ -1,5 +1,4 @@
 import type { ProcessorRequest } from 'xxscreeps/engine/processor/worker.js';
-import type { Effect } from 'xxscreeps/utility/types.js';
 import config from 'xxscreeps/config/index.js';
 import { consumeSet, consumeSortedSet, consumeSortedSetMembers } from 'xxscreeps/engine/db/async.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
@@ -16,15 +15,10 @@ const log = config.processor.log ?? isEntry
 	? (message: string) => process.stderr.write(message)
 	: () => {};
 
-// Interrupt handler
-let halt: Effect | undefined;
+// Interrupt handler. Don't break the message loop on SIGINT — main exits the processor via a `shutdown` publish on the processor channel.
 let halted = false as boolean;
-let processing = false;
 using _signal = handleInterruptSignal(() => {
 	halted = true;
-	if (!processing) {
-		halt?.();
-	}
 });
 
 // Connect to main & storage
@@ -108,7 +102,7 @@ await Promise.all([
 	getServiceChannel(shard).publish({ type: 'processorInitialized' }),
 	async function() {
 		const messages = processorSubscription.iterable();
-		for await (const message of Async.breakable(messages, breaker => halt = breaker)) {
+		for await (const message of messages) {
 			if (message.type === 'shutdown' || halted) {
 				throw new Error('Processor initialization failure');
 			} else if (message.type === 'process') {
@@ -120,14 +114,13 @@ await Promise.all([
 ]);
 
 // Process messages
-loop: for await (const message of Async.breakable(processorMessages, breaker => halt = breaker)) {
+loop: for await (const message of processorMessages) {
 	switch (message.type) {
 		case 'shutdown':
 			break loop;
 
 		case 'process': {
 			const { time, roomNames } = message;
-			processing = true;
 
 			// Update checkAffinity flag on workers
 			let activations = function() {
@@ -177,7 +170,6 @@ loop: for await (const message of Async.breakable(processorMessages, breaker => 
 					await worker.responder({ type: 'finalize', time });
 				}
 			}));
-			processing = false;
 			if (halted) {
 				// We check for interrupts at the end of tick
 				break loop;

--- a/packages/xxscreeps/engine/service/processor.ts
+++ b/packages/xxscreeps/engine/service/processor.ts
@@ -1,4 +1,5 @@
 import type { ProcessorRequest } from 'xxscreeps/engine/processor/worker.js';
+import type { Effect } from 'xxscreeps/utility/types.js';
 import config from 'xxscreeps/config/index.js';
 import { consumeSet, consumeSortedSet, consumeSortedSetMembers } from 'xxscreeps/engine/db/async.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
@@ -15,10 +16,16 @@ const log = config.processor.log ?? isEntry
 	? (message: string) => process.stderr.write(message)
 	: () => {};
 
-// Interrupt handler. Don't break the message loop on SIGINT — main exits the processor via a `shutdown` publish on the processor channel.
+// Interrupt handler. Standalone-only self-halt: under the launcher, main owns shutdown via the
+// processor channel, and breaking iterators here races its next-tick `process` publish.
+let halt: Effect | undefined;
 let halted = false as boolean;
+let processing = false;
 using _signal = handleInterruptSignal(() => {
 	halted = true;
+	if (isEntry && !processing) {
+		halt?.();
+	}
 });
 
 // Connect to main & storage
@@ -102,7 +109,7 @@ await Promise.all([
 	getServiceChannel(shard).publish({ type: 'processorInitialized' }),
 	async function() {
 		const messages = processorSubscription.iterable();
-		for await (const message of messages) {
+		for await (const message of Async.breakable(messages, breaker => halt = breaker)) {
 			if (message.type === 'shutdown' || halted) {
 				throw new Error('Processor initialization failure');
 			} else if (message.type === 'process') {
@@ -114,13 +121,14 @@ await Promise.all([
 ]);
 
 // Process messages
-loop: for await (const message of processorMessages) {
+loop: for await (const message of Async.breakable(processorMessages, breaker => halt = breaker)) {
 	switch (message.type) {
 		case 'shutdown':
 			break loop;
 
 		case 'process': {
 			const { time, roomNames } = message;
+			processing = true;
 
 			// Update checkAffinity flag on workers
 			let activations = function() {
@@ -170,6 +178,7 @@ loop: for await (const message of processorMessages) {
 					await worker.responder({ type: 'finalize', time });
 				}
 			}));
+			processing = false;
 			if (halted) {
 				// We check for interrupts at the end of tick
 				break loop;


### PR DESCRIPTION
## Summary

- Ctrl-C against the engine occasionally failed to shut down cleanly: most of the time it exited fine, but every few attempts it would hang at `Shutting down...` (or, depending on where the responder traffic landed, error out before exiting) instead of reaching `💾 Engine shut down successfully.`. The race lived in the idle gap between ticks — frequent enough to notice, rare enough to be annoying to reproduce.
- Root cause: the processor's SIGINT broadcast handler in `packages/xxscreeps/engine/service/processor.ts` set `halted = true` and called `halt?.()` (the breaker for the main message loop) whenever `processing` was false. When SIGINT landed after the previous `finalize` cleared `processing` and before the next `process` arrived, the loop broke and the pubsub subscription tore down. Main's next-tick `process` publish (and the recovery publish from `abandonIntentsForTick`) then landed on nothing, and main hung waiting for a `tickFinished` no one could produce.
- Main forwards `shutdown` on the processor channel after its own `while (true)` exits — that's the authoritative exit signal. Drop the `processing` flag and the `halt?.()` call from the SIGINT handler entirely; let main own loop teardown. Keep `halted = true` so the existing post-`finalize` `if (halted) break loop` still terminates promptly when SIGINT lands mid-tick.

## Validation

- `pnpm run build` — clean (pre-push hook).
- On `origin/main`: Ctrl-C against the launcher reliably fails to reach `💾 Engine shut down successfully.` within a handful of attempts.
- On this branch: Ctrl-C at varying points in the tick cycle consistently reaches `💾 Engine shut down successfully.` and exits cleanly.
