### PR TITLE
powerbank: add power bank structure mod

### DIFF
--- a/.changeset/powerbank-structure.md
+++ b/.changeset/powerbank-structure.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add power bank structures with decay, hit-back, and ruin looting.

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -12,7 +12,6 @@ registerGlobal('_', lodash);
 
 registerGlobal(function Deposit() {});
 registerGlobal(function PowerCreep() {});
-registerGlobal(function StructurePowerBank() {});
 registerGlobal(function StructurePowerSpawn() {});
 
 hooks.register('runtimeConnector', {

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -15,6 +15,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/nuker',
 		'xxscreeps/mods/observer',
 		'xxscreeps/mods/portal',
+		'xxscreeps/mods/powerbank',
 		'xxscreeps/mods/road',
 		'xxscreeps/mods/source',
 		'xxscreeps/mods/spawn',

--- a/packages/xxscreeps/mods/powerbank/backend.ts
+++ b/packages/xxscreeps/mods/powerbank/backend.ts
@@ -1,0 +1,12 @@
+import { bindMapRenderer, bindRenderer, bindTerrainRenderer } from 'xxscreeps/backend/index.js';
+import { renderStore } from 'xxscreeps/mods/resource/backend.js';
+import { StructurePowerBank } from './powerbank.js';
+
+bindMapRenderer(StructurePowerBank, () => 'pb');
+bindTerrainRenderer(StructurePowerBank, () => 0xf41f33);
+
+bindRenderer(StructurePowerBank, (powerBank, next) => ({
+	...next(),
+	...renderStore(powerBank.store),
+	decayTime: powerBank['#nextDecayTime'],
+}));

--- a/packages/xxscreeps/mods/powerbank/game.ts
+++ b/packages/xxscreeps/mods/powerbank/game.ts
@@ -1,0 +1,14 @@
+import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import { registerGlobal } from 'xxscreeps/game/index.js';
+import * as PowerBank from './powerbank.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const powerBankSchema = registerVariant('Room.objects', PowerBank.format);
+declare module 'xxscreeps/game/room/index.js' {
+	interface Schema { powerbank: [ typeof powerBankSchema ] }
+}
+
+registerGlobal(PowerBank.StructurePowerBank);
+declare module 'xxscreeps/game/runtime.js' {
+	interface Global { StructurePowerBank: typeof PowerBank.StructurePowerBank }
+}

--- a/packages/xxscreeps/mods/powerbank/index.ts
+++ b/packages/xxscreeps/mods/powerbank/index.ts
@@ -1,0 +1,11 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/combat',
+		'xxscreeps/mods/creep',
+		'xxscreeps/mods/resource',
+		'xxscreeps/mods/structure',
+	],
+	provides: [ 'backend', 'game', 'processor', 'test' ],
+};

