### PR TITLE
backend: render structures' absolute cooldownTime for client cooldown effects

### DIFF
--- a/.changeset/render-cooldown-time.md
+++ b/.changeset/render-cooldown-time.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Render structures' absolute `cooldownTime` so the client's cooldown effects show.

--- a/.changeset/render-cooldown-time.md
+++ b/.changeset/render-cooldown-time.md
@@ -2,4 +2,4 @@
 "xxscreeps": patch
 ---
 
-Render structures' absolute `cooldownTime` so the client's cooldown effects show.
+Render absolute `cooldownTime` so client cooldown effects show; fix deposit cooldown off by one.

--- a/packages/xxscreeps/mods/chemistry/backend.ts
+++ b/packages/xxscreeps/mods/chemistry/backend.ts
@@ -37,6 +37,6 @@ bindRenderer(StructureLab, (lab, next, previousTime) => {
 		...next(),
 		...renderStore(lab.store),
 		actionLog,
-		cooldown: lab.cooldown,
+		cooldownTime: lab['#cooldownTime'],
 	};
 });

--- a/packages/xxscreeps/mods/deposit/backend.ts
+++ b/packages/xxscreeps/mods/deposit/backend.ts
@@ -6,7 +6,7 @@ bindTerrainRenderer(Deposit, () => 0x777777);
 
 bindRenderer(Deposit, (deposit, next) => ({
 	...next(),
-	cooldown: deposit.cooldown,
+	cooldownTime: deposit['#cooldownTime'],
 	depositType: deposit.depositType,
 	lastCooldown: deposit.lastCooldown,
 	nextDecayTime: deposit['#nextDecayTime'],

--- a/packages/xxscreeps/mods/deposit/processor.ts
+++ b/packages/xxscreeps/mods/deposit/processor.ts
@@ -23,7 +23,7 @@ registerHarvestProcessor(Deposit, (creep, deposit) => {
 	const cooldown = Math.ceil(DEPOSIT_EXHAUST_MULTIPLY * deposit['#harvested'] ** DEPOSIT_EXHAUST_POW);
 	deposit.lastCooldown = cooldown;
 	if (cooldown > 1) {
-		deposit['#cooldownTime'] = Game.time + cooldown;
+		deposit['#cooldownTime'] = Game.time + cooldown - 1;
 	}
 	deposit['#nextDecayTime'] = Game.time + DEPOSIT_DECAY_TIME;
 	return amount;

--- a/packages/xxscreeps/mods/deposit/test.ts
+++ b/packages/xxscreeps/mods/deposit/test.ts
@@ -74,7 +74,9 @@ describe('Deposit', () => {
 		await poke('W1N1', '100', (_Game, room) => {
 			const deposit = room['#lookFor'](C.LOOK_DEPOSITS)[0];
 			assert.strictEqual(deposit?.lastCooldown, cooldown(1000));
-			assert.strictEqual(deposit.cooldown, cooldown(1000));
+			// Observable cooldown is the curve minus 1: written in the processor at gameTime T,
+			// read in user code at runtimeData.time T+1.
+			assert.strictEqual(deposit.cooldown, cooldown(1000) - 1);
 		});
 	}));
 

--- a/packages/xxscreeps/mods/factory/backend.ts
+++ b/packages/xxscreeps/mods/factory/backend.ts
@@ -7,6 +7,6 @@ bindRenderer(StructureFactory, (factory, next, previousTime) => ({
 	...next(),
 	...renderStore(factory.store),
 	actionLog: renderActionLog(factory['#actionLog'], previousTime),
-	cooldown: factory.cooldown,
+	cooldownTime: factory['#cooldownTime'],
 	level: factory.level,
 }));

--- a/packages/xxscreeps/mods/market/backend.ts
+++ b/packages/xxscreeps/mods/market/backend.ts
@@ -5,5 +5,5 @@ import { StructureTerminal } from './terminal.js';
 bindRenderer(StructureTerminal, (terminal, next) => ({
 	...next(),
 	...renderStore(terminal.store),
-	cooldown: terminal.cooldown,
+	cooldownTime: terminal['#cooldownTime'],
 }));

--- a/packages/xxscreeps/mods/nuker/backend.ts
+++ b/packages/xxscreeps/mods/nuker/backend.ts
@@ -6,7 +6,7 @@ import { StructureNuker } from './nuker.js';
 bindRenderer(StructureNuker, (nuker, next) => ({
 	...next(),
 	...renderStore(nuker.store),
-	cooldown: nuker.cooldown,
+	cooldownTime: nuker['#cooldownTime'],
 }));
 
 bindRenderer(Nuke, (nuke, next) => ({


### PR DESCRIPTION
The official client renders a structure's cooldown effect from its absolute,
serialized `cooldownTime` field. `cooldown` is a runtime-only getter derived from
that field and is never sent over the wire, so rendering the relative `cooldown`
under that key left labs, factories, terminals, nukers, and deposits with no
cooldown effect on the client. These now render the absolute `#cooldownTime`,
matching the sibling `nextDecayTime` renderers. (Links and extractors stay on the
relative `cooldown` — that's the field the client reads for those two.)

Switching the deposit renderer to the absolute field surfaced a latent off-by-one.
The deposit harvest processor stored `Game.time + cooldown`, but processors run with
`Game.time` already advanced to T+1, so `#cooldownTime` — and the player-facing
`cooldown` getter and `ERR_TIRED` harvest gate that read it — sat one tick high.
Lab, factory, and nuker already subtract one here; deposit now does too.

## Validation
- `npx xxscreeps test` — 428 passed, 0 failed.
- Deposit regression (`Deposit > harvest stores resources and updates cooldown
  curve`): asserts the observable `cooldown - 1`; fails against the pre-fix
  processor (reported 4, expected 3) and passes after.
- Placed a factory on cooldown on a running server (set `#cooldownTime`); the
  official client drew the cooldown overlay and counted it down. The nuker and the
  other three structures share the identical renderer.
