### PR TITLE
game: store RoomPosition coordinates under a private symbol

### DIFF
--- a/.changeset/room-position-wasm-construction.md
+++ b/.changeset/room-position-wasm-construction.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `RoomPosition` construction for wasm bot bindings that build positions via `__packedPos`.

--- a/packages/xxscreeps/driver/private/runtime.ts
+++ b/packages/xxscreeps/driver/private/runtime.ts
@@ -92,6 +92,7 @@ export function makeSetter(name: string): (object: Subject, value: unknown) => u
 				}
 			}
 			defineProperty(object, symbol, {
+				configurable: true,
 				get() { return value; },
 				set(this: object, value) {
 					defineProperty(this, symbol, {

--- a/packages/xxscreeps/game/position.ts
+++ b/packages/xxscreeps/game/position.ts
@@ -66,7 +66,7 @@ const RawPositionId = Symbol('defaultRoomPosition');
  * using the `Room.getPositionAt` method or using the constructor.
  */
 export class RoomPosition {
-	declare '#id': number;
+	declare private '#id': number;
 
 	/** @internal */
 	constructor(xx: typeof RawPositionId, id: number, roomName?: unknown);

--- a/packages/xxscreeps/game/position.ts
+++ b/packages/xxscreeps/game/position.ts
@@ -66,7 +66,7 @@ const RawPositionId = Symbol('defaultRoomPosition');
  * using the `Room.getPositionAt` method or using the constructor.
  */
 export class RoomPosition {
-	#id;
+	declare '#id': number;
 
 	/** @internal */
 	constructor(xx: typeof RawPositionId, id: number, roomName?: unknown);
@@ -81,7 +81,7 @@ export class RoomPosition {
 
 	constructor(xx: number | typeof RawPositionId, yy: number, roomName: string) {
 		if (xx === RawPositionId) {
-			this.#id = yy;
+			this['#id'] = yy;
 		} else {
 			const { rx, ry } = parseRoomName(roomName);
 			if (
@@ -92,7 +92,7 @@ export class RoomPosition {
 			) {
 				throw new TypeError('Invalid arguments in `RoomPosition` constructor');
 			}
-			this.#id = (yy << 24) | (xx << 16) | (ry << 8) | rx;
+			this['#id'] = (yy << 24) | (xx << 16) | (ry << 8) | rx;
 		}
 	}
 
@@ -100,7 +100,7 @@ export class RoomPosition {
 	 * The name of the room.
 	 */
 	@enumerable get roomName() {
-		return makeRoomNameFromId(this.#id & 0xffff);
+		return makeRoomNameFromId(this['#id'] & 0xffff);
 	}
 
 	/**
@@ -108,7 +108,7 @@ export class RoomPosition {
 	 */
 	// eslint-disable-next-line id-length
 	@enumerable get x() {
-		return (this.#id >>> 16) & 0xff;
+		return (this['#id'] >>> 16) & 0xff;
 	}
 
 	/**
@@ -116,7 +116,7 @@ export class RoomPosition {
 	 */
 	// eslint-disable-next-line id-length
 	@enumerable get y() {
-		return this.#id >>> 24;
+		return this['#id'] >>> 24;
 	}
 
 	/** @deprecated */
@@ -125,21 +125,17 @@ export class RoomPosition {
 		return ((id & 0xffff) << 16) | ((id >>> 8) & 0xff00) | (id >>> 24);
 	}
 
-	get '#id'() {
-		return this.#id;
-	}
-
 	get '#rx'() {
-		return this.#id & 0xff;
+		return this['#id'] & 0xff;
 	}
 
 	get '#ry'() {
-		return (this.#id >>> 8) & 0xff;
+		return (this['#id'] >>> 8) & 0xff;
 	}
 
 	/** @deprecated */
 	set __packedPos(value: number) {
-		this.#id = ((value & 0xff) << 24) | ((value & 0xff00) << 8) | ((value >>> 16) & 0xffff);
+		this['#id'] = ((value & 0xff) << 24) | ((value & 0xff00) << 8) | ((value >>> 16) & 0xffff);
 	}
 
 	// eslint-disable-next-line id-length
@@ -147,7 +143,7 @@ export class RoomPosition {
 		if (!(xx >= 0 && xx <= kMaxRoomCoordinate)) {
 			throw new TypeError('Invalid `x`');
 		}
-		this.#id = (this.#id & ~(0xff << 16)) | (xx << 16);
+		this['#id'] = (this['#id'] & ~(0xff << 16)) | (xx << 16);
 	}
 
 	// eslint-disable-next-line id-length
@@ -155,7 +151,7 @@ export class RoomPosition {
 		if (!(yy >= 0 && yy <= kMaxRoomCoordinate)) {
 			throw new TypeError('Invalid `y`');
 		}
-		this.#id = (this.#id & ~(0xff << 24)) | (yy << 24);
+		this['#id'] = (this['#id'] & ~(0xff << 24)) | (yy << 24);
 	}
 
 	set roomName(roomName: string) {
@@ -166,7 +162,7 @@ export class RoomPosition {
 		) {
 			throw new TypeError('Invalid `roomName`');
 		}
-		this.#id = (this.#id & ~0xffff) | (ry << 8) | rx;
+		this['#id'] = (this['#id'] & ~0xffff) | (ry << 8) | rx;
 	}
 
 	static '#create'(pos: number) {
@@ -195,7 +191,7 @@ export class RoomPosition {
 	getRangeTo(target: RoomObject | RoomPosition): number;
 	getRangeTo(...args: [ number, number ] | [ RoomObject | RoomPosition ]) {
 		const { xx, yy, room } = fetchArguments(...args);
-		if (room !== 0 && (this.#id & 0xffff) !== room) {
+		if (room !== 0 && (this['#id'] & 0xffff) !== room) {
 			return Infinity;
 		}
 		return Math.max(Math.abs(this.x - xx), Math.abs(this.y - yy));
@@ -211,7 +207,7 @@ export class RoomPosition {
 	isEqualTo(target: RoomObject | RoomPosition): boolean;
 	isEqualTo(...args: [ number, number ] | [ RoomObject | RoomPosition ]) {
 		const { pos } = fetchPositionArgument(this.roomName, ...args);
-		return this.#id === (pos ? pos.#id : 0);
+		return this['#id'] === (pos ? pos['#id'] : 0);
 	}
 
 	/**
@@ -238,7 +234,7 @@ export class RoomPosition {
 	inRangeTo(target: RoomObject | RoomPosition, range: number): boolean;
 	inRangeTo(...args: [ number, number, number ] | [ RoomObject | RoomPosition, number ]) {
 		const { xx, yy, room, rest } = fetchArguments(...args);
-		if (room !== 0 && (this.#id & 0xffff) !== room) {
+		if (room !== 0 && (this['#id'] & 0xffff) !== room) {
 			return false;
 		}
 		const range = Math.max(Math.abs(this.x - xx), Math.abs(this.y - yy));

--- a/packages/xxscreeps/game/test.ts
+++ b/packages/xxscreeps/game/test.ts
@@ -29,6 +29,12 @@ function positionAssertions(manifest: PositionAssertion) {
 	next.y = manifest.yy;
 	next.roomName = manifest.roomName;
 	assert.equal(next.__packedPos, manifest.packed);
+	// wasm bindings build positions via `Object.create` + `__packedPos`, never the constructor
+	const foreign = Object.create(RoomPosition.prototype) as RoomPosition;
+	foreign.__packedPos = manifest.packed;
+	assert.equal(foreign.x, manifest.xx);
+	assert.equal(foreign.y, manifest.yy);
+	assert.equal(foreign.roomName, manifest.roomName);
 }
 
 test('RoomPosition', () => {


### PR DESCRIPTION
`RoomPosition` packed its coordinates into an ECMAScript-private `#id` field, which only the constructor can install. The `screeps-game-api` Rust bindings build positions with `Object.create(RoomPosition.prototype)` and set `__packedPos` — never calling the constructor — so the field is absent and the first read or write throws `TypeError: Cannot write private member #id`. Every rustyscreeps-based bot crash-loops on its first position access.

Storing the packed value under the `'#id'` private symbol the rest of the engine uses fixes it — that slot can be written on any instance. It also surfaced a latent bug in `makeSetter`: when a private-symbol field's symbol isn't on the prototype, the value lands on the instance behind a non-configurable accessor whose own setter can never redefine it, so rewrites are silently dropped under real private symbols. Nothing exercised that path before (every `'#'` field is overlay-backed or a prototype method); the accessor is now `configurable`.

## Validation
- `npx xxscreeps test` — 432/432, with a new `RoomPosition` assertion that constructs via `Object.create` + `__packedPos` and reads back. Fails on `main`; passes under both `--private-transform=nodejs` and `--private-transform=isolated-vm`.
- Live `screeps-starter-rust` (stacked on the other two wasm fixes, #265/#266): Rust loop completes every tick across ~2000 ticks with a stable creep population. Without this change it crash-loops on `Cannot write private member #id`.
