### PR TITLE
Add power spawns (processPower → Global Power Level)

### DIFF
--- a/.changeset/powerspawn-process-power.md
+++ b/.changeset/powerspawn-process-power.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add power spawns that process power into Global Power Level.

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -13,7 +13,6 @@ registerGlobal('_', lodash);
 registerGlobal(function Deposit() {});
 registerGlobal(function PowerCreep() {});
 registerGlobal(function StructurePowerBank() {});
-registerGlobal(function StructurePowerSpawn() {});
 
 hooks.register('runtimeConnector', {
 	initialize() {

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -15,6 +15,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/nuker',
 		'xxscreeps/mods/observer',
 		'xxscreeps/mods/portal',
+		'xxscreeps/mods/powerspawn',
 		'xxscreeps/mods/road',
 		'xxscreeps/mods/source',
 		'xxscreeps/mods/spawn',

--- a/packages/xxscreeps/mods/powerspawn/backend.ts
+++ b/packages/xxscreeps/mods/powerspawn/backend.ts
@@ -1,0 +1,8 @@
+import { bindRenderer } from 'xxscreeps/backend/index.js';
+import { renderStore } from 'xxscreeps/mods/resource/backend.js';
+import { StructurePowerSpawn } from './powerspawn.js';
+
+bindRenderer(StructurePowerSpawn, (powerSpawn, next) => ({
+	...next(),
+	...renderStore(powerSpawn.store),
+}));

--- a/packages/xxscreeps/mods/powerspawn/driver.ts
+++ b/packages/xxscreeps/mods/powerspawn/driver.ts
@@ -1,0 +1,17 @@
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { hooks } from 'xxscreeps/engine/runner/index.js';
+
+declare module 'xxscreeps/engine/runner/index.js' {
+	interface TickPayload {
+		power: number;
+	}
+}
+
+hooks.register('runnerConnector', player => {
+	const { shard, userId } = player;
+	return [ undefined, {
+		async refresh(payload) {
+			payload.power = Number(await shard.db.data.hGet(User.infoKey(userId), 'power')) || 0;
+		},
+	} ];
+});

--- a/packages/xxscreeps/mods/powerspawn/game.ts
+++ b/packages/xxscreeps/mods/powerspawn/game.ts
@@ -1,0 +1,49 @@
+import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
+import * as PowerSpawn from './powerspawn.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const powerSpawnSchema = registerVariant('Room.objects', PowerSpawn.format);
+declare module 'xxscreeps/game/room/index.js' {
+	interface Schema { powerspawn: [ typeof powerSpawnSchema ] }
+}
+
+// Save `Game.gpl` from driver
+declare module 'xxscreeps/game/game.js' {
+	interface Game {
+		gpl: {
+			/**
+			 * The current Global Power Level.
+			 */
+			level: number;
+
+			/**
+			 * The current progress to the next level.
+			 */
+			progress: number;
+
+			/**
+			 * The progress required to reach the next level.
+			 */
+			progressTotal: number;
+		};
+	}
+}
+
+hooks.register('gameInitializer', (Game, payload) => {
+	if (payload) {
+		const level = Math.floor((payload.power / C.POWER_LEVEL_MULTIPLY) ** (1 / C.POWER_LEVEL_POW));
+		const base = level ** C.POWER_LEVEL_POW * C.POWER_LEVEL_MULTIPLY;
+		Game.gpl = {
+			level,
+			progress: payload.power - base,
+			progressTotal: (level + 1) ** C.POWER_LEVEL_POW * C.POWER_LEVEL_MULTIPLY - base,
+		};
+	}
+});
+
+registerGlobal(PowerSpawn.StructurePowerSpawn);
+declare module 'xxscreeps/game/runtime.js' {
+	interface Global { StructurePowerSpawn: typeof PowerSpawn.StructurePowerSpawn }
+}

--- a/packages/xxscreeps/mods/powerspawn/index.ts
+++ b/packages/xxscreeps/mods/powerspawn/index.ts
@@ -1,0 +1,12 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/construction',
+		'xxscreeps/mods/controller',
+		'xxscreeps/mods/creep',
+		'xxscreeps/mods/resource',
+		'xxscreeps/mods/structure',
+	],
+	provides: [ 'backend', 'driver', 'game', 'processor', 'test' ],
+};

--- a/packages/xxscreeps/mods/powerspawn/powerspawn.ts
+++ b/packages/xxscreeps/mods/powerspawn/powerspawn.ts
@@ -1,0 +1,78 @@
+import { chainIntentChecks } from 'xxscreeps/game/checks.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { intents } from 'xxscreeps/game/index.js';
+import * as RoomObject from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { registerBuildableStructure } from 'xxscreeps/mods/construction/index.js';
+import { OwnedStructure, checkIsActive, checkMyStructure, checkPlacement, ownedStructureFormat } from 'xxscreeps/mods/structure/structure.js';
+import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
+import { assign } from 'xxscreeps/utility/utility.js';
+import { PowerSpawnStore, powerSpawnStoreFormat } from './store.js';
+
+export const format = declare('PowerSpawn', () => compose(shape, StructurePowerSpawn));
+const shape = struct(ownedStructureFormat, {
+	...variant('powerSpawn'),
+	hits: 'int32',
+	store: powerSpawnStoreFormat,
+});
+
+export class StructurePowerSpawn extends withOverlay(OwnedStructure, shape) {
+	/** @deprecated */
+	@enumerable get energy() { return this.store[C.RESOURCE_ENERGY]; }
+	/** @deprecated */
+	@enumerable get energyCapacity() { return this.store.getCapacity(C.RESOURCE_ENERGY); }
+	/** @deprecated */
+	@enumerable get power() { return this.store[C.RESOURCE_POWER]; }
+	/** @deprecated */
+	@enumerable get powerCapacity() { return this.store.getCapacity(C.RESOURCE_POWER); }
+
+	override get hitsMax() { return C.POWER_SPAWN_HITS; }
+	override get structureType() { return C.STRUCTURE_POWER_SPAWN; }
+
+	/**
+	 * Register power to be processed by the spawn. Consumes 1 power plus
+	 * `POWER_SPAWN_ENERGY_RATIO` energy each tick the intent is issued, raising the owner's GPL.
+	 */
+	processPower() {
+		return chainIntentChecks(
+			() => checkProcessPower(this),
+			() => intents.save(this, 'processPower'));
+	}
+}
+
+export function create(pos: RoomPosition, owner: string) {
+	const powerSpawn = assign(RoomObject.create(new StructurePowerSpawn(), pos), {
+		hits: C.POWER_SPAWN_HITS,
+		store: new PowerSpawnStore(),
+	});
+	powerSpawn['#user'] = owner;
+	return powerSpawn;
+}
+
+registerBuildableStructure(C.STRUCTURE_POWER_SPAWN, {
+	obstacle: true,
+	checkPlacement(room, pos) {
+		return checkPlacement(room, pos) === C.OK ? C.CONSTRUCTION_COST.powerSpawn : null;
+	},
+	create(site) {
+		return create(site.pos, site['#user']);
+	},
+});
+
+function checkProcessResources(powerSpawn: StructurePowerSpawn) {
+	if (
+		powerSpawn.store[C.RESOURCE_POWER] < 1 ||
+		powerSpawn.store[C.RESOURCE_ENERGY] < C.POWER_SPAWN_ENERGY_RATIO
+	) {
+		return C.ERR_NOT_ENOUGH_RESOURCES;
+	}
+	return C.OK;
+}
+
+export function checkProcessPower(powerSpawn: StructurePowerSpawn) {
+	return chainIntentChecks(
+		() => checkMyStructure(powerSpawn, StructurePowerSpawn),
+		() => checkIsActive(powerSpawn),
+		() => checkProcessResources(powerSpawn),
+	);
+}

--- a/packages/xxscreeps/mods/powerspawn/processor.ts
+++ b/packages/xxscreeps/mods/powerspawn/processor.ts
@@ -1,0 +1,20 @@
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { registerIntentProcessor } from 'xxscreeps/engine/processor/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { StructurePowerSpawn, checkProcessPower } from './powerspawn.js';
+
+declare module 'xxscreeps/engine/processor/index.js' {
+	interface Intent { powerspawn: typeof intents }
+}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const intents = [
+	registerIntentProcessor(StructurePowerSpawn, 'processPower', {}, (powerSpawn, context) => {
+		if (checkProcessPower(powerSpawn) !== C.OK) {
+			return;
+		}
+		powerSpawn.store['#subtract'](C.RESOURCE_POWER, 1);
+		powerSpawn.store['#subtract'](C.RESOURCE_ENERGY, C.POWER_SPAWN_ENERGY_RATIO);
+		context.task(context.shard.db.data.hincrBy(User.infoKey(powerSpawn['#user']!), 'power', 1));
+		context.didUpdate();
+	}),
+];

--- a/packages/xxscreeps/mods/powerspawn/store.ts
+++ b/packages/xxscreeps/mods/powerspawn/store.ts
@@ -1,0 +1,70 @@
+import type { ResourceType } from 'xxscreeps/mods/resource/resource.js';
+import type { BufferView } from 'xxscreeps/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Store } from 'xxscreeps/mods/resource/store.js';
+import { compose, struct, withOverlay } from 'xxscreeps/schema/index.js';
+
+const shape = struct({
+	'#energy': 'int32',
+	'#power': 'int32',
+});
+export const powerSpawnStoreFormat = () => compose(shape, PowerSpawnStore);
+
+export class PowerSpawnStore extends withOverlay(Store, shape) {
+	constructor(view?: BufferView, offset?: number) {
+		super(view, offset);
+		const energy = this['#energy'];
+		if (energy > 0) {
+			this[C.RESOURCE_ENERGY] = energy;
+		}
+		const power = this['#power'];
+		if (power > 0) {
+			this[C.RESOURCE_POWER] = power;
+		}
+	}
+
+	'#storeCapacityResource'() {
+		return {
+			[C.RESOURCE_ENERGY]: C.POWER_SPAWN_ENERGY_CAPACITY,
+			[C.RESOURCE_POWER]: C.POWER_SPAWN_POWER_CAPACITY,
+		};
+	}
+
+	getCapacity(resourceType: typeof C.RESOURCE_ENERGY | typeof C.RESOURCE_POWER): number;
+	getCapacity(resourceType?: ResourceType): null;
+	getCapacity(resourceType?: ResourceType): number | null {
+		// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+		switch (resourceType) {
+			case C.RESOURCE_ENERGY: return C.POWER_SPAWN_ENERGY_CAPACITY;
+			case C.RESOURCE_POWER: return C.POWER_SPAWN_POWER_CAPACITY;
+			default: return null;
+		}
+	}
+
+	getUsedCapacity(resourceType: typeof C.RESOURCE_ENERGY | typeof C.RESOURCE_POWER): number;
+	getUsedCapacity(resourceType?: ResourceType): null;
+	getUsedCapacity(resourceType?: ResourceType): number | null {
+		// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+		switch (resourceType) {
+			case C.RESOURCE_ENERGY: return this['#energy'];
+			case C.RESOURCE_POWER: return this['#power'];
+			default: return null;
+		}
+	}
+
+	'#add'(type: ResourceType, amount: number) {
+		// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+		switch (type) {
+			case C.RESOURCE_ENERGY: this['#energy'] = this[C.RESOURCE_ENERGY] += amount; break;
+			case C.RESOURCE_POWER: this['#power'] = this[C.RESOURCE_POWER] += amount; break;
+		}
+	}
+
+	'#subtract'(type: ResourceType, amount: number) {
+		// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+		switch (type) {
+			case C.RESOURCE_ENERGY: this['#energy'] = this[C.RESOURCE_ENERGY] -= amount; break;
+			case C.RESOURCE_POWER: this['#power'] = this[C.RESOURCE_POWER] -= amount; break;
+		}
+	}
+}

