### PR TITLE
runtime: read main.loop each tick instead of caching the reference

### DIFF
--- a/.changeset/main-loop-reread.md
+++ b/.changeset/main-loop-reread.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Read `main.loop` each tick so a bot that reassigns `module.exports.loop` is honored.

--- a/packages/xxscreeps/driver/runtime/index.ts
+++ b/packages/xxscreeps/driver/runtime/index.ts
@@ -73,7 +73,6 @@ const hooksComposed = function() {
 
 let me: string;
 let world: World;
-let loop: (() => any) | undefined;
 let requireMain: () => any;
 
 export function initialize(compiler: Compiler, evaluate: Evaluate, data: InitializationPayload) {
@@ -121,16 +120,14 @@ export function tick(data: TickPayload, player = (fn: () => void) => fn()): Tick
 			globalThis.Game = Game;
 			try {
 				player(function thisIsWhereThePlayerCodeStarts() {
-					if (loop) {
-						loop();
+					// Read `main.loop` fresh each tick rather than caching the reference: a bot may swap
+					// `module.exports.loop` after first-tick setup (e.g. the rustyscreeps wasm loader replaces
+					// its bootstrap with the real loop). `require('main')` is a cache hit after the first tick.
+					const main = requireMain();
+					if (main.loop) {
+						main.loop();
 					} else {
-						const main = requireMain();
-						if (main.loop) {
-							loop = main.loop;
-							loop!();
-						} else {
-							throw new Error('No `loop` function exported by `main` module');
-						}
+						throw new Error('No `loop` function exported by `main` module');
 					}
 				});
 			} catch (err: any) {


### PR DESCRIPTION
The player loop was captured on the first tick (`loop = main.loop`) and reused every tick, so a bot that reassigns `module.exports.loop` after first-tick setup was never invoked. The rustyscreeps wasm loader does exactly this — its bootstrap loads and instantiates the `.wasm`, then replaces itself with `module.exports.loop = loaded_loop` — so under the cached reference the bootstrap re-ran every tick and the real loop never executed.

Read `main.loop` fresh each tick (`require('main')` is a cache hit) and call it as `main.loop()`.

## Validation
- Ran a `main` module that reassigns `module.exports.loop` after the first tick: the replacement runs each subsequent tick; previously the first-tick reference re-ran the bootstrap indefinitely.
