### PR TITLE
client: serve rewritten effect-icon template with no-store

### DIFF
--- a/.changeset/client-effect-icon-no-cache.md
+++ b/.changeset/client-effect-icon-no-cache.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/client": patch
+---
+
+Serve the rewritten effect-icon template with no-store so returning clients see updates.

--- a/packages/client/backend.ts
+++ b/packages/client/backend.ts
@@ -30,10 +30,18 @@ if (clientPackage) {
 				return next();
 			}
 
+			// effect-icon.html is rewritten from server-side template logic, so its content
+			// can change while the Steam package — and the `?bust` token baked into the
+			// client — stays the same. Caching it on the package version would freeze
+			// returning clients on a stale rewrite, so it's always re-fetched.
+			const serverDependent = path === 'components/game/room/effect-icon/effect-icon.html';
+
 			// Check cached response based on zip file modification
-			context.lastModified = lastModified;
-			if (context.fresh) {
-				return;
+			if (!serverDependent) {
+				context.lastModified = lastModified;
+				if (context.fresh) {
+					return;
+				}
 			}
 
 			context.body = await async function() {
@@ -144,11 +152,15 @@ if (clientPackage) {
 				'.woff2': 'font/woff2',
 			}[/\.[^.]+$/.exec(path.toLowerCase())?.[0] ?? '.html']!);
 
-			// We can safely cache explicitly-versioned resources forever
-			if (Boolean(context.query.bust)) {
-				context.set('Cache-Control', 'public,max-age=31536000,immutable');
+			if (serverDependent) {
+				context.set('Cache-Control', 'no-store');
+			} else {
+				// We can safely cache explicitly-versioned resources forever
+				if (Boolean(context.query.bust)) {
+					context.set('Cache-Control', 'public,max-age=31536000,immutable');
+				}
+				context.set('Last-Modified', `${new Date(lastModified)}`);
 			}
-			context.set('Last-Modified', `${new Date(lastModified)}`);
 
 			// Don't send any auth tokens for these requests
 			// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error


### PR DESCRIPTION
A tiptoe down the rabbit hole with this one. This bit me while trying to troubleshoot the earlier fix #255 and I think this is a focused enough caching change that it fits nicely. The big issue being that as we fix things like #255 if they're cached for a year, it's harder for others to see the fix.

The middleware rewrites `effect-icon.html` from server code, but the client
requests it as `?bust=<token>` (token fixed in `build.min.js`), so the response
is cached `immutable` and returning browsers never see later rewrite fixes —
#255's tooltip fix included — without a hard refresh. Removing `immutable` alone
wouldn't help: the `Last-Modified`/`context.fresh` fallback keys off the package
mtime, which also doesn't move on server-code changes, so it would still `304`.
Mark the template server-dependent: skip the freshness short-circuit and send
`no-store`. `build.min.js` stays `immutable` (its rewrite is a pure function of
the package).

`index.html` and `config.js` share the root cause and are deferred — both
benefit from caching, so they want a content ETag, not `no-store`. Already-cached
clients need one hard refresh; this only prevents the freeze going forward.

## Validation

`curl -I` against the running backend:
- `effect-icon.html?bust=…` → `200`, `no-store`, no `immutable`/`Last-Modified`;
  with a future `If-Modified-Since` still `200` (not `304`).
- `build.min.js?bust=…` → still `immutable`; a non-bust path (`config.js`) with
  the same `If-Modified-Since` → `304` (freshness validator intact elsewhere).
- `pnpm run build` + `eslint` clean.