--- a/packages/xxscreeps/mods/powerspawn/test.ts
+++ b/packages/xxscreeps/mods/powerspawn/test.ts
@@ -1,0 +1,82 @@
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { create as createPowerSpawn } from './powerspawn.js';
+
+const owner = '100';
+const hostile = '101';
+
+describe('PowerSpawn', () => {
+	const sim = simulate({
+		W1N1: room => {
+			const powerSpawn = createPowerSpawn(new RoomPosition(25, 25, 'W1N1'), owner);
+			powerSpawn.store['#add'](C.RESOURCE_ENERGY, C.POWER_SPAWN_ENERGY_CAPACITY);
+			powerSpawn.store['#add'](C.RESOURCE_POWER, C.POWER_SPAWN_POWER_CAPACITY);
+			room['#insertObject'](powerSpawn);
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = owner;
+		},
+	});
+
+	test('store capacity is per-resource', () => sim(async ({ player }) => {
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.store.getCapacity(C.RESOURCE_ENERGY), C.POWER_SPAWN_ENERGY_CAPACITY);
+			assert.strictEqual(powerSpawn.store.getCapacity(C.RESOURCE_POWER), C.POWER_SPAWN_POWER_CAPACITY);
+			assert.strictEqual(powerSpawn.store.getCapacity(C.RESOURCE_OXYGEN), null);
+			assert.strictEqual(powerSpawn.store.getFreeCapacity(C.RESOURCE_ENERGY), 0);
+			assert.strictEqual(powerSpawn.power, C.POWER_SPAWN_POWER_CAPACITY);
+			assert.strictEqual(powerSpawn.energy, C.POWER_SPAWN_ENERGY_CAPACITY);
+		});
+	}));
+
+	test('processPower burns 1 power + POWER_SPAWN_ENERGY_RATIO energy and credits power XP', () => sim(async ({ player, shard, tick }) => {
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.processPower(), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.power, C.POWER_SPAWN_POWER_CAPACITY - 1);
+			assert.strictEqual(powerSpawn.energy, C.POWER_SPAWN_ENERGY_CAPACITY - C.POWER_SPAWN_ENERGY_RATIO);
+		});
+		assert.strictEqual(Number(await shard.db.data.hGet(User.infoKey(owner), 'power')), 1);
+	}));
+
+	test('processPower returns ERR_NOT_ENOUGH_RESOURCES without power', () => sim(async ({ player, poke }) => {
+		await poke('W1N1', owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			powerSpawn.store['#subtract'](C.RESOURCE_POWER, C.POWER_SPAWN_POWER_CAPACITY);
+		});
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.processPower(), C.ERR_NOT_ENOUGH_RESOURCES);
+		});
+	}));
+
+	test('processPower returns ERR_NOT_ENOUGH_RESOURCES below the energy ratio', () => sim(async ({ player, poke }) => {
+		await poke('W1N1', owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			powerSpawn.store['#subtract'](C.RESOURCE_ENERGY, C.POWER_SPAWN_ENERGY_CAPACITY - (C.POWER_SPAWN_ENERGY_RATIO - 1));
+		});
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.energy, C.POWER_SPAWN_ENERGY_RATIO - 1);
+			assert.strictEqual(powerSpawn.processPower(), C.ERR_NOT_ENOUGH_RESOURCES);
+		});
+	}));
+
+	test('processPower returns ERR_NOT_OWNER for a structure you do not own', () => sim(async ({ player, poke }) => {
+		await poke('W1N1', hostile, (Game, room) => {
+			room['#insertObject'](createCreep(new RoomPosition(25, 24, 'W1N1'), [ C.MOVE ], 'raider', hostile));
+		});
+		await player(hostile, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(powerSpawn.processPower(), C.ERR_NOT_OWNER);
+		});
+	}));
+});