--- a/packages/xxscreeps/mods/powerbank/powerbank.ts
+++ b/packages/xxscreeps/mods/powerbank/powerbank.ts
@@ -1,0 +1,59 @@
+import type { RoomPosition } from 'xxscreeps/game/position.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import * as RoomObject from 'xxscreeps/game/object.js';
+import { captureDamage } from 'xxscreeps/game/processor.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
+import { Creep } from 'xxscreeps/mods/creep/creep.js';
+import { Structure, structureFormat } from 'xxscreeps/mods/structure/structure.js';
+import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
+import { assign } from 'xxscreeps/utility/utility.js';
+import { PowerBankStore, powerBankStoreFormat } from './store.js';
+
+export const format = declare('PowerBank', () => compose(shape, StructurePowerBank));
+const shape = struct(structureFormat, {
+	...variant('powerBank'),
+	hits: 'int32',
+	store: powerBankStoreFormat,
+	'#nextDecayTime': 'int32',
+});
+
+export class StructurePowerBank extends withOverlay(Structure, shape) {
+	@enumerable get power() { return this.store[C.RESOURCE_POWER]; }
+	@enumerable get ticksToDecay() { return RoomObject.requiredExpiryTime(Game, this['#nextDecayTime']); }
+	@enumerable get owner() { return { username: 'Power Bank' }; }
+	@enumerable override get my() { return false; }
+	override get hitsMax() { return C.POWER_BANK_HITS; }
+	override get structureType() { return C.STRUCTURE_POWER_BANK; }
+
+	override '#applyDamage'(power: number, type: number, source?: RoomObject.RoomObject) {
+		if (this.hits <= 0) {
+			return;
+		}
+		super['#applyDamage'](power, type, source);
+		// Divergence from Screeps, which also emits a hit-back event for non-creep attackers that
+		// never take the damage
+		if (source instanceof Creep && this.room.controller?.safeMode === undefined) {
+			const damage = captureDamage(source, power * C.POWER_BANK_HIT_BACK, C.EVENT_ATTACK_TYPE_HIT_BACK, null);
+			if (damage > 0) {
+				appendEventLog(this.room, {
+					event: C.EVENT_ATTACK,
+					objectId: this.id,
+					targetId: source.id,
+					attackType: C.EVENT_ATTACK_TYPE_HIT_BACK,
+					damage,
+				});
+				source['#applyDamage'](damage, C.EVENT_ATTACK_TYPE_HIT_BACK, this);
+			}
+		}
+	}
+}
+
+export function create(pos: RoomPosition, power: number) {
+	const bank = assign(RoomObject.create(new StructurePowerBank(), pos), {
+		hits: C.POWER_BANK_HITS,
+		store: PowerBankStore['#create'](power),
+	});
+	bank['#nextDecayTime'] = Game.time + C.POWER_BANK_DECAY;
+	return bank;
+}

