### PR TITLE
sandbox: treat a mid-deserialize memory-limit disposal as a disposed tick

### DIFF
--- a/.changeset/memory-limit-clone-disposal.md
+++ b/.changeset/memory-limit-clone-disposal.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Treat a memory-limit disposal mid-deserialize as a disposed tick, not an error.

--- a/packages/xxscreeps/driver/sandbox/isolated/index.ts
+++ b/packages/xxscreeps/driver/sandbox/isolated/index.ts
@@ -142,7 +142,11 @@ export class IsolatedSandbox implements Sandbox {
 			} else if (
 				err.message === 'Isolate is disposed' ||
 				err.message === 'Isolate was disposed during execution' ||
-				err.message === 'Isolate was disposed during execution due to memory limit'
+				err.message === 'Isolate was disposed during execution due to memory limit' ||
+				// The memory-limit reaper can dispose the isolate while a tick payload is being
+				// deserialized on its thread, which surfaces as v8's generic clone error rather than
+				// one of the disposal messages above.
+				(err.message === 'Unable to deserialize cloned data.' && this.isolate.isDisposed)
 			) {
 				return { result: 'disposed' };
 			}


### PR DESCRIPTION
Follow-up to #242. With `memoryLimit` now enforced, the reaper can dispose an isolate while a tick payload is deserializing on its thread; v8 reports that as a generic `Unable to deserialize cloned data.` rather than a known disposal message, so `run()` rethrew it and dropped the tick through the error path. Classify it as `disposed` when the isolate is in fact disposed — a live isolate throwing the same message still propagates.

For the player, a bot hitting the memory cap at this moment previously lost the tick silently (server-side stack trace only); it now gets the standard `Script was disposed` console message, the same as every other memory-limit disposal.

## Validation

Reproduced live: ZeSwarm OOM-cycling the 256 MB cap; `getHeapStatistics()` confirmed the isolate was already disposed at the clone error. No automated test — the race needs the reaper firing mid-deserialize (cf. #243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
