### PR TITLE
pf: treat CostMatrix value 255 as impassable

### DIFF
--- a/.changeset/pathfinder-cost-matrix-255-impassable.md
+++ b/.changeset/pathfinder-cost-matrix-255-impassable.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Treat a CostMatrix value of 255 as an impassable obstacle.

--- a/packages/pathfinder/src/pf.h.cc
+++ b/packages/pathfinder/src/pf.h.cc
@@ -11,7 +11,6 @@ namespace screeps {
 
 constexpr auto k_room_size = 50 * 50;
 constexpr auto map_position_size = 1 << sizeof(room_location_t) * 8;
-constexpr auto obstacle = cost_t{0};
 constexpr auto sentinel_pos_index = pos_index_t{std::numeric_limits<pos_index_t::value_type>::max()};
 
 // Params for `search`

--- a/packages/pathfinder/src/room.cc
+++ b/packages/pathfinder/src/room.cc
@@ -19,6 +19,8 @@ export using terrain_type = const std::uint8_t*;
 // maximum: longest chebyshev distance of whole map
 using cost_t = int;
 
+constexpr auto obstacle = cost_t{0};
+
 // Table of terrain costs [ plain, swamp, wall, [??] ]
 using terrain_cost_type = std::array<cost_t, 4>;
 
@@ -68,6 +70,7 @@ struct room_terrain {
 		[[nodiscard]] constexpr auto cost_matrix_look(const terrain_cost_type& costs, unsigned xx, unsigned yy) const -> cost_t {
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 			int cost = cost_matrix_[ xx % 50 ][ yy % 50 ];
+			if (cost == 0xff) return obstacle;
 			return cost == 0 ? terrain_look(costs, xx, yy) : cost;
 		}
 


### PR DESCRIPTION
The rewrite of `cost_matrix_look` dropped the `0xff` → impassable case, so a
CostMatrix value of 255 reads as a finite cost of 255 instead of blocking. The
search walks through walled-off tiles and `findClosestByPath` treats them as
reachable. Terrain walls still block (their `look_table_` slot is `obstacle`),
so it went unnoticed.

`obstacle` moves to `:room` because `room.cc` now references it and `:room`
can't import `:pf`.

## Validation

Verified against screeps-ok:
- COSTMATRIX-007 — CostMatrix 255 is unwalkable
- PATHFINDER-012 — `search` returns `incomplete` with a partial path when blocked
- ROOMPOS-FIND-007 — `findClosestByPath` returns null for an unreachable target
