### PR TITLE
Add `manage bot` verbs and register the `manage` subcommand

### DIFF
--- a/.changeset/bot-manage.md
+++ b/.changeset/bot-manage.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `manage bot` verbs (add/update/remove, first-spawn for JS/wasm bots) and register the `manage` subcommand.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ schema](src/config/config.ts).
 
 If you want to use your bot script, use `npx xxscreeps import --overwrite-code ../your-bot/dist` to replace builtin bots.
 
+### Adding bots
+
+`import --overwrite-code` replaces the built-in bots. To add a *named* bot — and optionally place
+its first spawn — without touching the built-ins, use the `manage` subcommand:
+
+```
+npx xxscreeps manage bot add <name> <dir> --spawn <room>
+```
+
+`<dir>` is a flat directory of a bot's built modules — `main.js` (CommonJS), `main.mjs` (ESM), or a
+`main.wasm`/`*.wasm` binary. Subdirectories are ignored, so point it at the build output (often `src`
+or `dist`), not the source tree of a bot that still needs compiling. `--spawn` also places the bot's
+first spawn, whether or not a server is running; drop it to just save the code. Open-source bots
+published for vanilla servers work as-is:
+
+```
+npm install screeps-bot-tooangel
+npx xxscreeps manage bot add tooangel node_modules/screeps-bot-tooangel/src --spawn W5N5
+```
+
+`manage` also has `user` verbs plus `bot update`/`bot remove`; run `xxscreeps manage` with no
+arguments to print the full command list.
+
 ## Operator CLI
 
 `xxscreeps cli` opens a JavaScript REPL in the CLI process's host realm, and

--- a/packages/xxscreeps/config/nodejs.ts
+++ b/packages/xxscreeps/config/nodejs.ts
@@ -56,7 +56,10 @@ export const load: LoadHook = (urlString, context, nextLoad) => {
 			shortCircuit: true,
 			source: makeModSourceText(mods, provide),
 		};
