### PR TITLE
cli: remove CommonJS host shims from the eval console

### DIFF
--- a/.changeset/cli-remove-cjs-shims.md
+++ b/.changeset/cli-remove-cjs-shims.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Remove CommonJS `require`/`__filename`/`__dirname` shims from the eval console.

--- a/packages/xxscreeps/cli/README.md
+++ b/packages/xxscreeps/cli/README.md
@@ -30,10 +30,9 @@ One-shot evaluator. Source comes from exactly one of `-e/--expression`, `--file`
 
 ## Realm
 
-Operator code runs in the CLI process's host realm. `process`, `require`, dynamic `import()`,
-`Buffer`, `__dirname`, `__filename`, every node built-in, and every npm dependency the launcher
-loads are all reachable. Operators already have shell access to the same machine — the prompt isn't
-a security boundary.
+Operator code runs in the CLI process's host realm. `process`, dynamic `import()`, `Buffer`, every
+node built-in, and every npm dependency the launcher loads are all reachable. Operators already have
+shell access to the same machine — the prompt isn't a security boundary.
 
 `argv` (eval only) is exposed as a global populated from trailing positionals.
 

--- a/packages/xxscreeps/cli/cli.ts
+++ b/packages/xxscreeps/cli/cli.ts
@@ -1,7 +1,6 @@
 import type * as vm from 'node:vm';
 import * as repl from 'node:repl';
 import { ArgumentParser } from 'argparse';
-import { installHostShims } from './eval-offline.js';
 import { makeUnsafeGlobalEvaluator } from './unsafe.js';
 
 const parser = new ArgumentParser({
@@ -9,8 +8,6 @@ const parser = new ArgumentParser({
 	prog: 'xxscreeps cli',
 });
 parser.parse_args();
-
-installHostShims();
 
 function customEval(
 	cmd: string,

--- a/packages/xxscreeps/cli/eval-offline.ts
+++ b/packages/xxscreeps/cli/eval-offline.ts
@@ -1,19 +1,7 @@
-import { createRequire } from 'node:module';
-import * as path from 'node:path';
 import * as util from 'node:util';
 import { evaluateUnsafeGlobal } from './unsafe.js';
 
-export function installHostShims(): void {
-	const globals = globalThis as Record<string, unknown>;
-	const cwd = process.cwd();
-	const syntheticFile = path.join(cwd, '[eval]');
-	globals.require ??= createRequire(syntheticFile);
-	globals.__filename ??= syntheticFile;
-	globals.__dirname ??= cwd;
-}
-
 function shareGlobals(argv: readonly string[]) {
-	installHostShims();
 	const globals = globalThis as Record<string, unknown>;
 	const previousConsole = globals.console;
 	const hadArgv = 'argv' in globals;


### PR DESCRIPTION
`installHostShims` put `require`, `__filename`, and `__dirname` on `globalThis` for the eval/REPL console — CommonJS globals salvaged from the closed #227. Per review they aren't needed: the eval surface is ESM-only (`SourceTextModule` + dynamic `import()`, static `import` rejected), so `require` was never load-bearing and `import.meta.url` covers the path globals.

This removes them from both the one-shot eval path and the REPL. Nothing is installed, so nothing leaks — the Disposable restoration from this PR's prior revision is gone too. README realm note updated to match.

## Validation

- Confirmed nothing in `cli/` or the eval engine references the three globals (grep); the ESM `import()` loading path is untouched.
- `tsc -b` clean; eslint over the changed files: no new warnings.