### PR TITLE
Throw on intent save when the receiver no longer exists

### DIFF
--- a/.changeset/intent-save-missing-receiver.md
+++ b/.changeset/intent-save-missing-receiver.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Throw `Could not find an object` when saving an intent for a stale object reference

--- a/packages/xxscreeps/game/intents.ts
+++ b/packages/xxscreeps/game/intents.ts
@@ -3,6 +3,7 @@ import type { Room } from './room/index.js';
 import type { IntentParameters, IntentReceivers, IntentsForReceiver } from 'xxscreeps/engine/processor/index.js';
 import type { ObjectReceivers, RoomIntentPayload } from 'xxscreeps/engine/processor/room.js';
 import type { Dictionary } from 'xxscreeps/utility/types.js';
+import * as BufferObject from 'xxscreeps/schema/buffer-object.js';
 import * as C from './constants/index.js';
 
 const kCpuCost = 0.2;
@@ -47,6 +48,9 @@ export class IntentManager {
 		Action extends IntentsForReceiver<any>,
 		//Action extends IntentsForReceiver<Receiver>,
 	>(receiver: Receiver, intent: Action, ...args: IntentParameters<Receiver, Action>) {
+		if (!BufferObject.check(receiver)) {
+			throw new Error(`Could not find an object with ID ${receiver.id}`);
+		}
 		const intents = this.makeIntentsForRoom(receiver.room.name).object[receiver.id] ??= {};
 		if (intents[intent as keyof typeof intents] === undefined) {
 			this.cpu += kCpuCost;


### PR DESCRIPTION
Fixes #205.

`IntentManager.save` now throws `Could not find an object with ID <id>` when `BufferObject.check(receiver)` is false — i.e. the wrapper's buffer was released at end of tick. That catches stale wrappers which pass a method's validation through memoized fields and act on a dead receiver, the confirmed case being a `ConstructionSite.remove()` cached across ticks that re-enqueued `remove` and returned `OK` after the site was gone.

## Validation

- Confirmed `remove()` on a wrapper whose room buffer was detached (as end-of-tick does) throws `Could not find an object with ID <id>`.
- Full xxscreeps suite: 399 passed.
