### PR TITLE
engine: return undefined from Game.map.getRoomStatus for a non-string argument

### DIFF
--- a/.changeset/getroomstatus-non-string-guard.md
+++ b/.changeset/getroomstatus-non-string-guard.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Return `undefined` from `Game.map.getRoomStatus` for a non-string argument instead of throwing.

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -232,6 +232,11 @@ export class GameMap {
 	getRoomStatus(roomName: string): RoomStatus;
 
 	getRoomStatus(roomName: string, actually?: boolean): RoomStatus | undefined {
+		// Player code may pass a non-string despite the typed signature; `parseRoomName` would
+		// throw on it, where a malformed string name already falls through to `undefined`.
+		if (typeof roomName !== 'string') {
+			return undefined;
+		}
 		const room = parseRoomName(roomName);
 		if (Number.isNaN(room.rx) || Number.isNaN(room.ry)) {
 			return undefined;

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -231,9 +231,7 @@ export class GameMap {
 	 */
 	getRoomStatus(roomName: string): RoomStatus;
 
-	getRoomStatus(roomName: string, actually?: boolean): RoomStatus | undefined {
-		// Player code may pass a non-string despite the typed signature; `parseRoomName` would
-		// throw on it, where a malformed string name already falls through to `undefined`.
+	getRoomStatus(roomName: unknown, actually?: boolean): RoomStatus | undefined {
 		if (typeof roomName !== 'string') {
 			return undefined;
 		}


### PR DESCRIPTION
`Game.map.getRoomStatus(roomName)` passes `roomName` straight to `parseRoomName`, whose `parseSignedRoomName` does `name.slice(1)` — so a non-string arg (`undefined` / `null` / a number) throws a TypeError instead of returning `undefined`. Vanilla guards this method with a format regex and returns `undefined`; xxscreeps's existing NaN branch already covers malformed *string* names, so only non-string args diverged. A `typeof` guard short-circuits to `undefined`, leaving every string path (including lowercase names that currently parse) untouched.

Surfaced while running TooAngel against this build, which calls `Game.map.getRoomStatus` with a non-string argument.

## Validation
- screeps-ok MAP-ROOM-006 — `getRoomStatus(undefined|null|123)` all return `undefined` — passes against this build (XXSCREEPS_LOCAL, targeted vitest).
- `pnpm run build` + eslint on the changed file: clean.