### PR TITLE
Add `manage user` badge, password, and branch verbs

### DIFF
--- a/.changeset/manage-user-account-verbs.md
+++ b/.changeset/manage-user-account-verbs.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add user badge, password, and branch verbs to the manage script.

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -1,38 +1,13 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
-import * as crypto from 'node:crypto';
-import { promisify } from 'node:util';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { findUserByName, findUserByProvider, infoKey } from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
+import { checkPassword, setPassword } from './model.js';
 
 const { allowEmailRegistration } = config.backend;
-
-async function checkPassword(db: Database, userId: string, password: string) {
-	const info = await async function() {
-		const payload = await db.data.hGet(infoKey(userId), 'password');
-		try {
-			return JSON.parse(payload!);
-		} catch {}
-	}();
-	if (info) {
-		const hash = await promisify(crypto.pbkdf2)(password, Buffer.from(info.salt, 'latin1'), info.iterations, 64, 'sha512');
-		return hash.compare(Buffer.from(info.hash, 'latin1')) === 0;
-	}
-}
-
-async function setPassword(db: Database, userId: string, password: string) {
-	const iterations = 100000;
-	const salt = crypto.randomBytes(16);
-	const hash = await promisify(crypto.pbkdf2)(password, salt, iterations, 64, 'sha512');
-	await db.data.hSet(infoKey(userId), 'password', JSON.stringify({
-		hash,
-		iterations,
-		salt: salt.toString('latin1'),
-	}));
-}
 
 async function findUserByUsernameOrEmail(db: Database, value: string) {
 	if (value.includes('@')) {

--- a/packages/xxscreeps/mods/backend/password/index.ts
+++ b/packages/xxscreeps/mods/backend/password/index.ts
@@ -1,5 +1,5 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
 
 export const manifest: Manifest = {
-	provides: 'backend',
+	provides: [ 'backend', 'test' ],
 };

--- a/packages/xxscreeps/mods/backend/password/model.ts
+++ b/packages/xxscreeps/mods/backend/password/model.ts
@@ -9,6 +9,8 @@ interface StoredPassword {
 	salt: string;
 }
 
+const pbkdf2 = promisify(crypto.pbkdf2);
+
 export async function checkPassword(db: Database, userId: string, password: string) {
 	const info = await async function() {
 		const payload = await db.data.hGet(infoKey(userId), 'password');
@@ -17,7 +19,7 @@ export async function checkPassword(db: Database, userId: string, password: stri
 		} catch {}
 	}();
 	if (info) {
-		const hash = await promisify(crypto.pbkdf2)(password, Buffer.from(info.salt, 'latin1'), info.iterations, 64, 'sha512');
+		const hash = await pbkdf2(password, Buffer.from(info.salt, 'latin1'), info.iterations, 64, 'sha512');
 		return hash.compare(Buffer.from(info.hash, 'latin1')) === 0;
 	}
 }
@@ -25,7 +27,7 @@ export async function checkPassword(db: Database, userId: string, password: stri
 export async function setPassword(db: Database, userId: string, password: string) {
 	const iterations = 100000;
 	const salt = crypto.randomBytes(16);
-	const hash = await promisify(crypto.pbkdf2)(password, salt, iterations, 64, 'sha512');
+	const hash = await pbkdf2(password, salt, iterations, 64, 'sha512');
 	await db.data.hSet(infoKey(userId), 'password', JSON.stringify({
 		hash,
 		iterations,

--- a/packages/xxscreeps/mods/backend/password/model.ts
+++ b/packages/xxscreeps/mods/backend/password/model.ts
@@ -1,0 +1,34 @@
+import type { Database } from 'xxscreeps/engine/db/index.js';
+import * as crypto from 'node:crypto';
+import { promisify } from 'node:util';
+import { infoKey } from 'xxscreeps/engine/db/user/index.js';
+
+interface StoredPassword {
+	hash: string;
+	iterations: number;
+	salt: string;
+}
+
+export async function checkPassword(db: Database, userId: string, password: string) {
+	const info = await async function() {
+		const payload = await db.data.hGet(infoKey(userId), 'password');
+		try {
+			return JSON.parse(payload!) as StoredPassword;
+		} catch {}
+	}();
+	if (info) {
+		const hash = await promisify(crypto.pbkdf2)(password, Buffer.from(info.salt, 'latin1'), info.iterations, 64, 'sha512');
+		return hash.compare(Buffer.from(info.hash, 'latin1')) === 0;
+	}
+}
+
+export async function setPassword(db: Database, userId: string, password: string) {
+	const iterations = 100000;
+	const salt = crypto.randomBytes(16);
+	const hash = await promisify(crypto.pbkdf2)(password, salt, iterations, 64, 'sha512');
+	await db.data.hSet(infoKey(userId), 'password', JSON.stringify({
+		hash,
+		iterations,
+		salt: salt.toString('latin1'),
+	}));
+}

--- a/packages/xxscreeps/mods/backend/password/test.ts
+++ b/packages/xxscreeps/mods/backend/password/test.ts
@@ -1,0 +1,15 @@
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { checkPassword, setPassword } from './model.js';
+
+describe('password', () => {
+	test('set then check round-trips', async () => {
+		using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '300', 'PwUser');
+		await setPassword(db, '300', 'correct horse battery');
+		assert.strictEqual(await checkPassword(db, '300', 'correct horse battery'), true);
+		assert.strictEqual(await checkPassword(db, '300', 'wrong horse battery'), false);
+	});
+});

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -6,13 +6,16 @@
 // processed until it owns an object in a room. `remove` deletes records only — owned room objects
 // are left alone — and is safe for inactive users; pause the engine first if the user is live.
 
+import * as fs from 'node:fs/promises';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import * as Badge from 'xxscreeps/engine/db/user/badge.js';
 import * as Code from 'xxscreeps/engine/db/user/code.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { primitiveComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { setPassword } from 'xxscreeps/mods/backend/password/model.js';
 import { deleteUserMemoryBlob, loadUserMemoryBlob } from 'xxscreeps/mods/memory/model.js';
 
 using db = await Database.connect();
@@ -91,12 +94,53 @@ async function userRemove(who: string) {
 	out(`Removed user ${who} (${id}).`);
 }
 
+// `source` is inline JSON or a path to a `.json` file holding a badge object (the same shape the
+// `/api/user/badge` endpoint accepts). The standard 24 numbered badges are `{ color1, color2,
+// color3, flip, param, type }`; see engine/db/user/badge.ts for the schema.
+async function userBadge(who: string, source: string) {
+	const id = await resolveUserId(who);
+	const json = source.endsWith('.json') ? await fs.readFile(source, 'utf8') : source;
+	const badge = Badge.validate(JSON.parse(json) as object);
+	await Badge.save(db, id, JSON.stringify(badge));
+	await save();
+	out(`Set badge for ${who} (${id}).`);
+}
+
+// Operator password reset; there is no online path that sets a password without the old one. Only
+// meaningful when the password backend mod is enabled. Mirrors its 8-character minimum.
+async function userPassword(who: string, password: string) {
+	if (password.length < 8) {
+		throw new Error('Password must be at least 8 characters');
+	}
+	const id = await resolveUserId(who);
+	await setPassword(db, id, password);
+	await save();
+	out(`Set password for ${who} (${id}).`);
+}
+
+// Switch the active code branch, mirroring `/api/user/set-active-branch`: persist then publish so a
+// running runner reloads it next tick; a no-op publish on a stopped server.
+async function userBranch(who: string, branch: string) {
+	const id = await resolveUserId(who);
+	if (!await db.data.sIsMember(Code.branchManifestKey(id), branch)) {
+		const branches = await db.data.sMembers(Code.branchManifestKey(id));
+		throw new Error(`No such branch: ${branch} (have: ${branches.length > 0 ? branches.join(', ') : 'none'})`);
+	}
+	await db.data.hSet(User.infoKey(id), 'branch', branch);
+	await save();
+	await Code.getUserCodeChannel(db, id).publish({ type: 'switch', branch });
+	out(`Set active branch for ${who} (${id}) to '${branch}'.`);
+}
+
 function usage(): never {
 	process.stderr.write(`Usage:
   user list
-  user show   <name|id>
-  user create <name> [email]
-  user remove <name|id>
+  user show     <name|id>
+  user create   <name> [email]
+  user remove   <name|id>
+  user badge    <name|id> <json|file>
+  user password <name|id> <password>
+  user branch   <name|id> <branch>
 `);
 	process.exit(2);
 }
@@ -108,6 +152,9 @@ try {
 		case 'user show': if (rest[0] === undefined) usage(); await userShow(rest[0]); break;
 		case 'user create': if (rest[0] === undefined) usage(); await userCreate(rest[0], rest[1]); break;
 		case 'user remove': if (rest[0] === undefined) usage(); await userRemove(rest[0]); break;
+		case 'user badge': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBadge(rest[0], rest[1]); break;
+		case 'user password': if (rest[0] === undefined || rest[1] === undefined) usage(); await userPassword(rest[0], rest[1]); break;
+		case 'user branch': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBranch(rest[0], rest[1]); break;
 		default: usage();
 	}
 } catch (err) {


### PR DESCRIPTION
## Summary

Adds three account-management verbs to `scripts/manage.ts`, extending the existing
`user` surface so a self-hosted operator can administer accounts from the CLI:

- `user badge <name|id> <json|file>` — set a badge from inline JSON or a `.json` file.
- `user password <name|id> <password>` — set/reset a password. No online path sets a
  password without the old one (`/api/user/password` requires it; registration is
  self-service), so an operator otherwise can't give a created account web-client access.
- `user branch <name|id> <branch>` — switch the active code branch.

Each mirrors its backend route (`/api/user/badge`, the registration password hash, and
`/api/user/set-active-branch`). All are plain storage writes, so they work against a
stopped server; `user branch` also publishes a code-switch that a running runner picks up
next tick (a no-op when stopped).

So the script can set passwords without pulling in the backend route registrations, the
`setPassword`/`checkPassword` helpers move from `mods/backend/password/backend.ts` into a
new `mods/backend/password/model.ts`, and the mod now declares `provides: 'test'`.

## Validation

- `npx xxscreeps test` — full suite green, including a new `password` round-trip test
  (set → check returns true for the right password, false for a wrong one).
- `eslint` on the changed files — no new warnings.
- Live-smoked against a self-hosted shard: `user badge` (inline JSON, `.json` file, and a
  malformed badge rejected); `user password` (set; a <8-character password rejected;
  `{ hash, iterations, salt }` persisted); `user branch` (switched a multi-branch user and
  reverted — both confirmed in storage — and an unknown branch rejected). The temporary
  user was removed cleanly afterward.
