### PR TITLE
user: add User.remove and a user-management script

### DIFF
--- a/.changeset/user-remove-management-script.md
+++ b/.changeset/user-remove-management-script.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `User.remove` and an operator script for listing, creating, and removing users.

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { branchManifestKey, buffersKey, stringsKey } from './code.js';
 
 const providerMembersKey = (provider: string) => `usersByProvider/${provider}`;
 const userProvidersKey = (userId: string) => `user/${userId}/provider`;
@@ -50,6 +51,29 @@ export async function create(db: Database, userId: string, username: string, pro
 			[ ...Fn.map(allProviders, ({ provider, id }): [ string, string ] => [ provider, id ]) ]),
 		...Fn.map(allProviders, ({ provider, id }) =>
 			db.data.hSet(providerMembersKey(provider), id, userId)),
+	]);
+}
+
+/**
+ * Deletes a user's database records: lookup entries, info, and code. Room objects owned by the
+ * user are unaffected.
+ */
+export async function remove(db: Database, userId: string) {
+	const [ providers, branches ] = await Promise.all([
+		findProvidersForUser(db, userId),
+		db.data.sMembers(branchManifestKey(userId)),
+	]);
+	await Promise.all([
+		db.data.sRem('users', [ userId ]),
+		db.data.del(infoKey(userId)),
+		db.data.del(userProvidersKey(userId)),
+		db.data.del(branchManifestKey(userId)),
+		...Fn.map(Object.entries(providers), ([ provider, providerId ]) =>
+			db.data.hDel(providerMembersKey(provider), [ providerId ])),
+		...Fn.transform(branches, branchName => [
+			db.data.vdel(buffersKey(userId, branchName)),
+			db.data.vdel(stringsKey(userId, branchName)),
+		]),
 	]);
 }
 

--- a/packages/xxscreeps/engine/db/user/test.ts
+++ b/packages/xxscreeps/engine/db/user/test.ts
@@ -1,0 +1,14 @@
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import * as User from './index.js';
+
+describe('User.remove', () => {
+	test('removed user is no longer found', async () => {
+		using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '200', 'RemoveMe', [ { provider: 'email', id: 'remove@me.test' } ]);
+		await User.remove(db, '200');
+		assert.strictEqual(await User.findUserByName(db, 'RemoveMe'), null);
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'remove@me.test'), null);
+	});
+});

--- a/packages/xxscreeps/mods/memory/model.ts
+++ b/packages/xxscreeps/mods/memory/model.ts
@@ -42,6 +42,10 @@ export function saveMemoryBlob(shard: Shard, userId: string, blob: Readonly<Uint
 	}
 }
 
