### PR TITLE
invader: render core level, deploy time, and invulnerability effect

### DIFF
--- a/.changeset/invader-core-render.md
+++ b/.changeset/invader-core-render.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Render invader core level, deploy time, and invulnerability effect to the client.

--- a/packages/xxscreeps/mods/invader/backend.ts
+++ b/packages/xxscreeps/mods/invader/backend.ts
@@ -10,12 +10,12 @@ bindRenderer(StructureInvaderCore, (core, next) => {
 	return {
 		...next(),
 		level: core.level,
-		...deployTime ? {
+		...deployTime > 0 && {
 			deployTime,
 			// The client divides remaining ticks by `duration` for the effect countdown; vanilla's
 			// backend stamps the fixed 5000-tick stronghold deploy window here.
 			effects: [ { effect: C.EFFECT_INVULNERABILITY, endTime: deployTime, duration: 5000 } ],
-		} : undefined,
+		},
 	};
 });
 

--- a/packages/xxscreeps/mods/invader/backend.ts
+++ b/packages/xxscreeps/mods/invader/backend.ts
@@ -1,8 +1,23 @@
 import type { JSONSchemaType } from 'ajv';
-import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { bindRenderer, hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { pushIntentsForRoomNextTick } from 'xxscreeps/engine/processor/model.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { StructureInvaderCore } from './invader-core.js';
+
+bindRenderer(StructureInvaderCore, (core, next) => {
+	const deployTime = core['#deployTime'];
+	return {
+		...next(),
+		level: core.level,
+		...deployTime ? {
+			deployTime,
+			// The client divides remaining ticks by `duration` for the effect countdown; vanilla's
+			// backend stamps the fixed 5000-tick stronghold deploy window here.
+			effects: [ { effect: C.EFFECT_INVULNERABILITY, endTime: deployTime, duration: 5000 } ],
+		} : undefined,
+	};
+});
 
 interface CreateInvaderRequest {
 	room: string;


### PR DESCRIPTION
The room socket sent invader cores as bare structures — no level, deploy
countdown, or invulnerability in the client panel. Bind a `StructureInvaderCore`
renderer emitting `level`, `deployTime`, and a derived `effects` entry (client
wire shape `{ effect, endTime, duration }`), all from the existing `#deployTime`.

No automated test — the harness doesn't load the `backend` mod slot; validated
manually.

## Validation

- `tsc -b` + eslint clean; 398/398 in-repo tests.
- Render payload dumped through the `[Render]` chain: deploying core carries
  `level`/`deployTime`/`effects`, deployed core only `level`.
- Client: deploying core's panel shows the `EFFECT_INVULNERABILITY` icon
  and "Deploying in" countdown; gone once deployed.

#251 also binds a core renderer — renderers don't stack, so whichever lands
second folds both into one `bindRenderer`.
