### PR TITLE
Add StructureInvaderCore NPC actions

### DIFF
--- a/.changeset/invader-core-npc-actions.md
+++ b/.changeset/invader-core-npc-actions.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": minor
+---
+
+Add `StructureInvaderCore` NPC actions, collapse expiry, action log, and invulnerable rangedMassAttack skip.

--- a/.changeset/invader-core-npc-actions.md
+++ b/.changeset/invader-core-npc-actions.md
@@ -2,4 +2,4 @@
 "xxscreeps": minor
 ---
 
-Add `StructureInvaderCore` NPC actions, collapse expiry, action log, and invulnerable rangedMassAttack skip.
+Add `StructureInvaderCore` NPC actions, deploy/collapse expiry, action log, and invulnerable rangedMassAttack skip.

--- a/packages/xxscreeps/mods/combat/processor.ts
+++ b/packages/xxscreeps/mods/combat/processor.ts
@@ -80,6 +80,10 @@ const intents = [
 					$$ => [ ...$$ ],
 					$$ => $$.sort(mappedComparator(invertedNumericComparator, object => object['#layer']!)));
 				walkLayers(objects, power, (object, layerPower) => {
+					// Invulnerable targets pass full power through to lower layers and emit no event.
+					if (object['#invulnerable']) {
+						return layerPower;
+					}
 					const remaining = object['#captureDamage'](layerPower, C.EVENT_ATTACK_TYPE_RANGED_MASS, creep);
 					const absorbed = layerPower - remaining;
 					if (absorbed === 0) {

--- a/packages/xxscreeps/mods/controller/controller.ts
+++ b/packages/xxscreeps/mods/controller/controller.ts
@@ -1,3 +1,4 @@
+import type { RoomObjectEffect } from 'xxscreeps/game/object.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
@@ -16,6 +17,7 @@ const shape = struct(ownedStructureFormat, {
 	'#reservationEndTime': 'int32',
 	'#safeModeCooldownTime': 'int32',
 	'#upgradeBlockedUntil': 'int32',
+	'#upgradeInvulnerableUntil': 'int32',
 });
 
 export class StructureController extends withOverlay(OwnedStructure, shape) {
@@ -55,6 +57,11 @@ export class StructureController extends withOverlay(OwnedStructure, shape) {
 		} : undefined;
 		Object.defineProperty(this, 'sign', { value });
 		return value;
+	}
+
+	@enumerable override get effects(): RoomObjectEffect[] | undefined {
+		const ticksRemaining = optionalExpiryTime(Game, this['#upgradeInvulnerableUntil']);
+		return ticksRemaining === undefined ? undefined : [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining } ];
 	}
 
 	override get hits() { return undefined; }

--- a/packages/xxscreeps/mods/controller/processor.ts
+++ b/packages/xxscreeps/mods/controller/processor.ts
@@ -47,6 +47,15 @@ export function release(context: ProcessorContext, controller: StructureControll
 	context.didUpdate();
 }
 
+export function reserve(context: ProcessorContext, controller: StructureController, userId: string, endTime: number) {
+	if (controller['#reservationEndTime'] === 0) {
+		updateRoomStatus(controller.room, 0, userId);
+		context.task(context.shard.scratch.sAdd(reservedRoomKey(userId), [ controller.room.name ]));
+	}
+	controller['#reservationEndTime'] = endTime;
+	context.didUpdate();
+}
+
 /**
  * Update room owner and/or level, and notify all objects of the change
  */
@@ -145,24 +154,16 @@ const intents = [
 		if (CreepLib.checkReserveController(creep, controller) === C.OK) {
 			const power = creep.getActiveBodyparts(C.CLAIM) * C.CONTROLLER_RESERVE;
 			const reservationEndTime = controller['#reservationEndTime'];
-			if (reservationEndTime) {
-				controller['#reservationEndTime'] = Math.min(
-					Game.time + C.CONTROLLER_RESERVE_MAX,
-					reservationEndTime + power + 1,
-				);
-			} else {
-				const userId = creep['#user'];
-				controller['#reservationEndTime'] = Game.time + power + 1;
-				updateRoomStatus(controller.room, 0, userId);
-				context.task(context.shard.scratch.sAdd(reservedRoomKey(userId), [ controller.room.name ]));
-			}
+			const endTime = reservationEndTime
+				? Math.min(Game.time + C.CONTROLLER_RESERVE_MAX, reservationEndTime + power + 1)
+				: Game.time + power + 1;
+			reserve(context, controller, creep['#user'], endTime);
 			saveAction(creep, 'reserveController', controller.pos);
 			appendEventLog(controller.room, {
 				event: C.EVENT_RESERVE_CONTROLLER,
 				objectId: creep.id,
 				amount: power,
 			});
-			context.didUpdate();
 		}
 	}),
 

--- a/packages/xxscreeps/mods/invader/backend.ts
+++ b/packages/xxscreeps/mods/invader/backend.ts
@@ -1,14 +1,16 @@
 import type { JSONSchemaType } from 'ajv';
 import { bindRenderer, hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { renderActionLog } from 'xxscreeps/backend/sockets/render.js';
 import { pushIntentsForRoomNextTick } from 'xxscreeps/engine/processor/model.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { StructureInvaderCore } from './invader-core.js';
 
-bindRenderer(StructureInvaderCore, (core, next) => {
+bindRenderer(StructureInvaderCore, (core, next, previousTime) => {
 	const deployTime = core['#deployTime'];
 	return {
 		...next(),
+		...renderActionLog(core['#actionLog'], previousTime),
 		level: core.level,
 		...deployTime > 0 && {
 			deployTime,

--- a/packages/xxscreeps/mods/invader/index.ts
+++ b/packages/xxscreeps/mods/invader/index.ts
@@ -6,6 +6,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/controller',
 		'xxscreeps/mods/creep',
 		'xxscreeps/mods/defense',
+		'xxscreeps/mods/logistics',
 		'xxscreeps/mods/npc',
 	],
 	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],

--- a/packages/xxscreeps/mods/invader/index.ts
+++ b/packages/xxscreeps/mods/invader/index.ts
@@ -3,7 +3,9 @@ import type { Manifest } from 'xxscreeps/config/mods.js';
 export const manifest: Manifest = {
 	dependencies: [
 		'xxscreeps/mods/combat',
+		'xxscreeps/mods/controller',
 		'xxscreeps/mods/creep',
+		'xxscreeps/mods/defense',
 		'xxscreeps/mods/npc',
 	],
 	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -41,15 +41,8 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	@enumerable get spawning(): null { return null; }
 
 	@enumerable get ticksToDeploy(): number | undefined {
-		// `+ 1 - 1` like nuke's `timeToLand`: yields `0` on the final invulnerable tick
-		// (`Game.time === #deployTime`) and clamps to `undefined` from the tick after, so reads at
-		// `#deployTime + 1` don't throw before the processor zeroes the field.
 		const deployTime = this['#deployTime'];
-		if (deployTime === 0) {
-			return undefined;
-		}
-		const ticks = RoomObject.requiredExpiryTime(Game, deployTime + 1) - 1;
-		return ticks < 0 ? undefined : ticks;
+		return deployTime === 0 ? undefined : RoomObject.requiredExpiryTime(Game, deployTime + 1) - 1;
 	}
 
 	override get hitsMax(): number {
@@ -127,6 +120,8 @@ export function create(pos: RoomPosition, level: number, deployTime: number) {
 
 // Block invader-core intents whose source was destroyed earlier in the same intent pass,
 // before `#flushObjects` removes the core from the object map.
+// TODO: Intents check is not the place to do this. Also, do other objects in the game have the same
+// condition?
 const checkSourceAlive = (core: StructureInvaderCore) =>
 	core.hits > 0 ? undefined : C.ERR_INVALID_TARGET;
 

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -1,8 +1,13 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
+import { chainIntentChecks, checkSameRoom, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { Game, registerGlobal } from 'xxscreeps/game/index.js';
+import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
 import * as RoomObject from 'xxscreeps/game/object.js';
-import { OwnedStructure, ownedStructureFormat } from 'xxscreeps/mods/structure/structure.js';
+import { StructureController } from 'xxscreeps/mods/controller/controller.js';
+import { Creep } from 'xxscreeps/mods/creep/creep.js';
+import { StructureTower } from 'xxscreeps/mods/defense/tower.js';
+import { OwnedStructure, checkMyStructure, ownedStructureFormat } from 'xxscreeps/mods/structure/structure.js';
 import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 
@@ -11,6 +16,8 @@ const shape = struct(ownedStructureFormat, {
 	...variant('invaderCore'),
 	hits: 'int32',
 	level: 'int8',
+	'#actionLog': RoomObject.actionLogFormat,
+	'#collapseTime': 'int32',
 	'#deployTime': 'int32',
 });
 
@@ -21,8 +28,13 @@ const shape = struct(ownedStructureFormat, {
  */
 export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	@enumerable override get effects(): RoomObject.RoomObjectEffect[] | undefined {
-		const ticksRemaining = this.ticksToDeploy;
-		return ticksRemaining === undefined ? undefined : [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining } ];
+		const { ticksToDeploy } = this;
+		const ticksToCollapse = RoomObject.optionalExpiryTime(Game, this['#collapseTime']);
+		const effects = [
+			...ticksToDeploy === undefined ? [] : [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining: ticksToDeploy } ],
+			...ticksToCollapse === undefined ? [] : [ { effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining: ticksToCollapse } ],
+		];
+		return effects.length === 0 ? undefined : effects;
 	}
 
 	// TODO: stronghold spawning
@@ -43,11 +55,61 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 		return this.ticksToDeploy !== undefined;
 	}
 
+	/**
+	 * Block claim/reservation of the target controller.
+	 * @param target Neutral or invader-reserved controller in the same room.
+	 */
+	reserveController(target: StructureController) {
+		return chainIntentChecks(
+			() => checkMyStructure(this, StructureInvaderCore),
+			() => checkReserveController(this, target),
+			() => intents.save(this, 'reserveController', target.id));
+	}
+
+	/**
+	 * Reduce a hostile controller's downgrade/reservation timer.
+	 */
+	attackController(target: StructureController) {
+		return chainIntentChecks(
+			() => checkMyStructure(this, StructureInvaderCore),
+			() => checkAttackController(this, target),
+			() => intents.save(this, 'attackController', target.id));
+	}
+
+	/**
+	 * Reset the downgrade timer on a controller already owned by this NPC.
+	 */
+	upgradeController(target: StructureController) {
+		return chainIntentChecks(
+			() => checkMyStructure(this, StructureInvaderCore),
+			() => checkUpgradeController(this, target),
+			() => intents.save(this, 'upgradeController', target.id));
+	}
+
+	/**
+	 * Push energy into a tower or creep in the same room. `amount` defaults to the target's free
+	 * capacity for energy.
+	 */
+	transferEnergy(target: StructureTower | Creep, amount?: number) {
+		return chainIntentChecks(
+			() => checkMyStructure(this, StructureInvaderCore),
+			() => checkTransferEnergy(this, target, amount),
+			() => intents.save(this, 'transferEnergy', target.id,
+				amount ?? target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
+	}
+
 	override '#applyDamage'(power: number, type: number, source?: RoomObject.RoomObject) {
 		if (this['#invulnerable']) {
 			return;
 		}
 		super['#applyDamage'](power, type, source);
+	}
+
+	override '#beforeInsert'(room: Room) {
+		super['#beforeInsert'](room);
+		// Keep NPC '2' active in any room that hosts a core; inlined to avoid pulling the
+		// processor entry-point into the runtime sandbox.
+		room['#npcData'].users.add('2');
 	}
 }
 
@@ -59,6 +121,89 @@ export function create(pos: RoomPosition, level: number, deployTime: number) {
 	core['#user'] = '2';
 	core['#deployTime'] = deployTime;
 	return core;
+}
+
+// Block invader-core intents whose source was destroyed earlier in the same intent pass,
+// before `#flushObjects` removes the core from the object map.
+const checkSourceAlive = (core: StructureInvaderCore) =>
+	core.hits > 0 ? undefined : C.ERR_INVALID_TARGET;
+
+export function checkReserveController(core: StructureInvaderCore, target: StructureController) {
+	return chainIntentChecks(
+		() => checkSourceAlive(core),
+		() => checkTarget(target, StructureController),
+		() => checkSameRoom(core, target),
+		() => {
+			if (target.level > 0) {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (target['#reservationEndTime'] > Game.time && target.room['#user'] !== '2') {
+				return C.ERR_INVALID_TARGET;
+			}
+		});
+}
+
+export function checkAttackController(core: StructureInvaderCore, target: StructureController) {
+	return chainIntentChecks(
+		() => checkSourceAlive(core),
+		() => checkTarget(target, StructureController),
+		() => checkSameRoom(core, target),
+		() => {
+			const reserved = target['#reservationEndTime'] > Game.time;
+			const owned = target.level > 0;
+			if (!reserved && !owned) {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (owned && target['#user'] === '2') {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (reserved && target.room['#user'] === '2') {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (target.safeMode !== undefined && target['#user'] !== '2') {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (target.upgradeBlocked !== undefined) {
+				return C.ERR_TIRED;
+			}
+		});
+}
+
+export function checkUpgradeController(core: StructureInvaderCore, target: StructureController) {
+	return chainIntentChecks(
+		() => checkSourceAlive(core),
+		() => checkTarget(target, StructureController),
+		() => checkSameRoom(core, target),
+		() => {
+			if (target.level === 0 || target['#user'] !== '2') {
+				return C.ERR_NOT_OWNER;
+			}
+			if (target.upgradeBlocked !== undefined) {
+				return C.ERR_INVALID_TARGET;
+			}
+		});
+}
+
+export function checkTransferEnergy(core: StructureInvaderCore, target: StructureTower | Creep, amount: number | undefined) {
+	return chainIntentChecks(
+		() => checkSourceAlive(core),
+		() => checkTarget(target, StructureTower, Creep),
+		() => checkSameRoom(core, target),
+		() => {
+			if (amount !== undefined && (typeof amount !== 'number' || amount < 0)) {
+				return C.ERR_INVALID_ARGS;
+			}
+			const free = target.store.getFreeCapacity(C.RESOURCE_ENERGY);
+			if (free === null) {
+				return C.ERR_INVALID_TARGET;
+			}
+			if (free === 0) {
+				return C.ERR_FULL;
+			}
+			if (amount !== undefined && amount > free) {
+				return C.ERR_NOT_ENOUGH_RESOURCES;
+			}
+		});
 }
 
 registerGlobal(StructureInvaderCore);

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -1,5 +1,4 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
-import type { Room } from 'xxscreeps/game/room/index.js';
 import { chainIntentChecks, checkSameRoom, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
@@ -42,7 +41,15 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	@enumerable get spawning(): null { return null; }
 
 	@enumerable get ticksToDeploy(): number | undefined {
-		return RoomObject.optionalExpiryTime(Game, this['#deployTime']);
+		// `+ 1 - 1` like nuke's `timeToLand`: yields `0` on the final invulnerable tick
+		// (`Game.time === #deployTime`) and clamps to `undefined` from the tick after, so reads at
+		// `#deployTime + 1` don't throw before the processor zeroes the field.
+		const deployTime = this['#deployTime'];
+		if (deployTime === 0) {
+			return undefined;
+		}
+		const ticks = RoomObject.requiredExpiryTime(Game, deployTime + 1) - 1;
+		return ticks < 0 ? undefined : ticks;
 	}
 
 	override get hitsMax(): number {
@@ -55,11 +62,14 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 		return this.ticksToDeploy !== undefined;
 	}
 
+	// These four actions are NPC-internal — only the invader loop calls them — so they're private
+	// rather than part of the player-facing structure API.
+
 	/**
 	 * Block claim/reservation of the target controller.
 	 * @param target Neutral or invader-reserved controller in the same room.
 	 */
-	reserveController(target: StructureController) {
+	'#reserveController'(target: StructureController) {
 		return chainIntentChecks(
 			() => checkReserveController(this, target),
 			() => intents.save(this, 'reserveController', target.id));
@@ -68,7 +78,7 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	/**
 	 * Reduce a hostile controller's downgrade/reservation timer.
 	 */
-	attackController(target: StructureController) {
+	'#attackController'(target: StructureController) {
 		return chainIntentChecks(
 			() => checkAttackController(this, target),
 			() => intents.save(this, 'attackController', target.id));
@@ -77,7 +87,7 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	/**
 	 * Reset the downgrade timer on a controller already owned by this NPC.
 	 */
-	upgradeController(target: StructureController) {
+	'#upgradeController'(target: StructureController) {
 		return chainIntentChecks(
 			() => checkUpgradeController(this, target),
 			() => intents.save(this, 'upgradeController', target.id));
@@ -88,7 +98,7 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	 * capacity for energy; oversized amounts clamp at the processor. The stronghold refill
 	 * behaviors are this action's driver and arrive in a later slice.
 	 */
-	transferEnergy(target: StructureTower | Creep, amount?: number) {
+	'#transferEnergy'(target: StructureTower | Creep, amount?: number) {
 		return chainIntentChecks(
 			() => checkTransferEnergy(this, target),
 			() => intents.save(this, 'transferEnergy', target.id,
@@ -101,15 +111,10 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 		}
 		super['#applyDamage'](power, type, source);
 	}
-
-	override '#beforeInsert'(room: Room) {
-		super['#beforeInsert'](room);
-		// Keep NPC '2' active in any room that hosts a core; inlined to avoid pulling the
-		// processor entry-point into the runtime sandbox.
-		room['#npcData'].users.add('2');
-	}
 }
 
+// Callers insert the returned core and are responsible for waking the invader NPC that drives it
+// (`activateNPC(room, '2')` + `context.setActive()`), the same way `requestInvader` does for creeps.
 export function create(pos: RoomPosition, level: number, deployTime: number) {
 	const core = assign(RoomObject.create(new StructureInvaderCore(), pos), {
 		hits: C.INVADER_CORE_HITS,

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -61,7 +61,6 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	 */
 	reserveController(target: StructureController) {
 		return chainIntentChecks(
-			() => checkMyStructure(this, StructureInvaderCore),
 			() => checkReserveController(this, target),
 			() => intents.save(this, 'reserveController', target.id));
 	}
@@ -71,7 +70,6 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	 */
 	attackController(target: StructureController) {
 		return chainIntentChecks(
-			() => checkMyStructure(this, StructureInvaderCore),
 			() => checkAttackController(this, target),
 			() => intents.save(this, 'attackController', target.id));
 	}
@@ -81,18 +79,17 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	 */
 	upgradeController(target: StructureController) {
 		return chainIntentChecks(
-			() => checkMyStructure(this, StructureInvaderCore),
 			() => checkUpgradeController(this, target),
 			() => intents.save(this, 'upgradeController', target.id));
 	}
 
 	/**
 	 * Push energy into a tower or creep in the same room. `amount` defaults to the target's free
-	 * capacity for energy.
+	 * capacity for energy; oversized amounts clamp at the processor. The stronghold refill
+	 * behaviors are this action's driver and arrive in a later slice.
 	 */
 	transferEnergy(target: StructureTower | Creep, amount?: number) {
 		return chainIntentChecks(
-			() => checkMyStructure(this, StructureInvaderCore),
 			() => checkTransferEnergy(this, target, amount),
 			() => intents.save(this, 'transferEnergy', target.id,
 				amount ?? target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
@@ -130,6 +127,7 @@ const checkSourceAlive = (core: StructureInvaderCore) =>
 
 export function checkReserveController(core: StructureInvaderCore, target: StructureController) {
 	return chainIntentChecks(
+		() => checkMyStructure(core, StructureInvaderCore),
 		() => checkSourceAlive(core),
 		() => checkTarget(target, StructureController),
 		() => checkSameRoom(core, target),
@@ -145,6 +143,7 @@ export function checkReserveController(core: StructureInvaderCore, target: Struc
 
 export function checkAttackController(core: StructureInvaderCore, target: StructureController) {
 	return chainIntentChecks(
+		() => checkMyStructure(core, StructureInvaderCore),
 		() => checkSourceAlive(core),
 		() => checkTarget(target, StructureController),
 		() => checkSameRoom(core, target),
@@ -171,6 +170,7 @@ export function checkAttackController(core: StructureInvaderCore, target: Struct
 
 export function checkUpgradeController(core: StructureInvaderCore, target: StructureController) {
 	return chainIntentChecks(
+		() => checkMyStructure(core, StructureInvaderCore),
 		() => checkSourceAlive(core),
 		() => checkTarget(target, StructureController),
 		() => checkSameRoom(core, target),
@@ -186,6 +186,7 @@ export function checkUpgradeController(core: StructureInvaderCore, target: Struc
 
 export function checkTransferEnergy(core: StructureInvaderCore, target: StructureTower | Creep, amount: number | undefined) {
 	return chainIntentChecks(
+		() => checkMyStructure(core, StructureInvaderCore),
 		() => checkSourceAlive(core),
 		() => checkTarget(target, StructureTower, Creep),
 		() => checkSameRoom(core, target),
@@ -199,9 +200,6 @@ export function checkTransferEnergy(core: StructureInvaderCore, target: Structur
 			}
 			if (free === 0) {
 				return C.ERR_FULL;
-			}
-			if (amount !== undefined && amount > free) {
-				return C.ERR_NOT_ENOUGH_RESOURCES;
 			}
 		});
 }

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -90,7 +90,7 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 	 */
 	transferEnergy(target: StructureTower | Creep, amount?: number) {
 		return chainIntentChecks(
-			() => checkTransferEnergy(this, target, amount),
+			() => checkTransferEnergy(this, target),
 			() => intents.save(this, 'transferEnergy', target.id,
 				amount ?? target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
 	}
@@ -184,16 +184,13 @@ export function checkUpgradeController(core: StructureInvaderCore, target: Struc
 		});
 }
 
-export function checkTransferEnergy(core: StructureInvaderCore, target: StructureTower | Creep, amount: number | undefined) {
+export function checkTransferEnergy(core: StructureInvaderCore, target: StructureTower | Creep) {
 	return chainIntentChecks(
 		() => checkMyStructure(core, StructureInvaderCore),
 		() => checkSourceAlive(core),
 		() => checkTarget(target, StructureTower, Creep),
 		() => checkSameRoom(core, target),
 		() => {
-			if (amount !== undefined && (typeof amount !== 'number' || amount < 0)) {
-				return C.ERR_INVALID_ARGS;
-			}
 			const free = target.store.getFreeCapacity(C.RESOURCE_ENERGY);
 			if (free === null) {
 				return C.ERR_INVALID_TARGET;

--- a/packages/xxscreeps/mods/invader/loop/index.ts
+++ b/packages/xxscreeps/mods/invader/loop/index.ts
@@ -16,15 +16,15 @@ function handleController(core: StructureInvaderCore) {
 	}
 	if (controller['#user'] === '2' && controller.level > 0) {
 		if ((controller.ticksToDowngrade ?? Infinity) < C.INVADER_CORE_CONTROLLER_DOWNGRADE - 25) {
-			core.upgradeController(controller);
+			core['#upgradeController'](controller);
 		}
 		return;
 	}
 	const reserved = controller['#reservationEndTime'] > Game.time;
 	if (!reserved || controller.room['#user'] === '2') {
-		core.reserveController(controller);
+		core['#reserveController'](controller);
 	} else {
-		core.attackController(controller);
+		core['#attackController'](controller);
 	}
 }
 

--- a/packages/xxscreeps/mods/invader/loop/index.ts
+++ b/packages/xxscreeps/mods/invader/loop/index.ts
@@ -1,30 +1,67 @@
+import type { StructureInvaderCore } from '../invader-core.js';
 import type { GameConstructor } from 'xxscreeps/game/index.js';
 import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
 import findAttack from './find-attack.js';
 import healer from './healer.js';
 import shootAtWill from './shoot-at-will.js';
 
+// Stronghold-template behaviors (refillTowers, refillCreeps, focusClosest) depend on a
+// deployed stronghold's towers/ramparts, which aren't implemented yet. Only the controller
+// driver lives here for now.
+function handleController(core: StructureInvaderCore) {
+	const controller = core.room.controller;
+	if (!controller) {
+		return;
+	}
+	if (controller['#user'] === '2' && controller.level > 0) {
+		if ((controller.ticksToDowngrade ?? Infinity) < C.INVADER_CORE_CONTROLLER_DOWNGRADE - 25) {
+			core.upgradeController(controller);
+		}
+		return;
+	}
+	const reserved = controller['#reservationEndTime'] > Game.time;
+	if (!reserved || controller.room['#user'] === '2') {
+		core.reserveController(controller);
+	} else {
+		core.attackController(controller);
+	}
+}
+
 export function loop(Game: GameConstructor) {
-	const creeps = Object.values(Game.creeps);
-	const room = creeps[0]?.room;
+	const room = Object.values(Game.rooms)[0];
 	if (!room) {
 		return false;
 	}
-	const healers = creeps.filter(
-		creep => creep.getActiveBodyparts(C.HEAL) > 0);
-	const fortifications = room.find(C.FIND_HOSTILE_STRUCTURES).filter(structure =>
-		structure.structureType === C.STRUCTURE_RAMPART ||
-		structure.structureType === C.STRUCTURE_WALL);
-	// TODO: Filter SK
-	const hostiles = room.find(C.FIND_HOSTILE_CREEPS);
 
-	for (const creep of Object.values(Game.creeps)) {
-		if (creep.getActiveBodyparts('heal') > 0) {
-			healer(creep, healers);
-		} else {
-			findAttack(creep, healers, hostiles, fortifications);
-		}
-		shootAtWill(creep);
+	// Drive invader cores
+	const cores = Object.values(Game.structures).filter(
+		(structure): structure is StructureInvaderCore =>
+			structure.structureType === C.STRUCTURE_INVADER_CORE);
+	for (const core of cores) {
+		handleController(core);
 	}
-	return true;
+
+	// Drive invader creeps
+	const creeps = Object.values(Game.creeps);
+	if (creeps.length > 0) {
+		const healers = creeps.filter(
+			creep => creep.getActiveBodyparts(C.HEAL) > 0);
+		const fortifications = room.find(C.FIND_HOSTILE_STRUCTURES).filter(structure =>
+			structure.structureType === C.STRUCTURE_RAMPART ||
+			structure.structureType === C.STRUCTURE_WALL);
+		// TODO: Filter SK
+		const hostiles = room.find(C.FIND_HOSTILE_CREEPS);
+
+		for (const creep of creeps) {
+			if (creep.getActiveBodyparts('heal') > 0) {
+				healer(creep, healers);
+			} else {
+				findAttack(creep, healers, hostiles, fortifications);
+			}
+			shootAtWill(creep);
+		}
+	}
+
+	return cores.length > 0 || creeps.length > 0;
 }

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -1,12 +1,19 @@
-import { registerIntentProcessor, registerRoomTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import type { StructureTower } from 'xxscreeps/mods/defense/tower.js';
+import { registerIntentProcessor, registerObjectTickProcessor, registerRoomTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
+import { saveAction } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Room } from 'xxscreeps/game/room/index.js';
+import { StructureController } from 'xxscreeps/mods/controller/controller.js';
+import { release, reserve } from 'xxscreeps/mods/controller/processor.js';
 import * as Creep from 'xxscreeps/mods/creep/creep.js';
+import { flushActionLog } from 'xxscreeps/mods/creep/processor.js';
 import { activateNPC, registerNPC } from 'xxscreeps/mods/npc/processor.js';
+import { StructureInvaderCore, checkAttackController, checkReserveController, checkTransferEnergy, checkUpgradeController } from './invader-core.js';
 import { loop } from './loop/index.js';
 
 // Register invader NPC
@@ -75,16 +82,115 @@ registerRoomTickProcessor((room, context) => {
 	}
 });
 
-// Add backend-only Invader request
+// Intent processors. Includes the backend-only `requestInvader` (Room) and the four
+// invader-core actions driven by the NPC loop.
 declare module 'xxscreeps/engine/processor/index.js' {
-	interface Intent { invader: typeof intent }
+	interface Intent { invader: typeof intents }
 }
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const intent = registerIntentProcessor(Room, 'requestInvader', { internal: true }, (room, context, xx: number, yy: number, role: Role, strength: Strength) => {
-	const pos = new RoomPosition(xx, yy, room.name);
-	room['#insertObject'](create(pos, role, strength, Game.time + 200));
-	activateNPC(room, '2');
-	context.setActive();
+const intents = [
+	registerIntentProcessor(Room, 'requestInvader', { internal: true }, (room, context, xx: number, yy: number, role: Role, strength: Strength) => {
+		const pos = new RoomPosition(xx, yy, room.name);
+		room['#insertObject'](create(pos, role, strength, Game.time + 200));
+		activateNPC(room, '2');
+		context.setActive();
+	}),
+
+	registerIntentProcessor(StructureInvaderCore, 'reserveController', {}, (core, context, id: string) => {
+		const controller = Game.getObjectById<StructureController>(id)!;
+		if (checkReserveController(core, controller) === C.OK) {
+			const power = C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_RESERVE;
+			const endTime = (controller['#reservationEndTime'] || Game.time + 1) + power;
+			if (endTime > Game.time + C.CONTROLLER_RESERVE_MAX) {
+				return;
+			}
+			reserve(context, controller, '2', endTime);
+			saveAction(core, 'reserveController', controller.pos);
+			appendEventLog(controller.room, {
+				event: C.EVENT_RESERVE_CONTROLLER,
+				objectId: core.id,
+				amount: power,
+			});
+		}
+	}),
+
+	registerIntentProcessor(StructureInvaderCore, 'attackController', {}, (core, context, id: string) => {
+		const controller = Game.getObjectById<StructureController>(id)!;
+		if (checkAttackController(core, controller) === C.OK) {
+			if (controller.level > 0) {
+				controller['#downgradeTime'] -= C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_CLAIM_DOWNGRADE;
+				controller['#upgradeBlockedUntil'] = Game.time + C.CONTROLLER_ATTACK_BLOCKED_UPGRADE - 1;
+			} else {
+				const reduced = controller['#reservationEndTime'] - C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_RESERVE;
+				if (reduced <= Game.time) {
+					release(context, controller);
+				} else {
+					controller['#reservationEndTime'] = reduced;
+				}
+			}
+			saveAction(core, 'attack', controller.pos);
+			appendEventLog(controller.room, {
+				event: C.EVENT_ATTACK_CONTROLLER,
+				objectId: core.id,
+			});
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(StructureInvaderCore, 'upgradeController', {}, (core, context, id: string) => {
+		const controller = Game.getObjectById<StructureController>(id)!;
+		if (checkUpgradeController(core, controller) === C.OK) {
+			const expiry = Game.time + C.INVADER_CORE_CONTROLLER_DOWNGRADE;
+			controller['#downgradeTime'] = expiry;
+			controller['#upgradeInvulnerableUntil'] = expiry;
+			saveAction(core, 'upgradeController', controller.pos);
+			appendEventLog(controller.room, {
+				event: C.EVENT_UPGRADE_CONTROLLER,
+				objectId: core.id,
+				amount: 1,
+				energySpent: 0,
+			});
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(StructureInvaderCore, 'transferEnergy', {}, (core, context, id: string, amount: number) => {
+		const target = Game.getObjectById<StructureTower | Creep.Creep>(id);
+		if (target && checkTransferEnergy(core, target, amount) === C.OK) {
+			const free = target.store.getFreeCapacity(C.RESOURCE_ENERGY)!;
+			const actual = Math.min(amount, free);
+			if (actual > 0) {
+				target.store['#add'](C.RESOURCE_ENERGY, actual);
+				saveAction(core, 'transferEnergy', target.pos);
+				appendEventLog(core.room, {
+					event: C.EVENT_TRANSFER,
+					objectId: core.id,
+					targetId: target.id,
+					resourceType: C.RESOURCE_ENERGY,
+					amount: actual,
+				});
+				context.didUpdate();
+			}
+		}
+	}),
+];
+
+registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
+	const collapseTime = core['#collapseTime'];
+	if (collapseTime > 0 && collapseTime <= Game.time) {
+		// Collapse expiry is a silent removal: no ruin, no EVENT_OBJECT_DESTROYED. Those
+		// only emit from the damage-destroy path, which collapse doesn't traverse. The NPC
+		// reservation is left to run out; the controller's tick processor releases it at expiry.
+		core.room['#removeObject'](core);
+		context.setActive();
+		return;
+	}
+
+	flushActionLog(core['#actionLog'], context);
+
+	const deployTime = core['#deployTime'];
+	if (deployTime > Game.time) context.wakeAt(deployTime);
+	if (collapseTime > Game.time) context.wakeAt(collapseTime);
 });
 
 // Creep factory for invaders

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -192,8 +192,19 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 
 	flushActionLog(core['#actionLog'], context);
 
+	// Clear the deploy timer the tick after it elapses. `ticksToDeploy`/`effects` read `#deployTime`
+	// through `optionalExpiryTime`, which throws on a past time, so this branches on the raw field
+	// rather than the getter. Zeroing lands in the blob read at `deployTime + 1` — one tick past the
+	// core's last invulnerable tick (`Game.time === deployTime`, `ticksToDeploy === 0`).
 	const deployTime = core['#deployTime'];
-	if (deployTime > Game.time) context.wakeAt(deployTime);
+	if (deployTime !== 0) {
+		if (deployTime < Game.time) {
+			core['#deployTime'] = 0;
+			context.didUpdate();
+		} else {
+			context.wakeAt(deployTime + 1);
+		}
+	}
 	if (collapseTime > Game.time) context.wakeAt(collapseTime);
 });
 

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -158,7 +158,7 @@ const intents = [
 
 	registerIntentProcessor(StructureInvaderCore, 'transferEnergy', {}, (core, context, id: string, amount: number) => {
 		const target = Game.getObjectById<StructureTower | Creep.Creep>(id);
-		if (target && checkTransferEnergy(core, target, amount) === C.OK) {
+		if (target && checkTransferEnergy(core, target) === C.OK) {
 			const free = target.store.getFreeCapacity(C.RESOURCE_ENERGY)!;
 			const actual = Math.min(amount, free);
 			if (actual > 0) {

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -128,6 +128,8 @@ const intents = [
 					controller['#reservationEndTime'] = reduced;
 				}
 			}
+			// Divergence from Screeps, which logs this under `reserveController` — a copy/paste slip
+			// in its core intent; the creep intent logs `attack`.
 			saveAction(core, 'attack', controller.pos);
 			appendEventLog(controller.room, {
 				event: C.EVENT_ATTACK_CONTROLLER,
@@ -181,6 +183,8 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 		// Collapse expiry is a silent removal: no ruin, no EVENT_OBJECT_DESTROYED. Those
 		// only emit from the damage-destroy path, which collapse doesn't traverse. The NPC
 		// reservation is left to run out; the controller's tick processor releases it at expiry.
+		// TODO: Reset an NPC-owned controller here (user/level/effects) once stronghold
+		// deployment can create one.
 		core.room['#removeObject'](core);
 		context.setActive();
 		return;

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -32,8 +32,6 @@ registerRoomTickProcessor((room, context) => {
 		}
 		// Check neighbor rooms to filter exits leading to owned/reserved rooms
 		const exitDirections = Game.map.describeExits(room.name);
-		// TODO: describeExits return type is `null as never` — fix upstream in map.ts
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
 		if (!exitDirections) {
 			return;
 		}
@@ -190,6 +188,7 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 		context.didUpdate();
 		return;
 	}
+	context.wakeAt(collapseTime);
 
 	flushActionLog(core['#actionLog'], context);
 
@@ -206,7 +205,6 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 			context.wakeAt(deployTime + 1);
 		}
 	}
-	if (collapseTime > Game.time) context.wakeAt(collapseTime);
 });
 
 // Creep factory for invaders

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -186,16 +186,17 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 		// TODO: Reset an NPC-owned controller here (user/level/effects) once stronghold
 		// deployment can create one.
 		core.room['#removeObject'](core);
-		context.setActive();
+		// Persist the removal; nothing's left to process here next tick, so don't re-wake the room.
+		context.didUpdate();
 		return;
 	}
 
 	flushActionLog(core['#actionLog'], context);
 
-	// Clear the deploy timer the tick after it elapses. `ticksToDeploy`/`effects` read `#deployTime`
-	// through `optionalExpiryTime`, which throws on a past time, so this branches on the raw field
-	// rather than the getter. Zeroing lands in the blob read at `deployTime + 1` — one tick past the
-	// core's last invulnerable tick (`Game.time === deployTime`, `ticksToDeploy === 0`).
+	// Zero the deploy timer once it elapses. `ticksToDeploy` already clamps to `undefined` from
+	// `deployTime + 1`, but the raw field has to be cleared by `deployTime + 2` or its
+	// `requiredExpiryTime` read throws; the `wakeAt` below guarantees a processing tick at
+	// `deployTime + 1` to do it.
 	const deployTime = core['#deployTime'];
 	if (deployTime !== 0) {
 		if (deployTime < Game.time) {

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -6,6 +6,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
 import { create as createTower } from 'xxscreeps/mods/defense/tower.js';
+import { activateNPC } from 'xxscreeps/mods/npc/processor.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { lookForStructures } from '../structure/structure.js';
 import { create as createInvaderCore } from './invader-core.js';
@@ -322,16 +323,13 @@ describe('Invader core', () => {
 		room.find(C.FIND_STRUCTURES).find(
 			(structure): structure is StructureInvaderCore => structure.structureType === C.STRUCTURE_INVADER_CORE);
 
-	// A presence creep activates the room for processing; NPC '2' alone is filtered out by
-	// `updateUserRoomRelationships`, so without a human user the room never enters the process queue.
-	const presencePos = new RoomPosition(10, 10, 'W1N1');
-	const placePresenceCreep = (room: Room) =>
-		room['#insertObject'](createCreep(presencePos, [ C.MOVE ], 'dummy', '100'));
-
+	// `activateNPC` registers invader NPC '2' as this room's loop driver; the `simulate` harness
+	// seeds rooms with an active NPC into the processor queue (mirroring the main-service boot), so
+	// these `peekRoom` cases process without a stand-in human presence creep.
 	const coreInNeutralRoom = simulate({
 		W1N1: room => {
-			placePresenceCreep(room);
 			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+			activateNPC(room, '2');
 		},
 	});
 
@@ -364,8 +362,8 @@ describe('Invader core', () => {
 		W1N1: room => {
 			room['#user'] = '101';
 			room.controller!['#reservationEndTime'] = 5000;
-			placePresenceCreep(room);
 			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+			activateNPC(room, '2');
 		},
 	});
 
@@ -388,8 +386,8 @@ describe('Invader core', () => {
 			room['#user'] = '2';
 			room.controller!['#user'] = '2';
 			room.controller!['#downgradeTime'] = 1000;
-			placePresenceCreep(room);
 			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+			activateNPC(room, '2');
 		},
 	});
 
@@ -419,7 +417,7 @@ describe('Invader core', () => {
 				(structure): structure is StructureTower => structure.structureType === C.STRUCTURE_TOWER,
 			)!;
 			// Oversized amounts pass the check and clamp at the processor
-			return [ core.transferEnergy(tower, 100), core.transferEnergy(tower, C.TOWER_CAPACITY + 100) ];
+			return [ core['#transferEnergy'](tower, 100), core['#transferEnergy'](tower, C.TOWER_CAPACITY + 100) ];
 		});
 		assert.deepStrictEqual(results, [ C.OK, C.OK ]);
 	}));
@@ -430,8 +428,8 @@ describe('Invader core', () => {
 			room.controller!['#reservationEndTime'] = 5000;
 			const core = createInvaderCore(corePos, 2, 0);
 			core['#collapseTime'] = 1; // expires by Game.time === 1 on the first processed tick
-			placePresenceCreep(room);
 			room['#insertObject'](core);
+			activateNPC(room, '2');
 		},
 	});
 

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -384,14 +384,15 @@ describe('Invader core', () => {
 	});
 
 	test('transferEnergy accepts in-room tower target', () => refillScene(async ({ poke }) => {
-		const result = await poke('W1N1', '2', (Game, room) => {
+		const results = await poke('W1N1', '2', (Game, room) => {
 			const core = findRoomCore(room)!;
 			const tower = room.find(C.FIND_STRUCTURES).find(
 				(structure): structure is StructureTower => structure.structureType === C.STRUCTURE_TOWER,
 			)!;
-			return core.transferEnergy(tower, 100);
+			// Oversized amounts pass the check and clamp at the processor
+			return [ core.transferEnergy(tower, 100), core.transferEnergy(tower, C.TOWER_CAPACITY + 100) ];
 		});
-		assert.strictEqual(result, C.OK);
+		assert.deepStrictEqual(results, [ C.OK, C.OK ]);
 	}));
 
 	const collapsing = simulate({

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -270,6 +270,35 @@ describe('Invader core', () => {
 		});
 	}));
 
+	// Deploy completes at Game.time === 2; an observer keeps the room visible across the boundary.
+	const deployBoundary = simulate({
+		W1N1: room => {
+			room['#insertObject'](createInvaderCore(corePos, 2, 2));
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.MOVE ], 'observer', '100'));
+		},
+	});
+
+	test('clears the deploy timer the tick after it elapses', () => deployBoundary(async ({ player, tick }) => {
+		// Game.time === deployTime: final invulnerable tick, `ticksToDeploy === 0`.
+		await tick(2);
+		await player('100', Game => {
+			const core = findCore(Game);
+			assert.strictEqual(Game.time, 2);
+			assert.strictEqual(core.ticksToDeploy, 0, 'invulnerable through Game.time === deployTime');
+			assert.deepStrictEqual(core.effects, [
+				{ effect: C.EFFECT_INVULNERABILITY, ticksRemaining: 0 },
+			]);
+		});
+		// Game.time === deployTime + 1: cleared. Reading the expiry getters must not throw.
+		await tick();
+		await player('100', Game => {
+			const core = findCore(Game);
+			assert.strictEqual(Game.time, 3);
+			assert.strictEqual(core.ticksToDeploy, undefined, 'deploy timer cleared after it elapses');
+			assert.strictEqual(core.effects, undefined);
+		});
+	}));
+
 	const deployingWithCollapse = simulate({
 		W1N1: room => {
 			const core = createInvaderCore(corePos, 2, 5000);

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -1,8 +1,11 @@
 import type { StructureInvaderCore } from './invader-core.js';
 import type { GameConstructor } from 'xxscreeps/game/index.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
+import type { StructureTower } from 'xxscreeps/mods/defense/tower.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { create as createTower } from 'xxscreeps/mods/defense/tower.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { lookForStructures } from '../structure/structure.js';
 import { create as createInvaderCore } from './invader-core.js';
@@ -212,7 +215,7 @@ describe('Invader core', () => {
 		});
 	}));
 
-	test('damage paths are all blocked while deploying', () => deploying(async ({ player, tick }) => {
+	test('damage paths are all blocked while deploying', () => deploying(async ({ player, tick, peekRoom }) => {
 		await player('100', Game => {
 			const core = findCore(Game);
 			const attacker = Game.creeps.attacker!;
@@ -220,13 +223,17 @@ describe('Invader core', () => {
 			assert.strictEqual(attacker.attack(core), C.ERR_INVALID_TARGET);
 			assert.strictEqual(attacker.rangedAttack(core), C.ERR_INVALID_TARGET);
 			assert.strictEqual(attacker.dismantle(core), C.ERR_INVALID_TARGET);
-			// rangedMassAttack has no per-target intent check; #applyDamage is the backstop.
+			// rangedMassAttack has no per-target intent check; the processor-level invulnerability skip is the backstop.
 			assert.strictEqual(attacker.rangedMassAttack(), C.OK);
 		});
 		await tick();
 		await player('100', Game => {
 			const core = findCore(Game);
 			assert.strictEqual(core.hits, core.hitsMax, 'invulnerable core should take no damage');
+		});
+		await peekRoom('W1N1', room => {
+			const attacked = room.getEventLog().some(event => event.event === C.EVENT_ATTACK);
+			assert.strictEqual(attacked, false, 'skipped rangedMassAttack must not emit EVENT_ATTACK');
 		});
 	}));
 
@@ -262,4 +269,191 @@ describe('Invader core', () => {
 			assert.strictEqual(core.hits, core.hitsMax - C.ATTACK_POWER);
 		});
 	}));
+
+	const deployingWithCollapse = simulate({
+		W1N1: room => {
+			const core = createInvaderCore(corePos, 2, 5000);
+			core['#collapseTime'] = 10000;
+			room['#insertObject'](core);
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.MOVE ], 'observer', '100'));
+		},
+	});
+
+	test('effects compose deploy + collapse timers', () => deployingWithCollapse(async ({ player }) => {
+		await player('100', Game => {
+			const core = findCore(Game);
+			assert.deepStrictEqual(core.effects, [
+				{ effect: C.EFFECT_INVULNERABILITY, ticksRemaining: 5000 - Game.time },
+				{ effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining: 10000 - Game.time },
+			]);
+		});
+	}));
+
+	const findRoomCore = (room: Room) =>
+		room.find(C.FIND_STRUCTURES).find(
+			(structure): structure is StructureInvaderCore => structure.structureType === C.STRUCTURE_INVADER_CORE);
+
+	// A presence creep activates the room for processing; NPC '2' alone is filtered out by
+	// `updateUserRoomRelationships`, so without a human user the room never enters the process queue.
+	const presencePos = new RoomPosition(10, 10, 'W1N1');
+	const placePresenceCreep = (room: Room) =>
+		room['#insertObject'](createCreep(presencePos, [ C.MOVE ], 'dummy', '100'));
+
+	const coreInNeutralRoom = simulate({
+		W1N1: room => {
+			placePresenceCreep(room);
+			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+		},
+	});
+
+	test('NPC reserves a neutral controller and logs the action', () => coreInNeutralRoom(async ({ tick, peekRoom }) => {
+		await tick();
+		await peekRoom('W1N1', (room, Game) => {
+			const controller = room.controller!;
+			const expectedFirst = Game.time + C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_RESERVE + 1;
+			assert.strictEqual(controller['#reservationEndTime'], expectedFirst);
+			assert.strictEqual(room['#user'], '2', 'room user becomes 2 once reserved');
+			const core = findRoomCore(room)!;
+			const action = [ ...core['#actionLog'] ].find(entry => entry.type === 'reserveController');
+			assert.ok(action, 'expected reserveController action log entry');
+			assert.strictEqual(action.time, Game.time);
+			assert.strictEqual(action.x, controller.pos.x);
+			assert.strictEqual(action.y, controller.pos.y);
+		});
+	}));
+
+	test('extending own reservation accumulates by INVADER_CORE_CONTROLLER_POWER * CONTROLLER_RESERVE',
+		() => coreInNeutralRoom(async ({ tick, peekRoom }) => {
+			await tick();
+			const first = await peekRoom('W1N1', room => room.controller!['#reservationEndTime']);
+			await tick();
+			const second = await peekRoom('W1N1', room => room.controller!['#reservationEndTime']);
+			assert.strictEqual(second - first, C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_RESERVE);
+		}));
+
+	const hostileReservation = simulate({
+		W1N1: room => {
+			room['#user'] = '101';
+			room.controller!['#reservationEndTime'] = 5000;
+			placePresenceCreep(room);
+			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+		},
+	});
+
+	test('NPC attacks a hostile reservation', () => hostileReservation(async ({ tick, peekRoom }) => {
+		await tick();
+		await peekRoom('W1N1', room => {
+			const controller = room.controller!;
+			const expected = 5000 - C.INVADER_CORE_CONTROLLER_POWER * C.CONTROLLER_RESERVE;
+			assert.strictEqual(controller['#reservationEndTime'], expected,
+				'attackController should subtract INVADER_CORE_CONTROLLER_POWER * CONTROLLER_RESERVE');
+		});
+	}));
+
+	// Synthetic state: invader "owns" the controller (level > 0 with #user='2'). No code path
+	// reaches this state today; the upgradeController processor exists for the stronghold
+	// deployment path that will set it.
+	const coreOwnsController = simulate({
+		W1N1: room => {
+			room['#level'] = 1;
+			room['#user'] = '2';
+			room.controller!['#user'] = '2';
+			room.controller!['#downgradeTime'] = 1000;
+			placePresenceCreep(room);
+			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+		},
+	});
+
+	test('NPC upgrades an own controller and applies invulnerability', () => coreOwnsController(async ({ tick, peekRoom }) => {
+		await tick();
+		await peekRoom('W1N1', (room, Game) => {
+			const controller = room.controller!;
+			const expiry = Game.time + C.INVADER_CORE_CONTROLLER_DOWNGRADE;
+			assert.strictEqual(controller['#downgradeTime'], expiry);
+			const invulnerability = controller.effects?.find(effect => effect.effect === C.EFFECT_INVULNERABILITY);
+			assert.ok(invulnerability, 'controller should report EFFECT_INVULNERABILITY after upgradeController');
+			assert.strictEqual(invulnerability.ticksRemaining, C.INVADER_CORE_CONTROLLER_DOWNGRADE);
+		});
+	}));
+
+	const refillScene = simulate({
+		W1N1: room => {
+			room['#insertObject'](createInvaderCore(corePos, 2, 0));
+			room['#insertObject'](createTower(new RoomPosition(26, 25, 'W1N1'), '2'));
+		},
+	});
+
+	test('transferEnergy accepts in-room tower target', () => refillScene(async ({ poke }) => {
+		const result = await poke('W1N1', '2', (Game, room) => {
+			const core = findRoomCore(room)!;
+			const tower = room.find(C.FIND_STRUCTURES).find(
+				(structure): structure is StructureTower => structure.structureType === C.STRUCTURE_TOWER,
+			)!;
+			return core.transferEnergy(tower, 100);
+		});
+		assert.strictEqual(result, C.OK);
+	}));
+
+	const collapsing = simulate({
+		W1N1: room => {
+			room['#user'] = '2';
+			room.controller!['#reservationEndTime'] = 5000;
+			const core = createInvaderCore(corePos, 2, 0);
+			core['#collapseTime'] = 1; // expires by Game.time === 1 on the first processed tick
+			placePresenceCreep(room);
+			room['#insertObject'](core);
+		},
+	});
+
+	test('collapse expiry removes the core and leaves the reservation ticking', () => collapsing(async ({ tick, peekRoom }) => {
+		await tick();
+		await peekRoom('W1N1', (room, Game) => {
+			assert.strictEqual(findRoomCore(room), undefined, 'core should be removed after collapse');
+			assert.ok(room.controller!['#reservationEndTime'] > Game.time, 'reservation is left to expire on its own');
+			assert.strictEqual(room['#user'], '2', 'room stays reserved by the NPC');
+		});
+	}));
+
+	test('collapse expiry leaves no ruin and emits no destroyed event', () => collapsing(async ({ tick, peekRoom }) => {
+		await tick();
+		await peekRoom('W1N1', room => {
+			const ruins = room.find(C.FIND_RUINS);
+			assert.strictEqual(ruins.length, 0, 'collapse expiry must not leave a Ruin');
+			const destroyed = room.getEventLog().find(event => event.event === C.EVENT_OBJECT_DESTROYED);
+			assert.strictEqual(destroyed, undefined, 'collapse must not emit EVENT_OBJECT_DESTROYED');
+		});
+	}));
+
+	const reservedThenKilled = simulate({
+		W1N1: room => {
+			room['#user'] = '2';
+			room.controller!['#reservationEndTime'] = 5000;
+			const core = createInvaderCore(corePos, 2, 0);
+			core.hits = 1; // single attack drops it; the kill path is what we're exercising
+			room['#insertObject'](core);
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 26, 'W1N1'),
+				[ C.ATTACK ],
+				'killer',
+				'100',
+			));
+		},
+	});
+
+	test('damage-destroy leaves a Ruin and the reservation ticking',
+		() => reservedThenKilled(async ({ player, tick, peekRoom }) => {
+			await player('100', Game => {
+				const core = findCore(Game);
+				assert.strictEqual(Game.creeps.killer!.attack(core), C.OK);
+			});
+			await tick();
+			await peekRoom('W1N1', (room, Game) => {
+				assert.strictEqual(findRoomCore(room), undefined, 'core should be removed');
+				assert.ok(room.controller!['#reservationEndTime'] > Game.time, 'reservation is left to expire on its own');
+				assert.strictEqual(room['#user'], '2', 'room stays reserved by the NPC');
+				assert.strictEqual(room.find(C.FIND_RUINS).length, 1, 'damage-destroy leaves a Ruin');
+				const destroyed = room.getEventLog().find(event => event.event === C.EVENT_OBJECT_DESTROYED);
+				assert.ok(destroyed, 'damage-destroy emits EVENT_OBJECT_DESTROYED');
+			});
+		}));
 });

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -1,7 +1,5 @@
-import type { StructureInvaderCore } from './invader-core.js';
 import type { GameConstructor } from 'xxscreeps/game/index.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
-import type { StructureTower } from 'xxscreeps/mods/defense/tower.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
@@ -286,9 +284,7 @@ describe('Invader core', () => {
 			const core = findCore(Game);
 			assert.strictEqual(Game.time, 2);
 			assert.strictEqual(core.ticksToDeploy, 0, 'invulnerable through Game.time === deployTime');
-			assert.deepStrictEqual(core.effects, [
-				{ effect: C.EFFECT_INVULNERABILITY, ticksRemaining: 0 },
-			]);
+			assert.deepStrictEqual(core.effects, [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining: 0 } ]);
 		});
 		// Game.time === deployTime + 1: cleared. Reading the expiry getters must not throw.
 		await tick();
@@ -319,9 +315,7 @@ describe('Invader core', () => {
 		});
 	}));
 
-	const findRoomCore = (room: Room) =>
-		room.find(C.FIND_STRUCTURES).find(
-			(structure): structure is StructureInvaderCore => structure.structureType === C.STRUCTURE_INVADER_CORE);
+	const findRoomCore = (room: Room) => lookForStructures(room, C.STRUCTURE_INVADER_CORE)[0];
 
 	// `activateNPC` registers invader NPC '2' as this room's loop driver; the `simulate` harness
 	// seeds rooms with an active NPC into the processor queue (mirroring the main-service boot), so
@@ -341,7 +335,7 @@ describe('Invader core', () => {
 			assert.strictEqual(controller['#reservationEndTime'], expectedFirst);
 			assert.strictEqual(room['#user'], '2', 'room user becomes 2 once reserved');
 			const core = findRoomCore(room)!;
-			const action = [ ...core['#actionLog'] ].find(entry => entry.type === 'reserveController');
+			const action = core['#actionLog'].find(entry => entry.type === 'reserveController');
 			assert.ok(action, 'expected reserveController action log entry');
 			assert.strictEqual(action.time, Game.time);
 			assert.strictEqual(action.x, controller.pos.x);
@@ -413,9 +407,7 @@ describe('Invader core', () => {
 	test('transferEnergy accepts in-room tower target', () => refillScene(async ({ poke }) => {
 		const results = await poke('W1N1', '2', (Game, room) => {
 			const core = findRoomCore(room)!;
-			const tower = room.find(C.FIND_STRUCTURES).find(
-				(structure): structure is StructureTower => structure.structureType === C.STRUCTURE_TOWER,
-			)!;
+			const tower = lookForStructures(room, C.STRUCTURE_TOWER)[0]!;
 			// Oversized amounts pass the check and clamp at the processor
 			return [ core['#transferEnergy'](tower, 100), core['#transferEnergy'](tower, C.TOWER_CAPACITY + 100) ];
 		});
@@ -459,12 +451,7 @@ describe('Invader core', () => {
 			const core = createInvaderCore(corePos, 2, 0);
 			core.hits = 1; // single attack drops it; the kill path is what we're exercising
 			room['#insertObject'](core);
-			room['#insertObject'](createCreep(
-				new RoomPosition(25, 26, 'W1N1'),
-				[ C.ATTACK ],
-				'killer',
-				'100',
-			));
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.ATTACK ], 'killer', '100'));
 		},
 	});
 

--- a/packages/xxscreeps/test/simulate.ts
+++ b/packages/xxscreeps/test/simulate.ts
@@ -11,7 +11,7 @@ import { consumeSet, consumeSortedSet } from 'xxscreeps/engine/db/async.js';
 import * as Code from 'xxscreeps/engine/db/user/code.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { initializeIntentConstraints } from 'xxscreeps/engine/processor/index.js';
-import { acquireIntentsForRoom, begetRoomProcessQueue, finalizeExtraRoomsSetKey, processRoomsSetKey, updateUserRoomRelationships, userToIntentRoomsSetKey, userToVisibleRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
+import { acquireIntentsForRoom, activeRoomsKey, begetRoomProcessQueue, finalizeExtraRoomsSetKey, processRoomsSetKey, updateUserRoomRelationships, userToIntentRoomsSetKey, userToVisibleRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
 import { runShardTickProcessors } from 'xxscreeps/engine/processor/shard.js';
 import { PlayerInstance } from 'xxscreeps/engine/runner/instance.js';
@@ -109,6 +109,12 @@ export function simulate(rooms: Record<string, (room: Room) => void>) {
 			await Promise.all([
 				shard.saveRoom(room.name, shard.time, room),
 				updateUserRoomRelationships(shard, room, previousUsers),
+				// The main service boots by processing every room once, which seeds NPC-driven rooms
+				// into the active set. `updateUserRoomRelationships` only adds rooms via their (non-NPC)
+				// players, so mirror the boot here: a room with an active NPC gets a first processing
+				// tick without needing a stand-in presence creep.
+				room['#npcData'].users.size > 0 &&
+					shard.scratch.zAdd(activeRoomsKey, [ [ 0, roomName ] ]),
 			]);
 		}));
 


### PR DESCRIPTION
## Summary

`StructureInvaderCore` gets `reserveController` / `attackController` /
`upgradeController` / `transferEnergy` intents, driven by a per-tick NPC
behavior loop, plus an action log and a collapse-expiry path. Only the
controller behaviors are wired for now — the stronghold-template behaviors
(refill towers/creeps) depend on deployed-stronghold structures that don't
exist yet.

- The four core actions are `#private` methods (`#reserveController` etc.) —
  they're NPC-only, called from the invader loop, not part of the player-facing
  structure API.
- NPC `'2'` is woken at the core's create/insert site (the same way
  `requestInvader` does for creeps) rather than from a `#beforeInsert` hook.
- Collapse expiry is a silent removal: no ruin and no `EVENT_OBJECT_DESTROYED`
  — those only emit from the damage-destroy path. The NPC reservation is left
  to run out on its own; the controller's existing tick processor releases it
  at expiry.
- `upgradeController` stores the controller invulnerability window in a new
  `StructureController` scalar `#upgradeInvulnerableUntil`, reported through
  the controller's `effects` getter (second producer on the #215 shape).
- `ticksToDeploy` uses nuke's `timeToLand` `+ 1 - 1` form so the getter clamps
  to `undefined` past expiry instead of throwing; the tick processor zeroes the
  stored field once it elapses.
- `rangedMassAttack`'s walk skips invulnerable targets so no `EVENT_ATTACK` is
  emitted for damage that wasn't applied, matching the intent-level gates in
  `attack` / `rangedAttack` / `dismantle`.
- A `checkSourceAlive` guard drops intents from a core destroyed earlier in
  the same intent pass; the four intent checks re-verify ownership through
  `checkMyStructure`, same shape as `checkTower`. Oversized `transferEnergy`
  amounts clamp at the processor instead of failing the check.
- One flagged divergence: the core's `attackController` logs an `attack`
  action; vanilla logs it under `reserveController` — a copy/paste slip in its
  core intent (the creep intent logs `attack`).

### Test harness

`simulate` now seeds rooms with an active NPC into the processor's active set,
mirroring the main-service boot that double-buffers every room once.
`updateUserRoomRelationships` only enqueues rooms via their non-NPC players, so
an NPC-only room never got a first processing tick under test — the
invader-core cases previously worked around this with a stand-in presence
creep, which this removes. In production the boot already seeds these rooms and
an active NPC keeps them awake (6873b3ca), so this only closes the harness gap.

## Validation

- `pnpm run build` clean; `npx xxscreeps test`: 426 passed. Ten invader-core
  cases cover deploy-phase damage blocking, deploy+collapse effects
  composition, reserve/attack/upgrade behaviors and reservation accumulation,
  tower refill, and collapse expiry vs damage-destroy (ruin, event, and
  reservation outcomes); the NPC-loop cases now run on the harness seed without
  a presence creep.
- `eslint` over the changed files: no new warnings.
- Live smoke on a dev server: injected a level-2 core into an empty
  controller room, observed deploy at the configured tick, `reserveController`
  action-logging with the reservation accumulating, then silent collapse with
  the reservation left ticking down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
