### PR TITLE
service: add serviceInitialized and afterTick mod hooks

### DIFF
--- a/packages/xxscreeps/config/mods/index.ts
+++ b/packages/xxscreeps/config/mods/index.ts
@@ -8,7 +8,7 @@ import { defaultAsyncFileSystem } from '@loaderkit/resolve/fs';
 import { configDefaults } from 'xxscreeps/config/config.js';
 import config from 'xxscreeps/config/raw.js';
 
-type Provide = 'backend' | 'config' | 'constants' | 'driver' | 'game' | 'processor' | 'storage' | 'test';
+type Provide = 'backend' | 'config' | 'constants' | 'driver' | 'game' | 'processor' | 'service' | 'storage' | 'test';
 export type Manifest = {
 	dependencies?: string[];
 	provides: Provide | Provide[] | null;

--- a/packages/xxscreeps/engine/service/main.ts
+++ b/packages/xxscreeps/engine/service/main.ts
@@ -1,4 +1,5 @@
 import config from 'xxscreeps/config/index.js';
+import { importMods } from 'xxscreeps/config/mods/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
 import { Mutex } from 'xxscreeps/engine/db/mutex.js';
 import { abandonIntentsForTick, activeRoomsKey, begetRoomProcessQueue, getProcessorChannel } from 'xxscreeps/engine/processor/model.js';
@@ -10,8 +11,10 @@ import { AveragingTimer } from 'xxscreeps/utility/averaging-timer.js';
 import { acquireTimeout } from 'xxscreeps/utility/utility.js';
 import { tickSpeed, watch } from './tick.js';
 import { checkIsEntry, getServiceChannel } from './index.js';
+import { hooks } from './symbols.js';
 
 checkIsEntry();
+await importMods('service');
 
 using db = await Database.connect();
 using shard = await Shard.connect(db, config.shards[0]!.name);
@@ -36,6 +39,10 @@ await watch(() => {
 	console.log(`Tick speed changed to ${tickSpeed}ms`);
 	tickDelay?.(true);
 });
+
+// Hook invocators (handlers are locked in at first call, after importMods above)
+const invokeServiceInitialized = hooks.makeMapped('serviceInitialized');
+const invokeAfterTick = hooks.makeMapped('afterTick');
 
 // Bookkeeping
 const performanceTimer = new AveragingTimer(100);
@@ -126,6 +133,14 @@ async function tick() {
 
 // Main loop
 if (didInitialize) {
+	// Notify mods that the service is ready; collect and register cleanup effects
+	const effects = await Promise.all([ ...invokeServiceInitialized(shard) ]);
+	for (const effect of effects) {
+		if (effect) {
+			disposable.defer(effect);
+		}
+	}
+
 	// Watch for shutdown and halt tick delay
 	disposable.defer(serviceChannel.listen(message => {
 		if (message.type === 'shutdown') {
@@ -144,6 +159,8 @@ if (didInitialize) {
 		const timeTaken = now - tickWallTime;
 		const averageTime = Math.floor(performanceTimer.stop() / 10000) / 100;
 		console.log(`Tick ${shard.time} ran in ${timeTaken}ms; avg: ${averageTime}ms`);
+
+		mustNotReject(Promise.all([ ...invokeAfterTick({ shard, timeTaken, averageTime }) ]));
 
 		// Maybe save
 		if (lastSave + saveInterval < now) {

--- a/packages/xxscreeps/engine/service/symbols.ts
+++ b/packages/xxscreeps/engine/service/symbols.ts
@@ -1,0 +1,16 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { Effect, MaybePromise } from 'xxscreeps/utility/types.js';
+import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
+
+export const hooks = makeHookRegistration<{
+	/**
+	 * Called once after the main service is initialized and ready to start ticking.
+	 * Return an Effect to register a cleanup that runs on shutdown.
+	 */
+	serviceInitialized: (shard: Shard) => MaybePromise<Effect | void>;
+
+	/**
+	 * Called after each game tick completes, with wall-clock timing.
+	 */
+	afterTick: (context: { shard: Shard; timeTaken: number; averageTime: number }) => MaybePromise<void>;
+}>();


### PR DESCRIPTION
Adds a 'service' mod context loaded via importMods at startup, alongside the existing 'driver', 'backend', and 'processor' contexts.

Two hooks are defined in engine/service/symbols.ts:

- serviceInitialized(shard): called once when the main loop is ready; returning an Effect registers a cleanup to run on shutdown
- afterTick({ shard, timeTaken, averageTime }): called after every tick

This allows mods to observe tick timing and register background tasks without modifying core engine code.