### PR TITLE
fix(spawn): correct regex group name in gen-unique-object-name

### DIFF
--- a/packages/xxscreeps/mods/spawn/backend.ts
+++ b/packages/xxscreeps/mods/spawn/backend.ts
@@ -100,7 +100,7 @@ hooks.register('route', {
 				room.find(C.FIND_CONSTRUCTION_SITES),
 			])) {
 				if (structure.structureType === 'spawn' && structure['#user'] === userId) {
-					const number = Number(/^Spawn(?<count>[0-9]+)$/.exec(structure.name)?.groups?.number);
+					const number = Number(/^Spawn(?<count>[0-9]+)$/.exec(structure.name)?.groups?.count);
 					if (number > max) {
 						max = number;
 					}


### PR DESCRIPTION
The regex used a named group 'count', but the code accessed 'groups.number'. This always returned undefined/NaN, so max stayed 0 and every generated spawn name was 'Spawn1' regardless of existing spawns.