-	} else if (privateTransformBase !== undefined && urlString.startsWith(privateTransformBase)) {
+	} else if (privateTransformBase !== undefined && urlString.startsWith(privateTransformBase) && context.importAttributes.type !== 'json') {
+		// JSON imports (`with { type: 'json' }`) aren't JavaScript, so they must skip the private
+		// transform and load through nodejs. `config.schema.json` only avoids this by loading before
+		// the hook installs; later JSON imports (e.g. `badge.schema.json`) hit the transform.
 		return async function() {
 			return {
 				format: 'module',

--- a/packages/xxscreeps/config/nodejs.ts
+++ b/packages/xxscreeps/config/nodejs.ts
@@ -56,10 +56,7 @@ export const load: LoadHook = (urlString, context, nextLoad) => {
 			shortCircuit: true,
 			source: makeModSourceText(mods, provide),
 		};
-	} else if (privateTransformBase !== undefined && urlString.startsWith(privateTransformBase) && context.importAttributes.type !== 'json') {
-		// JSON imports (`with { type: 'json' }`) aren't JavaScript, so they must skip the private
-		// transform and load through nodejs. `config.schema.json` only avoids this by loading before
-		// the hook installs; later JSON imports (e.g. `badge.schema.json`) hit the transform.
+	} else if (privateTransformBase !== undefined && urlString.startsWith(privateTransformBase) && context.importAttributes.type === undefined) {
 		return async function() {
 			return {
 				format: 'module',

--- a/packages/xxscreeps/engine/db/user/badge.ts
+++ b/packages/xxscreeps/engine/db/user/badge.ts
@@ -53,3 +53,17 @@ export function validate(badge: object): UserBadge {
 export async function save(db: Database, userId: string, badge: string) {
 	await db.data.hSet(User.infoKey(userId), 'badge', badge);
 }
+
+// Mirrors the vanilla private-server bot CLI (genRandomBadge) so freshly-added bots get a
+// distinct badge on the map instead of the default blank one.
+export function generateRandom(): UserBadge {
+	const color = () => `#${Math.floor(Math.random() * 0x1000000).toString(16).padStart(6, '0')}`;
+	return {
+		color1: color(),
+		color2: color(),
+		color3: color(),
+		flip: Math.random() > 0.5,
+		param: Math.floor(Math.random() * 200) - 100,
+		type: Math.floor(Math.random() * 24) + 1,
+	};
+}

--- a/packages/xxscreeps/engine/db/user/test.ts
+++ b/packages/xxscreeps/engine/db/user/test.ts
@@ -1,6 +1,19 @@
 import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { assert, describe, test } from 'xxscreeps/test/index.js';
+import * as Badge from './badge.js';
 import * as User from './index.js';
+
+describe('Badge.generateRandom', () => {
+	test('always produces a schema-valid badge', () => {
+		// A colour channel below 0x100000 renders as fewer than six hex digits; without
+		// zero-padding that fails the `^#[a-f0-9]{6}$` schema (~1/16 per channel), so loop
+		// enough times to surface it. validate() throws on a malformed badge.
+		for (let index = 0; index < 256; ++index) {
+			const badge = Badge.generateRandom();
+			assert.strictEqual(Badge.validate(badge), badge);
+		}
+	});
+});
 
 describe('User.remove', () => {
 	test('removed user is no longer found', async () => {

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -1,22 +1,41 @@
-// Ops tool for managing users on a self-hosted xxscreeps server — connects to the configured
-// storage provider directly, like scripts/scrape-world.ts. Run after `tsc -b`:
-// `node packages/xxscreeps/dist/scripts/manage.js user <verb> ...` (usage() lists commands).
+// Ops tool for managing users and bots on a self-hosted xxscreeps server — connects to the
+// configured storage provider directly, like scripts/scrape-world.ts. Registered as the `manage`
+// subcommand; run after `tsc -b`: `xxscreeps manage <user|bot> <verb> ...` (usage() lists commands).
 //
 // The running engine caches state: list/show/create read storage per request, but a new user isn't
-// processed until it owns an object in a room. `remove` deletes records only — owned room objects
-// are left alone — and is safe for inactive users; pause the engine first if the user is live.
+// processed until it owns an object in a room — `bot add --spawn` covers that by acquiring the game
+// mutex and applying the same claim/spawn mutation the `placeSpawn` intent performs, in between ticks,
+// so it works whether or not the server is running (a running server hands off the mutex between ticks).
+// Code saves are picked up by the runner on the next tick via the code channel. `remove` deletes
+// records only — owned room objects are left alone — and is safe for inactive users; pause the
+// engine first if the user is live.
 
 import * as fs from 'node:fs/promises';
+import * as nodePath from 'node:path';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { Mutex } from 'xxscreeps/engine/db/mutex.js';
 import * as Badge from 'xxscreeps/engine/db/user/badge.js';
 import * as Code from 'xxscreeps/engine/db/user/code.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
+import { updateUserRoomRelationships, userToIntentRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { primitiveComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game, GameState, runAsUser, runOneShot, runWithState } from 'xxscreeps/game/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { setPassword } from 'xxscreeps/mods/backend/password/model.js';
+import { checkCreateConstructionSite } from 'xxscreeps/mods/construction/room.js';
+import * as ControllerProc from 'xxscreeps/mods/controller/processor.js';
 import { deleteUserMemoryBlob, loadUserMemoryBlob } from 'xxscreeps/mods/memory/model.js';
+import { create as createSpawn } from 'xxscreeps/mods/spawn/spawn.js';
+import { createRuin } from 'xxscreeps/mods/structure/ruin.js';
+import { OwnedStructure } from 'xxscreeps/mods/structure/structure.js';
+
+import 'xxscreeps:mods/game';
 
 using db = await Database.connect();
 using shard = await Shard.connect(db, config.shards[0]!.name);
@@ -132,6 +151,172 @@ async function userBranch(who: string, branch: string) {
 	out(`Set active branch for ${who} (${id}) to '${branch}'.`);
 }
 
+// Modules are keyed by filename (`main.js`, ...) — the same shape the backend saves for players.
+async function loadCodeDir(dir: string) {
+	const names = await fs.readdir(dir);
+	const entries = await Fn.mapAwait(names, async name => {
+		const path = nodePath.join(dir, name);
+		if (!(await fs.stat(path)).isFile()) {
+			// Bots are a flat module map; a nested build tree would load partially and fail
+			// cryptically in the sandbox, so surface what's dropped instead of skipping silently.
+			process.stderr.write(`Warning: skipping non-file '${name}'; subdirectories are not loaded.\n`);
+			return undefined;
+		}
+		// `.wasm` modules are binary; reading them as utf8 corrupts the bytes. Store the raw bytes
+		// and key a required wasm module without the extension — `require('foo')` resolves `foo`,
+		// never `foo.wasm` — matching the upload format real bots use. The `main.wasm` WASI entry
+		// keeps its name so the runtime's entry detection still finds it.
+		const wasm = nodePath.extname(name) === '.wasm';
+		const content: string | Uint8Array = wasm ? await fs.readFile(path) : await fs.readFile(path, 'utf8');
+		const key = wasm && name !== 'main.wasm' ? nodePath.basename(name, '.wasm') : name;
+		return [ key, content ] as const;
+	});
+	const modules: Code.CodePayload = new Map(Fn.filter(entries, nonNullPredicate));
+	if (modules.size === 0) {
+		throw new Error(`No code files in ${dir}`);
+	}
+	if (![ 'main.js', 'main', 'main.mjs', 'main.wasm' ].some(name => modules.has(name))) {
+		process.stderr.write(`Warning: no main module in ${dir}; the bot has no entry point.\n`);
+	}
+	return modules;
+}
+
+// Shared by `bot add` and `bot update`. Code loads before any database write so a bad directory
+// can't leave a half-registered user.
+async function botSave(who: string, dir: string, branchArg: string | undefined, create: boolean) {
+	const modules = await loadCodeDir(dir);
+	const id = await async function() {
+		if (create) {
+			if (!User.checkUsername(who)) {
+				throw new Error(`Invalid username: ${who}`);
+			}
+			const existing = await User.findUserByName(db, who);
+			if (existing !== null) {
+				process.stderr.write(`User ${who} already exists (${existing}); updating its code.\n`);
+				return existing;
+			}
+			const id = Id.generateId(12);
+			await User.create(db, id, who);
+			// A new bot has no badge and renders blank on the map; assign a random one, as the
+			// vanilla bot CLI does. Existing users keep theirs.
+			await Badge.save(db, id, JSON.stringify(Badge.generateRandom()));
+			return id;
+		}
+		return resolveUserId(who);
+	}();
+	const branch = branchArg ?? await db.data.hGet(User.infoKey(id), 'branch') ?? 'default';
+	await Code.saveContent(db, id, branch, modules);
+	await save();
+	out(`Saved ${modules.size} module(s) to ${who} (${id}) branch '${branch}'.`);
+	return id;
+}
+
+async function botSpawn(userId: string, roomName: string, coords?: string) {
+	const position = function() {
+		if (coords === undefined) {
+			return undefined;
+		}
+		const [ xx = NaN, yy = NaN ] = coords.split(',').map(Number);
+		if (!Number.isInteger(xx) || !Number.isInteger(yy)) {
+			throw new Error(`Invalid coords: ${coords} (expected 'x,y')`);
+		}
+		return new RoomPosition(xx, yy, roomName);
+	}();
+
+	// Hold the game mutex so no tick runs while we mutate the room. A running server releases it
+	// between ticks; with no server it's uncontended and acquired immediately.
+	await using gameMutex = await Mutex.connect('game', shard.data, shard.pubsub);
+	await using lock = await gameMutex.acquire();
+
+	// Authoritative under the lock: the previous tick committed `time` before releasing the mutex,
+	// and no tick can start while we hold it.
+	const time = Number(await shard.data.get('time'));
+	const [ intentRooms, world ] = await Promise.all([
+		shard.scratch.sMembers(userToIntentRoomsSetKey(userId)),
+		shard.loadWorld(),
+	]);
+	if (intentRooms.length !== 0) {
+		throw new Error(`User has presence in: ${intentRooms.join(', ')}`);
+	}
+
+	// Validate the position (and pick a random one) against an owned copy of the room; this room is
+	// discarded — `runOneShot` mutates only in memory, nothing here is persisted.
+	const validateRoom = await shard.loadRoom(roomName, time);
+	const spawnPos = runOneShot(world, validateRoom, time, userId, () => {
+		if (!validateRoom.controller) {
+			throw new Error(`No controller in ${roomName}`);
+		}
+		if (validateRoom.controller.reservation || validateRoom.controller.owner) {
+			throw new Error(`Room is owned: ${roomName}`);
+		}
+		validateRoom['#user'] = validateRoom.controller['#user'] = userId;
+		validateRoom['#level'] = 1;
+		if (position) {
+			if (checkCreateConstructionSite(validateRoom, position, 'spawn', 'Spawn1') !== C.OK) {
+				throw new Error(`Invalid spawn position: ${position.x},${position.y}`);
+			}
+			return position;
+		}
+		const random = () => 3 + Math.floor(Math.random() * 46);
+		const found = Fn.find(
+			Fn.map(Fn.range(1000), () => new RoomPosition(random(), random(), roomName)),
+			pos => checkCreateConstructionSite(validateRoom, pos, 'spawn', 'Spawn1') === C.OK);
+		if (!found) {
+			throw new Error(`No valid spawn position found in ${roomName}`);
+		}
+		return found;
+	});
+
+	// Apply the spawn directly on a fresh, still-unowned room — the same mutation the `placeSpawn`
+	// intent performs (drop neutral objects, claim the controller, insert the spawn), but without the
+	// processor. `claim` queues its scratch writes through a minimal context we drain afterwards.
+	const room = await shard.loadRoom(roomName, time);
+	const state = new GameState(world, time + 1, [ room ]);
+	const tasks: Promise<unknown>[] = [];
+	const context = {
+		shard,
+		state,
+		didUpdate() {},
+		setActive() {},
+		wakeAt() {},
+		sendRoomIntent() {},
+		task(task: Promise<unknown>) {
+			tasks.push(task);
+		},
+	};
+	runWithState(state, () => runAsUser(userId, () => {
+		for (const object of room['#objects']) {
+			if (object['#user'] === null) {
+				if (object.hits !== undefined) {
+					room['#removeObject'](object);
+				}
+			} else if (object instanceof OwnedStructure) {
+				room['#insertObject'](createRuin(object, 100000));
+				room['#removeObject'](object);
+			} else {
+				room['#removeObject'](object);
+			}
+		}
+		ControllerProc.claim(context, room.controller!, userId);
+		room['#insertObject'](createSpawn(spawnPos, userId, 'Spawn1'));
+		room['#cumulativeEnergyHarvested'] = 0;
+		room['#safeModeUntil'] = Game.time + C.SAFE_MODE_DURATION;
+		room['#flushObjects'](state);
+	}));
+	await Promise.all(tasks);
+
+	// Persist both double-buffer slots so the room reads correctly whichever tick first processes it,
+	// and register the user/room relationship so the server keeps the room active.
+	const previousUsers = flushUsers(room);
+	await Promise.all([
+		updateUserRoomRelationships(shard, room, previousUsers),
+		shard.saveRoom(roomName, time, room),
+		shard.saveRoom(roomName, time + 1, room),
+	]);
+	await save();
+	out(`Placed spawn at ${spawnPos.x},${spawnPos.y} in ${roomName} (tick ${time}).`);
+}
+
 function usage(): never {
 	process.stderr.write(`Usage:
   user list
@@ -141,6 +326,9 @@ function usage(): never {
   user badge    <name|id> <json|file>
   user password <name|id> <password>
   user branch   <name|id> <branch>
+  bot  add    <name> <codeDir> [branch] [--spawn <room> [x,y]]
+  bot  update <name|id> <codeDir> [branch]
+  bot  remove <name|id>
 `);
 	process.exit(2);
 }
@@ -155,6 +343,20 @@ try {
 		case 'user badge': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBadge(rest[0], rest[1]); break;
 		case 'user password': if (rest[0] === undefined || rest[1] === undefined) usage(); await userPassword(rest[0], rest[1]); break;
 		case 'user branch': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBranch(rest[0], rest[1]); break;
+		case 'bot add': {
+			const spawnIndex = rest.indexOf('--spawn');
+			const args = spawnIndex === -1 ? rest : rest.slice(0, spawnIndex);
+			const spawnArgs = spawnIndex === -1 ? undefined : rest.slice(spawnIndex + 1);
+			if (args[0] === undefined || args[1] === undefined) usage();
+			const userId = await botSave(args[0], args[1], args[2], true);
+			if (spawnArgs !== undefined) {
+				if (spawnArgs[0] === undefined) usage();
+				await botSpawn(userId, spawnArgs[0], spawnArgs[1]);
+			}
+			break;
+		}
+		case 'bot update': if (rest[0] === undefined || rest[1] === undefined) usage(); await botSave(rest[0], rest[1], rest[2], false); break;
+		case 'bot remove': if (rest[0] === undefined) usage(); await userRemove(rest[0]); break;
 		default: usage();
 	}
 } catch (err) {

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -217,9 +217,6 @@ async function botSpawn(userId: string, roomName: string, coords?: string) {
 			return undefined;
 		}
 		const [ xx = NaN, yy = NaN ] = coords.split(',').map(Number);
-		if (!Number.isInteger(xx) || !Number.isInteger(yy)) {
-			throw new Error(`Invalid coords: ${coords} (expected 'x,y')`);
-		}
 		return new RoomPosition(xx, yy, roomName);
 	}();
 

--- a/packages/xxscreeps/xxscreeps.js
+++ b/packages/xxscreeps/xxscreeps.js
@@ -8,6 +8,7 @@ const specifier = process.argv[1];
 // Launch entry command
 const commands = {
 	import: './dist/scripts/scrape-world.js',
+	manage: './dist/scripts/manage.js',
 	start: './dist/engine/service/launcher.js',
 	main: './dist/engine/service/main.js',
 	backend: './dist/backend/server.js',


### PR DESCRIPTION
## Summary

Adds `manage bot` verbs — `bot add` / `bot update` / `bot remove` — alongside the existing
`user` verbs, and registers `manage` as an `xxscreeps` subcommand (previously run via
`node dist/scripts/manage.js`). `bot add` loads a flat directory of built modules (`main.js` CJS,
`main.mjs` ESM, or `main.wasm`/`*.wasm`), saves them under a named user (auto-assigning a random
badge to new users, matching the vanilla server's `genRandomBadge` so fresh bots aren't blank on
the map), and optionally places the bot's first spawn with `--spawn <room> [x,y]`.

Three non-obvious bits:

- **`--spawn` runs under the game mutex.** Instead of queueing a `placeSpawn` intent and waiting
  for the processor next tick, it acquires the `gameMutex` and applies the same claim/spawn
  mutation directly, between ticks — so it no longer requires a running server (a running server
  hands the mutex off cooperatively; with none it's uncontended). It reuses the engine's
  `create`/`claim` helpers and persists both double-buffer slots plus the user/room relationship,
  so the next processed tick picks the spawn up normally. Position validation still happens on a
  throwaway in-memory copy of the room; nothing is persisted until the mutation succeeds.

- **wasm keying matches the player upload format**: a `*.wasm` file is stored under its
  extension-stripped key (`require('foo')` resolves `foo`, not `foo.wasm`), while `main.wasm` keeps
  its name so the runtime's entry detection finds it.

- **The private transform now passes JSON imports through to nodejs**: `badge.ts` imports
  `badge.schema.json` `with { type: 'json' }`, which surfaced a latent loader bug — under
  `--private-transform` the ESM load hook babel-parsed every package module, JSON included, so it
  threw on the schema. The hook now skips `type: 'json'` imports.

Subdirectories are ignored (bots are a flat module map), so `bot add` warns on skipped entries —
point it at flattened build output.

## Validation

- Live-smoked against a running server: `manage bot add … --spawn <room>` acquired the game mutex
  between the server's ticks (observed the contention/handoff), placed the spawn directly, and the
  server processed the newly-claimed room without interruption — controller claimed, spawn present,
  room registered active. Re-validated with the server stopped (uncontended path) and with explicit
  `--spawn <room> x,y`. `bot update` / `bot remove` and the `user` verbs exercised.
- Full test suite green under `--private-transform=isolated-vm` (the CI command), including the
  `Badge.generateRandom` schema test.
- `tsc -b` and `eslint` clean on the changed files.