### PR DESCRIPTION
Adds `StructurePowerSpawn` and its `processPower()` intent. A power spawn burns 1 power + `POWER_SPAWN_ENERGY_RATIO` energy per tick to raise the owner's Global Power Level, surfaced to the runtime as `Game.gpl` the same way `Game.gcl` is. The restricted store and the GPL driver → `gameInitializer` plumbing follow the nuker and controller mods respectively.

`PWR_OPERATE_POWER` boosting — and power creeps themselves — are deferred; this is the base structure plus GPL plumbing only.

## Validation
- `mods/powerspawn/test.ts` — 5 tests: placement / per-resource store capacity, `processPower` OK + consumption + power XP, two `ERR_NOT_ENOUGH_RESOURCES` boundaries, `ERR_NOT_OWNER`. Full suite green.
- screeps-ok parity catalog, this branch under `XXSCREEPS_LOCAL`: `POWER-SPAWN-001` (`processPower` OK, consumption, GPL credit), `POWER-SPAWN-003` (`ERR_NOT_ENOUGH_RESOURCES` — lacking power and lacking energy), `POWER-SPAWN-004` (`ERR_RCL_NOT_ENOUGH`), `POWER-SPAWN-005` (`ERR_NOT_OWNER`), `GPL-001` (initial `Game.gpl`) — all green.
