### PR TITLE
client: render effect-icon tooltip via uib-tooltip directive

### DIFF
--- a/.changeset/client-effect-icon-tooltip.md
+++ b/.changeset/client-effect-icon-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/client": patch
+---
+
+Render the effect-icon tooltip via uib-tooltip so the live countdown shows.

--- a/packages/client/backend.ts
+++ b/packages/client/backend.ts
@@ -107,6 +107,17 @@ if (clientPackage) {
 					// Replace official CDN with local assets
 					const content = await file.async('text');
 					return content.replace(/https:\/\/d3os7yery2usni\.cloudfront\.net\//g, '/assets/');
+				} else if (path === 'components/game/room/effect-icon/effect-icon.html') {
+					// The effect icon's countdown lives in a native `title`, which the browser
+					// re-arms on every tick the text changes, so the tooltip never settles long
+					// enough to render. Reuse the same expression as a `uib-tooltip`
+					// directive — the tooltip directive this client's ui-bootstrap 2.5.0 actually
+					// registers (legacy unprefixed `tooltip-html-unsafe` is not), which shows on
+					// mouseenter and re-interpolates each digest so the countdown stays live.
+					const content = await file.async('text');
+					return content.replace(
+						/(<div class='effect-icon')\s+title="([^"]*)"/,
+						(full: string, div: string, expr: string) => `${div} tooltip-append-to-body='true' tooltip-placement='top' uib-tooltip="${expr.replace(/\\n/g, ' ')}"`);
 				} else {
 					// JSZip doesn't implement their read stream correctly and it causes EPIPE crashes. Pass it
 					// through a no-op transform stream first to iron that out.


### PR DESCRIPTION
The effect icon's countdown lives in a native `title`; its text changes every
tick, so at this tick rate the browser keeps re-arming the hover delay and the
tooltip never shows. Rewrite it on serve to `uib-tooltip` (the directive this
client's ui-bootstrap 2.5.0 registers), which opens on mouseenter and stays live.

## Validation

Built `@xxscreeps/client` and ran the backend against a live shard. Hovered an
invader core's deploy effect icon: tooltip shows `EFFECT_INVULNERABILITY — Ticks
remaining: N / 5000`, counting down live, ticking and paused.
<img width="227" height="137" alt="Screenshot 2026-06-13 at 4 27 48 PM" src="https://github.com/user-attachments/assets/323db933-d26d-45b7-baba-80eb66d92826" />
