### PR TITLE
Report a creep spawned this tick as spawning the same tick

### DIFF
--- a/.changeset/spawn-same-tick-creep-spawning.md
+++ b/.changeset/spawn-same-tick-creep-spawning.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Report a creep spawned this tick as spawning the same tick.

--- a/packages/xxscreeps/mods/spawn/spawn.ts
+++ b/packages/xxscreeps/mods/spawn/spawn.ts
@@ -205,6 +205,8 @@ export class StructureSpawn extends withOverlay(OwnedStructure, shape) {
 				// Fake creep
 				const creep = createCreep(this.pos, body, name, this['#user']!);
 				creep.room = this.room;
+				// Spawning this tick; the processor assigns the real age
+				creep['#ageTime'] = 0;
 				userGame!.creeps[name] = creep;
 				return C.OK;
 			});


### PR DESCRIPTION
`StructureSpawn.spawnCreep` adds a same-tick placeholder creep to `Game.creeps`, but `createCreep` left its `#ageTime` at `Game.time + CREEP_LIFE_TIME`, so `spawning` (`#ageTime === 0`) read `false` the same tick — an intent on that creep skipped the `ERR_BUSY` guard. Setting `#ageTime = 0` puts the placeholder in the same state the processor assigns the real spawning creep (`mods/spawn/processor.ts`), so `spawning === true` and `ticksToLive === undefined`.

Known divergence: on the call-tick vanilla's synthetic creep reports `ticksToLive === CREEP_LIFE_TIME`, reverting to `undefined` for the rest of the spawn (the real creep carries no `ageTime` while spawning). Here `spawning` and `ticksToLive` both derive from one `#ageTime` field, so the call-tick reports `undefined` like every later spawning tick rather than reproducing the one-tick `1500`.

## Validation

Ran screeps-ok CREEP-SPAWNING-006 (same-tick `spawning === true`) and CREEP-SPAWNING-007 (same-tick `move` → `ERR_BUSY`, no throw); both flipped failing → passing.