+export function deleteUserMemoryBlob(shard: Shard, userId: string) {
+	return shard.data.vdel(`user/${userId}/memory`);
+}
+
 export function loadMemorySegmentBlob(shard: Shard, userId: string, segmentId: number) {
 	return shard.data.get(`user/${userId}/segment${segmentId}`, { blob: true });
 }

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -1,0 +1,116 @@
+// Ops tool for managing users on a self-hosted xxscreeps server — connects to the configured
+// storage provider directly, like scripts/scrape-world.ts. Run after `tsc -b`:
+// `node packages/xxscreeps/dist/scripts/manage.js user <verb> ...` (usage() lists commands).
+//
+// The running engine caches state: list/show/create read storage per request, but a new user isn't
+// processed until it owns an object in a room. `remove` deletes records only — owned room objects
+// are left alone — and is safe for inactive users; pause the engine first if the user is live.
+
+import { config } from 'xxscreeps/config/index.js';
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import * as Code from 'xxscreeps/engine/db/user/code.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import * as Id from 'xxscreeps/engine/schema/id.js';
+import { primitiveComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { deleteUserMemoryBlob, loadUserMemoryBlob } from 'xxscreeps/mods/memory/model.js';
+
+using db = await Database.connect();
+using shard = await Shard.connect(db, config.shards[0]!.name);
+
+const out = (line: string) => process.stdout.write(`${line}\n`);
+const save = () => Promise.all([ db.save(), shard.save() ]);
+
+// Accepts either a raw user id or a username.
+async function resolveUserId(who: string) {
+	if (await db.data.sIsMember('users', who)) {
+		return who;
+	}
+	const byName = await User.findUserByName(db, who);
+	if (byName !== null) {
+		return byName;
+	}
+	throw new Error(`No such user: ${who}`);
+}
+
+async function userList() {
+	const ids = await db.data.sMembers('users');
+	if (ids.length === 0) {
+		out('(no users)');
+		return;
+	}
+	const idWidth = Math.max(...Fn.map(ids, id => id.length));
+	const rows = await Fn.mapAwait(ids.sort(primitiveComparator), async id => {
+		const info = await db.data.hmGet(User.infoKey(id), [ 'username', 'branch' ]);
+		return `${id.padEnd(idWidth)}  ${(info.username ?? '?').padEnd(20)}  ${info.branch ?? '(none)'}`;
+	});
+	out(`${'id'.padEnd(idWidth)}  ${'username'.padEnd(20)}  branch`);
+	for (const row of rows) {
+		out(row);
+	}
+}
+
+async function userShow(who: string) {
+	const id = await resolveUserId(who);
+	const [ info, providers, branches, memory ] = await Promise.all([
+		db.data.hGetAll(User.infoKey(id)),
+		User.findProvidersForUser(db, id),
+		db.data.sMembers(Code.branchManifestKey(id)),
+		loadUserMemoryBlob(shard, id),
+	]);
+	const providerList = Object.entries(providers).map(([ provider, value ]) => `${provider}=${value}`);
+	out(`id            ${id}`);
+	out(`username      ${info.username ?? '?'}`);
+	out(`active branch ${info.branch ?? '(none)'}`);
+	if (info.registeredDate !== undefined) {
+		out(`registered    ${new Date(Number(info.registeredDate)).toISOString()}`);
+	}
+	out(`badge         ${info.badge === undefined ? 'none' : 'set'}`);
+	out(`providers     ${providerList.length > 0 ? providerList.join(', ') : '(none)'}`);
+	out(`code branches ${branches.length > 0 ? branches.join(', ') : '(none)'}`);
+	out(`memory        ${memory === null ? 'none' : `${memory.length} bytes`}`);
+}
+
+async function userCreate(name: string, email?: string) {
+	if (!User.checkUsername(name)) {
+		throw new Error(`Invalid username: ${name}`);
+	}
+	const id = Id.generateId(12);
+	await User.create(db, id, name, email === undefined ? [] : [ { provider: 'email', id: email } ]);
+	await save();
+	out(`Created user ${name} (${id}).`);
+}
+
+async function userRemove(who: string) {
+	const id = await resolveUserId(who);
+	await Promise.all([
+		User.remove(db, id),
+		deleteUserMemoryBlob(shard, id),
+	]);
+	await save();
+	out(`Removed user ${who} (${id}).`);
+}
+
+function usage(): never {
+	process.stderr.write(`Usage:
+  user list
+  user show   <name|id>
+  user create <name> [email]
+  user remove <name|id>
+`);
+	process.exit(2);
+}
+
+const [ noun, verb, ...rest ] = process.argv.slice(2);
+try {
+	switch (`${noun} ${verb}`) {
+		case 'user list': await userList(); break;
+		case 'user show': if (rest[0] === undefined) usage(); await userShow(rest[0]); break;
+		case 'user create': if (rest[0] === undefined) usage(); await userCreate(rest[0], rest[1]); break;
+		case 'user remove': if (rest[0] === undefined) usage(); await userRemove(rest[0]); break;
+		default: usage();
+	}
+} catch (err) {
+	process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+	process.exitCode = 1;
+}

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -3,6 +3,7 @@ import './import.js';
 import 'xxscreeps:mods/driver';
 
 await import('xxscreeps/engine/db/storage/local/test.js');
+await import('xxscreeps/engine/db/user/test.js');
 await import('xxscreeps/game/test.js');
 await import('xxscreeps:mods/test');
 await import('xxscreeps/cli/test.js');


### PR DESCRIPTION
## Summary

Server operators have no way to manage users — the engine has no user-deletion
path anywhere, so removing a stale account means hand-editing storage.

- `User.remove(db, userId)` in `engine/db/user/index.ts`, next to `create`:
  deletes the `users` set entry, the info hash, the user→providers hash, the
  per-provider member entries, and the code records (branch manifest plus
  per-branch buffer/string blobs). Records only — room objects owned by the
  user are deliberately untouched.
- `deleteUserMemoryBlob(shard, userId)` exported from `mods/memory/model.ts`
  next to the existing load/save pair; the memory key belongs to the mod, so
  the engine primitive doesn't reach into it.
- `scripts/manage.ts`: an operator tool following the `scrape-world.ts`
  precedent (connects to configured storage directly, runs after `tsc -b`)
  with four verbs: `user list`, `user show <name|id>`,
  `user create <name> [email]`, `user remove <name|id>`.

A follow-up extends manage.ts with bot code management (registering a bot
user and uploading its code from a directory).

## Validation

- `tsc -b` clean; `npx xxscreeps test` — 399/399, including a new behavioral
  test for `User.remove` (create → remove → `findUserByName`/`findUserByProvider`
  return null), revert-verified. eslint over changed files: no new warnings.
- Exercised all four verbs against a live redis-backed server: created a user,
  seeded it with code on two branches and a memory blob, removed it, and
  scanned both the database and shard keyspaces for residue — no keys remain.
