### PR TITLE
Fix nuke flight crashing the room processor

### DIFF
--- a/.changeset/nuker-flight-wake-time.md
+++ b/.changeset/nuker-flight-wake-time.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix in-flight nukes crashing the room processor with an invalid scheduler wake time.

--- a/packages/xxscreeps/mods/nuker/processor.ts
+++ b/packages/xxscreeps/mods/nuker/processor.ts
@@ -63,7 +63,7 @@ registerObjectTickProcessor(Nuke, (nuke, context) => {
 	// player to observe; removal happens on the following tick.
 	const { timeToLand } = nuke;
 	if (timeToLand > 0) {
-		context.wakeAt(timeToLand - 1);
+		context.wakeAt(nuke['#landTime']);
 	} else if (timeToLand === 0) {
 		applyNukeImpact(nuke);
 		context.setActive();


### PR DESCRIPTION
The in-flight `Nuke` tick branch passed the relative `timeToLand - 1`
duration to `context.wakeAt`, which expects an absolute game tick and throws
`Invalid wake time` once `Game.time` exceeds it — i.e. on every real server
(`Game.time > ~NUKE_LAND_TIME`). The nuke never resolves: impact is never
applied and the object is never removed.

Wake at the absolute `#landTime` instead, matching every other processor's
`wakeAt(obj['#…Time'])` call. The two-tick lifecycle (impact at
`timeToLand === 0`, removal at `-1`) is unchanged.

Introduced by 5715ec7, which refactored the absolute-`landTime` scheduling
into the relative-`timeToLand` form.

## Validation
- `xxscreeps test Nuker` green.
- Verified against screeps-ok: `NUKE-FLIGHT-005` (landed nuke removed from
  `FIND_NUKES`) and `RAMPART-PROTECT-008` (rampart-first nuke damage on a shared
  tile) throw `Invalid wake time` on the pre-fix engine and pass with this change.
