### PR TITLE
chemistry: render lab reaction action logs in the client's format

### DIFF
--- a/.changeset/lab-reaction-action-log-render.md
+++ b/.changeset/lab-reaction-action-log-render.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Emit lab reaction and reverse-reaction action logs to clients.

--- a/packages/xxscreeps/backend/sockets/render.ts
+++ b/packages/xxscreeps/backend/sockets/render.ts
@@ -1,9 +1,16 @@
-import type { ActionLog } from 'xxscreeps/game/object.js';
+import type { ActionLog, ActionLogType } from 'xxscreeps/game/object.js';
 import { bindRenderer } from 'xxscreeps/backend/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomObject } from 'xxscreeps/game/object.js';
 import { Variant } from 'xxscreeps/schema/index.js';
+
+interface CoordinatesObject {
+	x: number;
+	y: number;
+}
+
+type RenderedActionLog = Partial<Record<ActionLogType, CoordinatesObject>>;
 
 // Base object renderer
 bindRenderer(RoomObject, object => ({
@@ -13,12 +20,11 @@ bindRenderer(RoomObject, object => ({
 	y: object.pos.y,
 }));
 
-export function renderActionLog(actionLog: ActionLog, previousTime: number | undefined): Record<string, any> {
-	return {
-		actionLog: Fn.fromEntries(
-			Fn.filter(actionLog, previousTime
-				? action => action.time > previousTime :
-				action => action.time === Game.time),
-			action => [ action.type, { x: action.x, y: action.y } ]),
-	};
+export function renderActionLog(actionLog: ActionLog, previousTime: number | undefined): RenderedActionLog {
+	return Fn.pipe(
+		actionLog,
+		$$ => Fn.filter($$, previousTime === undefined
+			? action => action.time === Game.time
+			: action => action.time > previousTime),
+		$$ => Fn.fromEntries($$, action => [ action.type, { x: action.x, y: action.y } ]));
 }

--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -178,6 +178,7 @@ export const actionLogFormat = declare('ActionLog', () => vector(struct({
 })));
 
 export type ActionLog = TypeOf<typeof actionLogFormat>;
+export type ActionLogType = ActionLog[number]['type'];
 type WithActionLog = Record<'#actionLog', ActionLog>;
 
 export function saveAction(object: WithActionLog, type: ActionLog[number]['type'], pos: RoomPosition) {

--- a/packages/xxscreeps/mods/chemistry/backend.ts
+++ b/packages/xxscreeps/mods/chemistry/backend.ts
@@ -3,31 +3,35 @@ import { renderActionLog } from 'xxscreeps/backend/sockets/render.js';
 import { renderStore } from 'xxscreeps/mods/resource/backend.js';
 import { StructureLab } from './lab.js';
 
-interface RenderedActionLog {
-	actionLog: Record<string, { x: number; y: number }>;
+interface LabActionCoordinates {
+	x1: number;
+	y1: number;
+	x2: number;
+	y2: number;
+}
+
+interface RenderedLabActionLog {
+	runReaction: LabActionCoordinates | undefined;
+	reverseReaction: LabActionCoordinates | undefined;
 }
 
 bindRenderer(StructureLab, (lab, next, previousTime) => {
 	// Combine paired action log entries into the format the client expects
-	const actionLog = function() {
+	const actionLog = function(): RenderedLabActionLog {
 		// renderActionLog nests entries under `.actionLog` (cf. the creep/tower renderers).
-		const { actionLog: raw } = renderActionLog(lab['#actionLog'], previousTime) as RenderedActionLog;
-		const result: Record<string, { x1: number; y1: number; x2: number; y2: number }> = {};
-		if (raw.reaction1 && raw.reaction2) {
-			result.runReaction = {
-				x1: raw.reaction1.x, y1: raw.reaction1.y,
-				x2: raw.reaction2.x, y2: raw.reaction2.y,
-			};
-		}
-		if (raw.reverseReaction1 && raw.reverseReaction2) {
-			result.reverseReaction = {
-				x1: raw.reverseReaction1.x, y1: raw.reverseReaction1.y,
-				x2: raw.reverseReaction2.x, y2: raw.reverseReaction2.y,
-			};
-		}
+		const actionLog = renderActionLog(lab['#actionLog'], previousTime);
 		// Return the object even when empty: the diff then clears just the changed reaction
 		// sub-key instead of nulling the whole `actionLog`, which breaks the client's lab renderer.
-		return result;
+		return {
+			runReaction: actionLog.reaction1 && actionLog.reaction2 && {
+				x1: actionLog.reaction1.x, y1: actionLog.reaction1.y,
+				x2: actionLog.reaction2.x, y2: actionLog.reaction2.y,
+			},
+			reverseReaction: actionLog.reverseReaction1 && actionLog.reverseReaction2 && {
+				x1: actionLog.reverseReaction1.x, y1: actionLog.reverseReaction1.y,
+				x2: actionLog.reverseReaction2.x, y2: actionLog.reverseReaction2.y,
+			},
+		};
 	}();
 	return {
 		...next(),

--- a/packages/xxscreeps/mods/chemistry/backend.ts
+++ b/packages/xxscreeps/mods/chemistry/backend.ts
@@ -3,10 +3,15 @@ import { renderActionLog } from 'xxscreeps/backend/sockets/render.js';
 import { renderStore } from 'xxscreeps/mods/resource/backend.js';
 import { StructureLab } from './lab.js';
 
+interface RenderedActionLog {
+	actionLog: Record<string, { x: number; y: number }>;
+}
+
 bindRenderer(StructureLab, (lab, next, previousTime) => {
 	// Combine paired action log entries into the format the client expects
 	const actionLog = function() {
-		const raw = renderActionLog(lab['#actionLog'], previousTime);
+		// renderActionLog nests entries under `.actionLog` (cf. the creep/tower renderers).
+		const { actionLog: raw } = renderActionLog(lab['#actionLog'], previousTime) as RenderedActionLog;
 		const result: Record<string, { x1: number; y1: number; x2: number; y2: number }> = {};
 		if (raw.reaction1 && raw.reaction2) {
 			result.runReaction = {
@@ -20,7 +25,9 @@ bindRenderer(StructureLab, (lab, next, previousTime) => {
 				x2: raw.reverseReaction2.x, y2: raw.reverseReaction2.y,
 			};
 		}
-		return Object.keys(result).length ? result : undefined;
+		// Return the object even when empty: the diff then clears just the changed reaction
+		// sub-key instead of nulling the whole `actionLog`, which breaks the client's lab renderer.
+		return result;
 	}();
 	return {
 		...next(),

--- a/packages/xxscreeps/mods/creep/backend.ts
+++ b/packages/xxscreeps/mods/creep/backend.ts
@@ -9,14 +9,14 @@ bindMapRenderer(Creep, creep => creep['#user']);
 
 bindRenderer(Creep, (creep, next, previousTime) => {
 	// Inject `saying` into `actionLog`
-	const actionLog = renderActionLog(creep['#actionLog'], previousTime);
+	const actionLog: Record<string, unknown> = renderActionLog(creep['#actionLog'], previousTime);
 	const saying = creep['#saying'];
 	if (
 		saying &&
 		(!previousTime || previousTime < saying.time) &&
 		(saying.isPublic || creep.my)
 	) {
-		actionLog.actionLog.say = {
+		actionLog.say = {
 			isPublic: saying.isPublic,
 			message: saying.message,
 		};
@@ -24,7 +24,7 @@ bindRenderer(Creep, (creep, next, previousTime) => {
 	return {
 		...next(),
 		...renderStore(creep.store),
-		...actionLog,
+		actionLog,
 		name: creep.name,
 		body: creep.body,
 		hits: creep.hits,

--- a/packages/xxscreeps/mods/defense/backend.ts
+++ b/packages/xxscreeps/mods/defense/backend.ts
@@ -17,5 +17,5 @@ bindRenderer(StructureRampart, (rampart, next) => ({
 bindRenderer(StructureTower, (tower, next, previousTime) => ({
 	...next(),
 	...renderStore(tower.store),
-	...renderActionLog(tower['#actionLog'], previousTime),
+	actionLog: renderActionLog(tower['#actionLog'], previousTime),
 }));

--- a/packages/xxscreeps/mods/factory/backend.ts
+++ b/packages/xxscreeps/mods/factory/backend.ts
@@ -6,7 +6,7 @@ import { StructureFactory } from './factory.js';
 bindRenderer(StructureFactory, (factory, next, previousTime) => ({
 	...next(),
 	...renderStore(factory.store),
-	...renderActionLog(factory['#actionLog'], previousTime),
+	actionLog: renderActionLog(factory['#actionLog'], previousTime),
 	cooldown: factory.cooldown,
 	level: factory.level,
 }));

--- a/packages/xxscreeps/mods/logistics/backend.ts
+++ b/packages/xxscreeps/mods/logistics/backend.ts
@@ -7,7 +7,7 @@ import { StructureStorage } from './storage.js';
 bindRenderer(StructureLink, (link, next, previousTime) => ({
 	...next(),
 	...renderStore(link.store),
-	...renderActionLog(link['#actionLog'], previousTime),
+	actionLog: renderActionLog(link['#actionLog'], previousTime),
 	cooldown: link.cooldown,
 }));
 


### PR DESCRIPTION
The lab renderer never emitted reaction effects to clients, for two reasons:

1. It read `renderActionLog()`'s result one nesting level too shallow (`raw.reaction1` rather than the nested `.actionLog.reaction1`), so the `runReaction` / `reverseReaction` guards never fired and the effect was silently dropped.
2. It returned `undefined` for an idle lab, which the room diff collapses to a whole-object `actionLog: null`. The official client's lab renderer can't handle that and throws mid-render, freezing every object drawn after the lab. Returning the (possibly empty) object makes the diff clear only the changed sub-key — matching the creep/tower/link renderers, which spread the always-an-object `renderActionLog` result.

Also types the laundered render result so the entry accesses are no longer `any`.

## Validation
- `pnpm run build` (`tsc -b`) clean; eslint on the changed file drops from 17 warnings to 1 (the pre-existing `...next()` `no-unsafe-return`).
- Live-traced against the official Steam client: an idle lab now emits `actionLog: { runReaction: null }` (sub-key clear) rather than the whole-object `actionLog: null` that froze rendering, and `runReaction` / `reverseReaction` beams render.
