### PR TITLE
auth: allow login with email address in addition to username

### DIFF
--- a/.changeset/auth-email-login-lookup.md
+++ b/.changeset/auth-email-login-lookup.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Allow signing in with an email address instead of only a username for form auth and HTTP Basic auth.

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -34,6 +34,13 @@ async function setPassword(db: Database, userId: string, password: string) {
 	}));
 }
 
+async function findUserByUsernameOrEmail(db: Database, value: string) {
+	if (value.includes('@')) {
+		return findUserByProvider(db, 'email', value);
+	}
+	return findUserByName(db, value);
+}
+
 // HTTP Basic Auth
 hooks.register('middleware', koa => {
 	koa.use(async (context, next): Promise<unknown> => {
@@ -43,7 +50,7 @@ hooks.register('middleware', koa => {
 			const colon = auth.indexOf(':');
 			const username = auth.substr(0, colon);
 			const password = auth.substr(colon + 1);
-			const userId = await findUserByName(context.db, username) ?? await findUserByProvider(context.db, 'email', username);
+			const userId = await findUserByUsernameOrEmail(context.db, username);
 			if (userId !== null && await checkPassword(context.db, userId, password)) {
 				context.state.userId = userId;
 			}
@@ -73,7 +80,7 @@ hooks.register('route', {
 
 	execute: makeValidatedPayloadRoute(signinRequestSchema, async context => {
 		const { email, password } = context.request.body;
-		const userId = await findUserByName(context.db, email) ?? await findUserByProvider(context.db, 'email', email);
+		const userId = await findUserByUsernameOrEmail(context.db, email);
 		if (userId !== null) {
 			if (await checkPassword(context.db, userId, password)) {
 				context.state.userId = userId;

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -5,7 +5,7 @@ import { JSONSchemaType } from 'ajv';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import config from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
-import { findUserByName, infoKey } from 'xxscreeps/engine/db/user/index.js';
+import { findUserByName, findUserByProvider, infoKey } from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 
 const { allowEmailRegistration } = config.backend;
@@ -43,7 +43,7 @@ hooks.register('middleware', koa => {
 			const colon = auth.indexOf(':');
 			const username = auth.substr(0, colon);
 			const password = auth.substr(colon + 1);
-			const userId = await findUserByName(context.db, username);
+			const userId = await findUserByName(context.db, username) ?? await findUserByProvider(context.db, 'email', username);
 			if (userId !== null && await checkPassword(context.db, userId, password)) {
 				context.state.userId = userId;
 			}
@@ -73,7 +73,7 @@ hooks.register('route', {
 
 	execute: makeValidatedPayloadRoute(signinRequestSchema, async context => {
 		const { email, password } = context.request.body;
-		const userId = await findUserByName(context.db, email);
+		const userId = await findUserByName(context.db, email) ?? await findUserByProvider(context.db, 'email', email);
 		if (userId !== null) {
 			if (await checkPassword(context.db, userId, password)) {
 				context.state.userId = userId;


### PR DESCRIPTION
Both the form signin endpoint and HTTP Basic Auth middleware now fall back to an email provider lookup when no user is found by username.

This is to be in sync with the usual private server and the official client that allows login by email or username.