### PR TITLE
map: fix getRoomStatus returning 'closed' for every room

### DIFF
--- a/.changeset/get-room-status-accessible-rooms.md
+++ b/.changeset/get-room-status-accessible-rooms.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `Game.map.getRoomStatus` returning `closed` for every room.

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -63,7 +63,7 @@ export class GameMap {
 
 	constructor(terrain: TerrainByRoom, accessibleRooms?: ReadonlySet<string>) {
 		this.#terrain = terrain;
-		this.#accessibleRooms = accessibleRooms ?? new Set(Object.keys(terrain));
+		this.#accessibleRooms = accessibleRooms ?? new Set(terrain.keys());
 		let maxX = -Infinity;
 		let minX = Infinity;
 		let maxY = -Infinity;


### PR DESCRIPTION
## Summary

`Game.map.getRoomStatus(roomName)` returns `{ status: 'closed', timestamp: null }`
for every room in the player sandbox and processor worker.

The `GameMap` constructor defaults its accessible-rooms set to
`accessibleRooms ?? new Set(Object.keys(terrain))`. `terrain` is a `Map` (the
`World` schema's `compose` returns `new Map(...)`), so `Object.keys(terrain)` is
`[]` — any `World` built without an explicit `accessibleRooms` (the sandbox in
`driver/runtime/index.ts`, the processor worker in `engine/processor/worker.ts`)
gets an empty set and every room falls through to `closed`.

Seed the default from `terrain.keys()` instead. `shard.loadWorld()` passes an
explicit `new Set(rooms)` and is unaffected; the internal `getRoomStatus(name, true)`
callers (observer, room processor) fall through to the terrain check regardless of
the set, so only the player-facing no-arg path changes. Regression from 2cf66aaf.

## Validation

- `tsc -b` clean; `npx xxscreeps test` — 379/379.
- Verified against screeps-ok — `Game.map.getRoomStatus` parity in `tests/21-map/21.1-room-queries.test.ts`:
  - `MAP-ROOM-004:normal` — in-world room with no admin status → `{status:'normal', timestamp:null}` (the regression this PR fixes)
  - `MAP-ROOM-004:offWorld` — valid-format room not on the world → `{status:'closed', timestamp:null}` (must stay closed; unchanged by the fix)
  - `MAP-ROOM-004:invalid` — invalid-format room name → `undefined`
- The remaining `MAP-ROOM-004` branches (`adminClosed`, `novice`, `respawn`) are capability-skipped on xxscreeps, which does not model admin/novice/respawn room-status data.
