### PR TITLE
functional: stop Fn.lookAhead leaking an unhandled rejection when a source throws

### DIFF
--- a/.changeset/lookahead-unhandled-rejection.md
+++ b/.changeset/lookahead-unhandled-rejection.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix Fn.lookAhead leaking an unhandled rejection when a source iterator throws.

--- a/packages/xxscreeps/functional/asyncIterable/lookAhead.ts
+++ b/packages/xxscreeps/functional/asyncIterable/lookAhead.ts
@@ -10,15 +10,18 @@ export function lookAhead<Type>(iterable: AsyncIterable<Type>, count = 1): Async
 	return async function*() {
 		const iterator = iterable[Symbol.asyncIterator]();
 		try {
+			// The prefetch is floated to pump the queue ahead of the consumer; a rejection
+			// still surfaces through the awaited `queue[0]`, so each float takes a no-op
+			// rejection handler to avoid leaking a duplicate unhandled rejection.
 			const push = (result: IteratorResult<Type>) => {
 				if (!result.done && queue.length <= count) {
 					const next = iterator.next();
-					void next.then(push);
+					void next.then(push, () => {});
 					queue.push(next);
 				}
 			};
 			const first = iterator.next();
-			void first.then(push);
+			void first.then(push, () => {});
 			const queue: [ QueueItem, ...QueueItem[] ] = [ first ];
 			while (true) {
 				const next = await queue[0];


### PR DESCRIPTION
Believed source of a shutdown crash I encountered some time back. This was salvaged as a snippet from a larger branch that didn't make the 'overengineered' cut. Maybe would have been better as an issue for you to review, but here it is.

`Fn.lookAhead` prefetches `iterator.next()` and floats it (`void next.then(push)`) to pump the next read. That float has no rejection handler, so when a source iterator throws it raises a second, **unhandled** rejection — the real error already reaches the consumer through the queue `await`, so the float is a pure duplicate. `engine/service/signal.ts` escalates any unhandled rejection to `process.exit(1)`.

This bites where `Fn.lookAhead` drives a `shard.scratch` consumer and a `keyval.eval` rejects — a redis error, or a connection closing mid-tick during shutdown. In the processor the consumer runs inside `Async.mustNotReject`, which logs and `process.exit()`s with code 0; the floated duplicate races that and turns the clean exit into a `process.exit(1)` crash. The runner's consumer isn't wrapped — it exits non-zero on the real error regardless — so there the float is a redundant leak.

Add a no-op rejection handler to both prefetch pumps so the duplicate is handled; the real error still surfaces via the consumer `await`. The handlers are commented inline so they aren't removed as dead code.

## Validation
- Reproduced manually: a source iterator that throws makes stock `Fn.lookAhead` raise a second, unhandled rejection — in-process it trips `signal.ts`'s `process.exit(1)`. With the fix the duplicate is gone and the consumer still receives the real error.
- Full suite: 398 passed; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
