### PR TITLE
map-stats: add minerals0 (type and density) to room stats response

### DIFF
--- a/.changeset/map-stats-minerals.md
+++ b/.changeset/map-stats-minerals.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add minerals0 (type and density) to /api/game/map-stats response.

--- a/packages/xxscreeps/backend/endpoints/game/map-stats.ts
+++ b/packages/xxscreeps/backend/endpoints/game/map-stats.ts
@@ -4,6 +4,7 @@ import type { UserBadge } from 'xxscreeps/engine/db/user/badge.js';
 import { makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import { Mineral } from 'xxscreeps/mods/mineral/mineral.js';
 
 interface MapStatsRequest {
@@ -72,7 +73,7 @@ export const MapStatsEndpoint: Endpoint = {
 				}(),
 				// Mineral info
 				...function() {
-					const mineral = room['#objects'].find(obj => obj instanceof Mineral) as Mineral | undefined;
+					const mineral = room['#objects'].find(instanceOfPredicate(Mineral));
 					if (mineral) {
 						return {
 							minerals0: {

--- a/packages/xxscreeps/backend/endpoints/game/map-stats.ts
+++ b/packages/xxscreeps/backend/endpoints/game/map-stats.ts
@@ -4,6 +4,7 @@ import type { UserBadge } from 'xxscreeps/engine/db/user/badge.js';
 import { makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { Mineral } from 'xxscreeps/mods/mineral/mineral.js';
 
 interface MapStatsRequest {
 	rooms: string[];
@@ -65,6 +66,18 @@ export const MapStatsEndpoint: Endpoint = {
 								text: sign.text,
 								time: sign.time,
 								user: sign.userId,
+							},
+						};
+					}
+				}(),
+				// Mineral info
+				...function() {
+					const mineral = room['#objects'].find(obj => obj instanceof Mineral) as Mineral | undefined;
+					if (mineral) {
+						return {
+							minerals0: {
+								type: mineral.mineralType,
+								density: mineral.density,
 							},
 						};
 					}


### PR DESCRIPTION
Currently the Map is missing the info about minerals.. this PR fixes that.