--- a/packages/xxscreeps/mods/powerbank/powerbank.ts
+++ b/packages/xxscreeps/mods/powerbank/powerbank.ts
@@ -27,6 +27,9 @@ export class StructurePowerBank extends withOverlay(Structure, shape) {
 	override get structureType() { return C.STRUCTURE_POWER_BANK; }
 
 	override '#applyDamage'(power: number, type: number, source?: RoomObject.RoomObject) {
+		// FIXME: removal is deferred to the object flush, so a creep can still attack this bank the
+		// tick it dies; bail to suppress the spurious second hit-back. Remove once intents stop
+		// resolving queued-for-removal targets.
 		if (this.hits <= 0) {
 			return;
 		}

--- a/packages/xxscreeps/mods/powerbank/processor.ts
+++ b/packages/xxscreeps/mods/powerbank/processor.ts
@@ -1,0 +1,11 @@
+import { registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import { StructurePowerBank } from './powerbank.js';
+
+registerObjectTickProcessor(StructurePowerBank, (powerBank, context) => {
+	if (powerBank.ticksToDecay === 0) {
+		powerBank.room['#removeObject'](powerBank);
+		context.didUpdate();
+	} else {
+		context.wakeAt(powerBank['#nextDecayTime']);
+	}
+});

--- a/packages/xxscreeps/mods/powerbank/store.ts
+++ b/packages/xxscreeps/mods/powerbank/store.ts
@@ -1,0 +1,50 @@
+import type { ResourceType } from 'xxscreeps/mods/resource/resource.js';
+import type { BufferView } from 'xxscreeps/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Store } from 'xxscreeps/mods/resource/store.js';
+import { compose, struct, withOverlay } from 'xxscreeps/schema/index.js';
+
+const shape = struct({
+	'#power': 'int32',
+});
+export const powerBankStoreFormat = () => compose(shape, PowerBankStore);
+
+export class PowerBankStore extends withOverlay(Store, shape) {
+	constructor(view?: BufferView, offset?: number) {
+		super(view, offset);
+		const power = this['#power'];
+		if (power > 0) {
+			this[C.RESOURCE_POWER] = power;
+		}
+	}
+
+	static '#create'(power: number) {
+		const instance = new PowerBankStore();
+		instance['#add'](C.RESOURCE_POWER, power);
+		return instance;
+	}
+
+	override '#doesAllowWithdraw'() { return false; }
+
+	'#storeCapacityResource'() { return null; }
+
+	getCapacity(_resourceType?: ResourceType) { return null; }
+
+	getUsedCapacity(resourceType: typeof C.RESOURCE_POWER): number;
+	getUsedCapacity(resourceType?: ResourceType): null;
+	getUsedCapacity(resourceType?: ResourceType) {
+		return resourceType === C.RESOURCE_POWER ? this['#power'] : null;
+	}
+
+	'#add'(type: ResourceType, amount: number) {
+		if (type === C.RESOURCE_POWER) {
+			this['#power'] = this[C.RESOURCE_POWER] += amount;
+		}
+	}
+
+	'#subtract'(type: ResourceType, amount: number) {
+		if (type === C.RESOURCE_POWER) {
+			this['#power'] = this[C.RESOURCE_POWER] -= amount;
+		}
+	}
+}

--- a/packages/xxscreeps/mods/powerbank/store.ts
+++ b/packages/xxscreeps/mods/powerbank/store.ts
@@ -5,14 +5,14 @@ import { Store } from 'xxscreeps/mods/resource/store.js';
 import { compose, struct, withOverlay } from 'xxscreeps/schema/index.js';
 
 const shape = struct({
-	'#power': 'int32',
+	'#amount': 'int32',
 });
 export const powerBankStoreFormat = () => compose(shape, PowerBankStore);
 
 export class PowerBankStore extends withOverlay(Store, shape) {
 	constructor(view?: BufferView, offset?: number) {
 		super(view, offset);
-		const power = this['#power'];
+		const power = this['#amount'];
 		if (power > 0) {
 			this[C.RESOURCE_POWER] = power;
 		}
@@ -33,18 +33,18 @@ export class PowerBankStore extends withOverlay(Store, shape) {
 	getUsedCapacity(resourceType: typeof C.RESOURCE_POWER): number;
 	getUsedCapacity(resourceType?: ResourceType): null;
 	getUsedCapacity(resourceType?: ResourceType) {
-		return resourceType === C.RESOURCE_POWER ? this['#power'] : null;
+		return resourceType === C.RESOURCE_POWER ? this['#amount'] : null;
 	}
 
 	'#add'(type: ResourceType, amount: number) {
 		if (type === C.RESOURCE_POWER) {
-			this['#power'] = this[C.RESOURCE_POWER] += amount;
+			this['#amount'] = this[C.RESOURCE_POWER] += amount;
 		}
 	}
 
 	'#subtract'(type: ResourceType, amount: number) {
 		if (type === C.RESOURCE_POWER) {
-			this['#power'] = this[C.RESOURCE_POWER] -= amount;
+			this['#amount'] = this[C.RESOURCE_POWER] -= amount;
 		}
 	}
 }

--- a/packages/xxscreeps/mods/powerbank/test.ts
+++ b/packages/xxscreeps/mods/powerbank/test.ts
@@ -1,0 +1,126 @@
+import type { PartType } from 'xxscreeps/mods/creep/creep.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { create as createPowerBank } from './powerbank.js';
+
+interface PowerBankSimOptions {
+	body?: PartType[];
+	decayTicks?: number;
+	hits?: number;
+}
+
+const bankPower = 1000;
+
+function powerBankSim(options: PowerBankSimOptions = {}) {
+	return simulate({
+		W1N1: room => {
+			const bank = createPowerBank(new RoomPosition(25, 25, 'W1N1'), bankPower);
+			bank['#nextDecayTime'] = Game.time + (options.decayTicks ?? 100);
+			if (options.hits !== undefined) {
+				bank.hits = options.hits;
+			}
+			room['#insertObject'](bank);
+			room['#insertObject'](createCreep(
+				new RoomPosition(25, 26, 'W1N1'),
+				options.body ?? [ C.ATTACK ],
+				'attacker',
+				'100'));
+		},
+	});
+}
+
+describe('PowerBank', () => {
+	test('surface is hostile and rejects transfer & withdraw', () => powerBankSim()(async ({ player }) => {
+		await player('100', Game => {
+			const room = Game.rooms.W1N1!;
+			const bank = lookForStructures(room, C.STRUCTURE_POWER_BANK)[0]!;
+			assert.strictEqual(bank.power, bankPower);
+			assert.strictEqual(bank.store[C.RESOURCE_POWER], bankPower);
+			assert.strictEqual(bank.hits, C.POWER_BANK_HITS);
+			assert.strictEqual(bank.hitsMax, C.POWER_BANK_HITS);
+			assert.strictEqual(bank.my, false);
+			assert.strictEqual(bank.owner.username, 'Power Bank');
+			assert.strictEqual(room.find(C.FIND_HOSTILE_STRUCTURES)[0]?.id, bank.id);
+			const attacker = Game.creeps.attacker!;
+			assert.strictEqual(attacker.withdraw(bank, C.RESOURCE_POWER), C.ERR_INVALID_TARGET);
+			assert.strictEqual(attacker.transfer(bank, C.RESOURCE_POWER), C.ERR_INVALID_TARGET);
+		});
+	}));
+
+	test('decays silently without a ruin or dropped power', () => powerBankSim({
+		decayTicks: 2,
+	})(async ({ player, tick }) => {
+		await tick(2);
+		await player('100', Game => {
+			const room = Game.rooms.W1N1!;
+			assert.strictEqual(lookForStructures(room, C.STRUCTURE_POWER_BANK).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_RUINS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_RESOURCES).length, 0);
+		});
+	}));
+
+	test('melee attack reflects damage', () => powerBankSim()(async ({ player, tick }) => {
+		await player('100', Game => {
+			const bank = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_BANK)[0]!;
+			assert.strictEqual(Game.creeps.attacker?.attack(bank), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const room = Game.rooms.W1N1!;
+			const bank = lookForStructures(room, C.STRUCTURE_POWER_BANK)[0]!;
+			const attacker = Game.creeps.attacker!;
+			assert.strictEqual(bank.hits, C.POWER_BANK_HITS - C.ATTACK_POWER);
+			assert.strictEqual(attacker.hits, 100 - C.ATTACK_POWER * C.POWER_BANK_HIT_BACK);
+			const hitBack = room.getEventLog().find(event =>
+				event.event === C.EVENT_ATTACK && event.data?.attackType === C.EVENT_ATTACK_TYPE_HIT_BACK);
+			assert.ok(hitBack, 'expected a hit-back attack event');
+			assert.strictEqual(hitBack.objectId, bank.id);
+			assert.ok(hitBack.data, 'expected nested data payload');
+			assert.strictEqual(hitBack.data.targetId, attacker.id);
+			assert.strictEqual(hitBack.data.damage, C.ATTACK_POWER * C.POWER_BANK_HIT_BACK);
+		});
+	}));
+
+	test('ranged attack reflects damage', () => powerBankSim({
+		body: [ C.RANGED_ATTACK ],
+	})(async ({ player, tick }) => {
+		await player('100', Game => {
+			const bank = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_BANK)[0]!;
+			assert.strictEqual(Game.creeps.attacker?.rangedAttack(bank), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const bank = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_BANK)[0]!;
+			assert.strictEqual(bank.hits, C.POWER_BANK_HITS - C.RANGED_ATTACK_POWER);
+			assert.strictEqual(Game.creeps.attacker?.hits, 100 - C.RANGED_ATTACK_POWER * C.POWER_BANK_HIT_BACK);
+		});
+	}));
+
+	test('killing blow leaves a lootable ruin and still reflects', () => powerBankSim({
+		hits: 10,
+	})(async ({ player, tick }) => {
+		await player('100', Game => {
+			const bank = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_BANK)[0]!;
+			assert.strictEqual(Game.creeps.attacker?.attack(bank), C.OK);
+		});
+		await tick();
+		await player('100', Game => {
+			const room = Game.rooms.W1N1!;
+			assert.strictEqual(lookForStructures(room, C.STRUCTURE_POWER_BANK).length, 0);
+			const ruin = room['#lookFor'](C.LOOK_RUINS)[0]!;
+			assert.strictEqual(ruin.store[C.RESOURCE_POWER], bankPower);
+			assert.strictEqual(ruin.ticksToDecay, C.RUIN_DECAY_STRUCTURES.powerBank);
+			assert.strictEqual(ruin.structureType, C.STRUCTURE_POWER_BANK);
+			assert.strictEqual(Game.creeps.attacker?.hits, 100 - C.ATTACK_POWER * C.POWER_BANK_HIT_BACK);
+			const log = room.getEventLog();
+			assert.ok(log.some(event =>
+				event.event === C.EVENT_OBJECT_DESTROYED && event.objectId === ruin.structure.id));
+			assert.ok(log.some(event =>
+				event.event === C.EVENT_ATTACK && event.data?.attackType === C.EVENT_ATTACK_TYPE_HIT_BACK));
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/powerbank/test.ts
+++ b/packages/xxscreeps/mods/powerbank/test.ts
@@ -24,11 +24,7 @@ function powerBankSim(options: PowerBankSimOptions = {}) {
 				bank.hits = options.hits;
 			}
 			room['#insertObject'](bank);
-			room['#insertObject'](createCreep(
-				new RoomPosition(25, 26, 'W1N1'),
-				options.body ?? [ C.ATTACK ],
-				'attacker',
-				'100'));
+			room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), options.body ?? [ C.ATTACK ], 'attacker', '100'));
 		},
 	});
 }


### PR DESCRIPTION
Adds `mods/powerbank` with `StructurePowerBank`:

- Plain `Structure` (no owner bytes) with `my === false` and an `owner` getter, so banks appear in `FIND_HOSTILE_STRUCTURES` and work as ranged-mass-attack targets with no combat-mod changes.
- `PowerBankStore`: single `power` resource, no capacity, withdraw and transfer both rejected with `ERR_INVALID_TARGET`.
- Damage from creep attackers reflects at `POWER_BANK_HIT_BACK` through `captureDamage`, including on the killing blow, with the `EVENT_ATTACK_TYPE_HIT_BACK` event entry. Non-creep attackers don't reflect — the reflected damage is a dead write upstream; we also skip the event-log entry (commented at the site).
- Natural decay after `POWER_BANK_DECAY` ticks removes the bank silently; violent destruction leaves a ruin carrying the power (`RUIN_DECAY_STRUCTURES.powerBank`).
- Backend renders map key `pb`, the store, and `decayTime`; the runtime global stub is replaced by the real class.
- `create(pos, power)` is the entry point for the spawn-policy PR stacked on this one.

## Validation
- `pnpm run build` + `npx xxscreeps test`: 424 passed, including 5 new PowerBank tests — hostile surface and withdraw/transfer rejection, silent decay (no ruin, no drop), melee and ranged hit-back with event-log entries, killing-blow ruin loot with reflect.
- Live smoke on a local world (~3200 ticks across two server runs): bank injected into an active bot's room survived blob round-trips and server restarts, sat as an obstacle while the room ticked, then decayed silently at its exact `#nextDecayTime` — no ruin, no dropped power, no processor errors or expiry throws.
- Client render verified in the web client: bank draws at its tile with store and hits, plus the `pb` map-view dot.
- `eslint` on the mod: zero new warnings except one `no-unsafe-return` in `backend.ts` from `renderStore`'s untyped return, identical to every existing consumer (container/ruin/tombstone); typing that helper is a separate cleanup.
