### PR TITLE
runtime: expose require.cache on the player runtime

### DIFF
--- a/.changeset/require-cache.md
+++ b/.changeset/require-cache.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Expose `require.cache` on the player runtime so module entries can be deleted.

--- a/packages/xxscreeps/driver/runtime/module.ts
+++ b/packages/xxscreeps/driver/runtime/module.ts
@@ -11,7 +11,7 @@ type Loader<Source> = {
 
 export function makeEnvironment(modules: CodePayload, evaluate: Evaluate, compiler: Compiler) {
 	const main = [ 'main.js', 'main.mjs', 'main.wasm', 'main' ].find(entry => modules.has(entry));
-	if (main === 'main' || main == 'main.js') {
+	if (main === 'main' || main === 'main.js') {
 		// Use flat CommonJS loader
 		const require = makeRequire(evaluate, {
 			resolve(specifier) {
@@ -227,9 +227,8 @@ function splitLocator(url: string): [ string, string ] {
 
 function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 
-	// A single `require` for `globalThis.require`, `main`, and every submodule: the flat loader resolves a
-	// specifier independently of the requiring module, so a referrer-bound `require` per module adds nothing.
-	const cache = new Map<string, null | { error?: any; exports?: any }>();
+	// Screeps `require` operates on a flat namespace, independent of the requiring module.
+	const cache = new Map<string | symbol, null | { error?: any; exports?: any }>();
 	const require = (specifier: string) => {
 		// Resolve and check for existing or pending module
 		const url = loader.resolve(specifier);
@@ -286,25 +285,15 @@ function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 	// reachable at `require.cache.foo` though stored under the resolved `foo.js`.
 	return Object.assign(require, {
 		cache: new Proxy<Record<string, unknown>>({}, {
-			get: (target, key) => (typeof key === 'string' ? cache.get(loader.resolve(key))?.exports : Reflect.get(target, key)) as unknown,
-			has: (target, key) => typeof key === 'string' ? cache.has(loader.resolve(key)) : Reflect.has(target, key),
-			deleteProperty: (target, key) => {
-				if (typeof key === 'string') {
-					cache.delete(loader.resolve(key));
-				} else {
-					Reflect.deleteProperty(target, key);
-				}
-				return true;
-			},
+			get: (target, key) => cache.get(typeof key === 'string' ? loader.resolve(key) : key)?.exports,
+			has: (target, key) => cache.has(typeof key === 'string' ? loader.resolve(key) : key),
+			deleteProperty: (target, key) => cache.delete(typeof key === 'string' ? loader.resolve(key) : key),
 			ownKeys: () => [ ...cache.keys() ],
 			getOwnPropertyDescriptor: (target, key) => {
-				if (typeof key === 'string') {
-					const url = loader.resolve(key);
-					return cache.has(url)
-						? { configurable: true, enumerable: true, value: cache.get(url)?.exports as unknown }
-						: undefined;
+				const resolvedKey = typeof key === 'string' ? loader.resolve(key) : key;
+				if (cache.has(resolvedKey)) {
+					return { configurable: true, enumerable: true, value: cache.get(resolvedKey)?.exports };
 				}
-				return Reflect.getOwnPropertyDescriptor(target, key);
 			},
 		}),
 	});

--- a/packages/xxscreeps/driver/runtime/module.ts
+++ b/packages/xxscreeps/driver/runtime/module.ts
@@ -227,11 +227,12 @@ function splitLocator(url: string): [ string, string ] {
 
 function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 
-	// Create `require` factory
+	// A single `require` for `globalThis.require`, `main`, and every submodule: the flat loader resolves a
+	// specifier independently of the requiring module, so a referrer-bound `require` per module adds nothing.
 	const cache = new Map<string, null | { error?: any; exports?: any }>();
-	const requireFrom = (referrer?: string) => (specifier: string) => {
+	const require = (specifier: string) => {
 		// Resolve and check for existing or pending module
-		const url = loader.resolve(specifier, referrer);
+		const url = loader.resolve(specifier);
 		const cached = cache.get(url);
 		if (cached !== undefined) {
 			if (cached === null) {
@@ -243,7 +244,7 @@ function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 		}
 		const content = loader.compile(url);
 		if (content === undefined) {
-			throw new Error(`Cannot find module '${specifier}' imported from '${referrer}'`);
+			throw new Error(`Cannot find module '${specifier}'`);
 		}
 		cache.set(url, null);
 		const exports = function() {
@@ -256,7 +257,7 @@ function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 					try {
 						type Require = (require: unknown, module: unknown, exports: unknown) => void;
 						const moduleFunction = evaluate(`(function(require,module,exports){${content}\n})`, url) as Require;
-						const run = () => moduleFunction.apply(module, [ requireFrom(url), module, module.exports ]);
+						const run = () => moduleFunction.apply(module, [ require, module, module.exports ]);
 						run();
 						return run;
 					} catch (error) {
@@ -281,7 +282,32 @@ function makeRequire(evaluate: Evaluate, loader: Loader<any>) {
 		cache.set(url, { exports });
 		return exports;
 	};
-	return requireFrom();
+	// `require.cache`: a live view keyed by the names `require` accepts, so an entry required as `foo` is
+	// reachable at `require.cache.foo` though stored under the resolved `foo.js`.
+	return Object.assign(require, {
+		cache: new Proxy<Record<string, unknown>>({}, {
+			get: (target, key) => (typeof key === 'string' ? cache.get(loader.resolve(key))?.exports : Reflect.get(target, key)) as unknown,
+			has: (target, key) => typeof key === 'string' ? cache.has(loader.resolve(key)) : Reflect.has(target, key),
+			deleteProperty: (target, key) => {
+				if (typeof key === 'string') {
+					cache.delete(loader.resolve(key));
+				} else {
+					Reflect.deleteProperty(target, key);
+				}
+				return true;
+			},
+			ownKeys: () => [ ...cache.keys() ],
+			getOwnPropertyDescriptor: (target, key) => {
+				if (typeof key === 'string') {
+					const url = loader.resolve(key);
+					return cache.has(url)
+						? { configurable: true, enumerable: true, value: cache.get(url)?.exports as unknown }
+						: undefined;
+				}
+				return Reflect.getOwnPropertyDescriptor(target, key);
+			},
+		}),
+	});
 }
 
 export function makeModule<Module>(compiler: Compiler<Module>, loader: Loader<Module>) {


### PR DESCRIPTION
The player-runtime `require` had no `.cache`, so `delete require.cache[name]` threw `TypeError: Cannot convert undefined or null to object`. A stock wasm-bindgen bot deletes its cache entry right after instantiation to free the `.wasm` bytes, so the throw bricked it before its loop ran.

`makeRequire` minted a fresh `require` per module but attached `.cache` only to the outermost one, so the `require` a module receives had none. The per-module `require` only carried a `referrer` the flat loader ignores, so this collapses the factory to a single `require` shared by every module and exposes `require.cache` as a live view over the module cache — reads return a module's exports, deletes evict, keyed by the same names `require` accepts.

## Validation
- screeps-ok `UNDOC-GLOBAL-004` (`require.cache` exposes a required module's exports and `delete` evicts the entry) passes; closes the `require-cache-missing` parity gap.
