### PR TITLE
map: return 'closed' from getRoomStatus for off-world and inaccessible rooms

### DIFF
--- a/.changeset/get-room-status-vanilla-parity.md
+++ b/.changeset/get-room-status-vanilla-parity.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Return `{status:'closed', timestamp:null}` from `Game.map.getRoomStatus()` for off-world or inaccessible rooms.

--- a/packages/xxscreeps/backend/endpoints/assets/terrain.ts
+++ b/packages/xxscreeps/backend/endpoints/assets/terrain.ts
@@ -204,7 +204,7 @@ function register(paths: string[], fn: (shard: Shard, map: GameMap, room: string
 
 // Full thumbnail
 register([ '/assets/map/:room.png', '/assets/map/:shard/:room.png' ], async (shard, map, roomName) => {
-	if (map.getRoomStatus(roomName)) {
+	if (map.hasRoom(roomName)) {
 		return generate(map, [ [ await shard.loadRoom(roomName) ] ], 3);
 	} else {
 		return null;
@@ -224,7 +224,7 @@ for (const [ fragment, grid, align, zoom ] of [ [ 'zoom1', 10, 2, 0.4 ], [ 'zoom
 						Fn.range(left, left + grid),
 						async xx => {
 							const roomName = generateRoomName(xx, yy);
-							const room = map.getRoomStatus(roomName) ? await shard.loadRoom(roomName) : null;
+							const room = map.hasRoom(roomName) ? await shard.loadRoom(roomName) : null;
 							didFindRoom ||= room !== null;
 							return room;
 						}),

--- a/packages/xxscreeps/backend/endpoints/game/map-stats.ts
+++ b/packages/xxscreeps/backend/endpoints/game/map-stats.ts
@@ -31,7 +31,7 @@ export const MapStatsEndpoint: Endpoint = {
 		const userIds = new Set<string>();
 		const stats = Fn.fromEntries(Fn.filter(await Promise.all(Fn.map(roomNames, async roomName => {
 			// The client spams requests for rooms that don't exist
-			if (!context.backend.world.map.getRoomStatus(roomName)) {
+			if (!context.backend.world.map.hasRoom(roomName)) {
 				return;
 			}
 

--- a/packages/xxscreeps/backend/endpoints/user/world.ts
+++ b/packages/xxscreeps/backend/endpoints/user/world.ts
@@ -20,7 +20,7 @@ hooks.register('route', {
 		const { map } = context.backend.world;
 		if (userId) {
 			const lastRoom = await context.db.data.hGet(User.infoKey(userId), 'lastViewedRoom');
-			if (lastRoom !== null && map.getRoomStatus(lastRoom)) {
+			if (lastRoom !== null && map.hasRoom(lastRoom)) {
 				return {
 					ok: 1,
 					room: [ lastRoom ],

--- a/packages/xxscreeps/backend/sockets/room.ts
+++ b/packages/xxscreeps/backend/sockets/room.ts
@@ -121,7 +121,7 @@ export const roomSubscription: SubscriptionEndpoint = {
 		const { shard } = this.context;
 		const seenUsers = new Set<string>();
 		const roomName = parameters.room!;
-		if (!this.context.world.map.getRoomStatus(roomName)) {
+		if (!this.context.world.map.hasRoom(roomName)) {
 			return () => {};
 		}
 

--- a/packages/xxscreeps/engine/processor/room.ts
+++ b/packages/xxscreeps/engine/processor/room.ts
@@ -261,7 +261,7 @@ export class RoomProcessor implements ProcessorContext {
 	}
 
 	sendRoomIntent(roomName: string, intent: string, ...args: any[]) {
-		if (this.state.world.map.getRoomStatus(roomName)) {
+		if (this.state.world.map.hasRoom(roomName)) {
 			getOrSet(this.interRoomIntents, roomName, () => []).push({ intent, args });
 		}
 	}

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -36,10 +36,10 @@ type FindRoute = {
 	routeCallback?: (roomName: string, fromRoomName: string) => number;
 };
 
-type RoomStatus = RoomOutOfBorders | NormalRoom;
+type RoomStatus = ClosedRoom | NormalRoom;
 
-interface RoomOutOfBorders {
-	status: 'out of borders';
+interface ClosedRoom {
+	status: 'closed';
 	timestamp: number | null;
 }
 
@@ -230,14 +230,24 @@ export class GameMap {
 	 */
 	getRoomStatus(roomName: string): RoomStatus;
 	getRoomStatus(roomName: string): RoomStatus | undefined {
-		if (!this.#terrain.has(roomName)) {
+		if (!/^[WE]\d+[NS]\d+$/.test(roomName)) {
 			return;
+		}
+		if (!this.#terrain.has(roomName)) {
+			return { status: 'closed', timestamp: null };
 		}
 		// Callers without the active-rooms set (sandbox init, processor worker) see every terrain-backed room as `normal`.
 		if (this.#accessibleRooms !== undefined && !this.#accessibleRooms.has(roomName)) {
-			return { status: 'out of borders', timestamp: null };
+			return { status: 'closed', timestamp: null };
 		}
 		return { status: 'normal', timestamp: null };
+	}
+
+	/**
+	 * Returns true if `roomName` refers to a terrain-backed room known to this world.
+	 */
+	hasRoom(roomName: string) {
+		return this.#terrain.has(roomName);
 	}
 
 	/**

--- a/packages/xxscreeps/mods/observer/observer.ts
+++ b/packages/xxscreeps/mods/observer/observer.ts
@@ -48,7 +48,7 @@ registerBuildableStructure(C.STRUCTURE_OBSERVER, {
 //
 // Intent checks
 function checkObserveRoomName(target: string) {
-	return Game.map.getRoomStatus(target) ? C.OK : C.ERR_INVALID_ARGS;
+	return Game.map.hasRoom(target) ? C.OK : C.ERR_INVALID_ARGS;
 }
 
 function checkObserveRoomRange(observer: StructureObserver, target: string) {


### PR DESCRIPTION
## Summary

- `Game.map.getRoomStatus()` diverged from vanilla in two places
  (`packages/xxscreeps/game/map.ts`): off-world room names returned
  `undefined` (vanilla returns `{status:'closed', timestamp:null}`),
  and inaccessible rooms (terrain present, not in the active-rooms
  set) returned a made-up `'out of borders'` status (vanilla returns
  `'closed'`).
- Add a vanilla-style `^[WE]\d+[NS]\d+$` format check (invalid names
  still return `undefined`), and collapse the off-world and
  inaccessible cases to `{status:'closed', timestamp:null}`. Drop the
  `'out of borders'` literal from the `RoomStatus` type union.
- Six internal callers were using `if (map.getRoomStatus(x))` as a
  "has terrain" gate (backend room subscription, map-stats, terrain
  thumbnails, last-viewed-room start, inter-room intent routing,
  `observer.observeRoom`). After the parity fix off-world names would
  have flipped truthy and routed those callers to load nonexistent
  rooms. Introduce `GameMap.hasRoom(name)` (wraps the private terrain
  map) and point all six call sites at it so their existing gate
  semantics are preserved.
- `observer.observeRoom` retains the existing xxscreeps-specific
  defensive rejection of off-world targets (locked in by the
  `observer_nonexistent_room` unit test); only
  `Game.map.getRoomStatus()`'s return value changes shape.

## Validation

- `pnpm run build` — clean.
- `npx eslint` on the seven changed files — zero new warnings.
- `npx xxscreeps test` — 373/373 passed, including the
  `Observer observer_nonexistent_room` regression-defense test that
  asserts `observeRoom` to an off-world target returns
  `ERR_INVALID_ARGS`.
- screeps-ok suite against this branch:
  - `MAP-ROOM-004:normal` — `getRoomStatus` returns
    `{status:'normal', timestamp:null}` for an in-world room with no
    admin status set. Passes on xxscreeps and vanilla.
  - `MAP-ROOM-004:offWorld` — `getRoomStatus` returns
    `{status:'closed', timestamp:null}` for a valid-format room name
    that does not exist on the world. Was returning `undefined` on
    xxscreeps before this PR; now passes on xxscreeps and vanilla.
  - `MAP-ROOM-004:adminClosed` — `getRoomStatus` returns
    `{status:'closed', timestamp:<number>}` for an admin-closed
    in-world room. Passes on vanilla; skipped on xxscreeps via
    `shard.requires('roomStatus')` because xxscreeps has no admin
    room-status storage yet.