### PR TITLE
Add StructureInvaderCore defender spawning

### DIFF
--- a/.changeset/invader-core-create-creep.md
+++ b/.changeset/invader-core-create-creep.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": minor
+---
+
+Add `StructureInvaderCore` defender spawning via `createCreep` and a shared spawn-completion helper.

--- a/packages/xxscreeps/mods/invader/index.ts
+++ b/packages/xxscreeps/mods/invader/index.ts
@@ -8,6 +8,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/defense',
 		'xxscreeps/mods/logistics',
 		'xxscreeps/mods/npc',
+		'xxscreeps/mods/spawn',
 	],
 	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/invader/invader-core.ts
+++ b/packages/xxscreeps/mods/invader/invader-core.ts
@@ -1,4 +1,5 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
+import type { PartType } from 'xxscreeps/mods/creep/creep.js';
 import { chainIntentChecks, checkSameRoom, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
@@ -6,8 +7,9 @@ import * as RoomObject from 'xxscreeps/game/object.js';
 import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { Creep } from 'xxscreeps/mods/creep/creep.js';
 import { StructureTower } from 'xxscreeps/mods/defense/tower.js';
+import { Spawning, spawningFormat } from 'xxscreeps/mods/spawn/spawn.js';
 import { OwnedStructure, checkMyStructure, ownedStructureFormat } from 'xxscreeps/mods/structure/structure.js';
-import { compose, declare, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
+import { compose, declare, optional, struct, variant, withOverlay } from 'xxscreeps/schema/index.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 
 export const format = declare('InvaderCore', () => compose(shape, StructureInvaderCore));
@@ -15,6 +17,7 @@ const shape = struct(ownedStructureFormat, {
 	...variant('invaderCore'),
 	hits: 'int32',
 	level: 'int8',
+	spawning: optional(compose(spawningFormat, Spawning), null),
 	'#actionLog': RoomObject.actionLogFormat,
 	'#collapseTime': 'int32',
 	'#deployTime': 'int32',
@@ -35,10 +38,6 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 		];
 		return effects.length === 0 ? undefined : effects;
 	}
-
-	// TODO: stronghold spawning
-	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
-	@enumerable get spawning(): null { return null; }
 
 	@enumerable get ticksToDeploy(): number | undefined {
 		const deployTime = this['#deployTime'];
@@ -96,6 +95,18 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, shape) {
 			() => checkTransferEnergy(this, target),
 			() => intents.save(this, 'transferEnergy', target.id,
 				amount ?? target.store.getFreeCapacity(C.RESOURCE_ENERGY)!));
+	}
+
+	/**
+	 * Incubate an NPC defender on the core's own tile. The spawn takes
+	 * `INVADER_CORE_CREEP_SPAWN_TIME[level]` ticks per body part and materializes on an adjacent
+	 * tile once it elapses. The stronghold population behaviors that supply bodies and boosts arrive
+	 * in a later slice.
+	 */
+	'#createCreep'(body: PartType[], name: string) {
+		return chainIntentChecks(
+			() => checkCreateCreep(this),
+			() => intents.save(this, 'createCreep', body, name));
 	}
 
 	override '#applyDamage'(power: number, type: number, source?: RoomObject.RoomObject) {
@@ -182,6 +193,17 @@ export function checkUpgradeController(core: StructureInvaderCore, target: Struc
 				return C.ERR_INVALID_TARGET;
 			}
 		});
+}
+
+// The NPC loop is the only caller and supplies the body/name, so this validates core state only,
+// mirroring vanilla's invader core (which never rejects an internal `createCreep` on its arguments).
+export function checkCreateCreep(core: StructureInvaderCore) {
+	return chainIntentChecks(
+		() => checkMyStructure(core, StructureInvaderCore),
+		() => checkSourceAlive(core),
+		() => core.spawning ? C.ERR_BUSY : C.OK,
+		// Only levels with a configured spawn time (2+) field defenders.
+		() => (C.INVADER_CORE_CREEP_SPAWN_TIME[core.level] ?? 0) > 0 ? undefined : C.ERR_INVALID_TARGET);
 }
 
 export function checkTransferEnergy(core: StructureInvaderCore, target: StructureTower | Creep) {

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -13,7 +13,10 @@ import { release, reserve } from 'xxscreeps/mods/controller/processor.js';
 import * as Creep from 'xxscreeps/mods/creep/creep.js';
 import { flushActionLog } from 'xxscreeps/mods/creep/processor.js';
 import { activateNPC, registerNPC } from 'xxscreeps/mods/npc/processor.js';
-import { StructureInvaderCore, checkAttackController, checkReserveController, checkTransferEnergy, checkUpgradeController } from './invader-core.js';
+import { birthSpawnCreep } from 'xxscreeps/mods/spawn/processor.js';
+import { Spawning } from 'xxscreeps/mods/spawn/spawn.js';
+import { assign } from 'xxscreeps/utility/utility.js';
+import { StructureInvaderCore, checkAttackController, checkCreateCreep, checkReserveController, checkTransferEnergy, checkUpgradeController } from './invader-core.js';
 import { loop } from './loop/index.js';
 
 // Register invader NPC
@@ -154,6 +157,22 @@ const intents = [
 		}
 	}),
 
+	registerIntentProcessor(StructureInvaderCore, 'createCreep', {}, (core, context, body: Creep.PartType[], name: string) => {
+		if (checkCreateCreep(core) === C.OK) {
+			// Incubate the defender on the core's own tile (`#ageTime === 0` marks it spawning); the
+			// object tick processor spawns it onto an adjacent tile once the timer elapses.
+			const creep = Creep.create(core.pos, body, name, '2');
+			creep['#ageTime'] = 0;
+			core.room['#insertObject'](creep);
+			const needTime = C.INVADER_CORE_CREEP_SPAWN_TIME[core.level]! * body.length;
+			const spawning = core.spawning = assign(new Spawning(), { needTime });
+			spawning['#spawnId'] = core.id;
+			spawning['#spawningCreepId'] = creep.id;
+			spawning['#spawnTime'] = Game.time + needTime - 1;
+			context.didUpdate();
+		}
+	}),
+
 	registerIntentProcessor(StructureInvaderCore, 'transferEnergy', {}, (core, context, id: string, amount: number) => {
 		const target = Game.getObjectById<StructureTower | Creep.Creep>(id);
 		if (target && checkTransferEnergy(core, target) === C.OK) {
@@ -203,6 +222,17 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 			context.didUpdate();
 		} else {
 			context.wakeAt(deployTime + 1);
+		}
+	}
+
+	// Advance an in-progress defender spawn. A player spawn's room is kept ticking by its energy
+	// regen; this NPC core has none, so wake it at completion.
+	const { spawning } = core;
+	if (spawning) {
+		if (spawning.remainingTime === 0) {
+			birthSpawnCreep(core, context, () => core['#collapseTime'] || Game.time + C.CREEP_LIFE_TIME - 1);
+		} else {
+			context.wakeAt(spawning['#spawnTime']);
 		}
 	}
 });

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -1,7 +1,9 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { GameConstructor } from 'xxscreeps/game/index.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
+import { pushIntentsForRoomNextTick } from 'xxscreeps/engine/processor/model.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
+import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/creep/creep.js';
 import { create as createTower } from 'xxscreeps/mods/defense/tower.js';
 import { activateNPC } from 'xxscreeps/mods/npc/processor.js';
@@ -471,4 +473,105 @@ describe('Invader core', () => {
 				assert.ok(destroyed, 'damage-destroy emits EVENT_OBJECT_DESTROYED');
 			});
 		}));
+});
+
+describe('Invader core spawning', () => {
+	const corePos = new RoomPosition(25, 25, 'W1N1');
+	const findRoomCore = (room: Room) => lookForStructures(room, C.STRUCTURE_INVADER_CORE)[0]!;
+	const findCreep = (room: Room, name: string) => room.find(C.FIND_CREEPS).find(creep => creep.name === name);
+	// Level 5 spawns one tick per body part (`INVADER_CORE_CREEP_SPAWN_TIME[5] === 1`), so a 2-part
+	// body needs 2 ticks — the shortest countdown the mechanism still exercises.
+	const body = [ C.MOVE, C.ATTACK ];
+
+	// A deployed (deployTime 0), NPC-driven core. `activateNPC` keeps the room processing every
+	// tick; the loop only drives the controller, so spawning happens solely via the injected intent.
+	const spawnScene = (level = 5, decorate?: (room: Room) => void) => simulate({
+		W1N1: room => {
+			room['#insertObject'](createInvaderCore(corePos, level, 0));
+			activateNPC(room, '2');
+			decorate?.(room);
+		},
+	});
+
+	// Inject the NPC-internal `createCreep` intent. NPCs are filtered out of the player intent
+	// pipeline, so the processor is otherwise only reachable from the (slice 5) behavior loop.
+	const requestCreep = (shard: Shard, coreId: string, creepBody = body, name = 'def') =>
+		pushIntentsForRoomNextTick(shard, 'W1N1', '2', { object: { [coreId]: { createCreep: [ creepBody, name ] } } });
+
+	test('createCreep inserts a spawning defender and records the spawn', () => spawnScene()(async ({ shard, tick, peekRoom }) => {
+		const coreId = await peekRoom('W1N1', room => findRoomCore(room).id);
+		await requestCreep(shard, coreId);
+		await tick();
+		await peekRoom('W1N1', room => {
+			const core = findRoomCore(room);
+			assert.ok(core.spawning, 'core reports a spawning record');
+			assert.strictEqual(core.spawning.name, 'def');
+			assert.strictEqual(core.spawning.needTime, C.INVADER_CORE_CREEP_SPAWN_TIME[5]! * body.length);
+			assert.ok(core.spawning.remainingTime > 0, 'spawn timer is still counting down');
+			const def = findCreep(room, 'def');
+			assert.ok(def, 'defender creep is inserted');
+			assert.strictEqual(def['#user'], '2', 'defender is owned by the invader NPC');
+			assert.ok(def.spawning, 'defender is still incubating');
+			assert.ok(def.pos.isEqualTo(corePos), 'incubating defender sits on the core tile');
+		});
+	}));
+
+	test('the defender materializes adjacent once the timer elapses', () => spawnScene()(async ({ shard, tick, peekRoom }) => {
+		const coreId = await peekRoom('W1N1', room => findRoomCore(room).id);
+		await requestCreep(shard, coreId);
+		await tick(3);
+		await peekRoom('W1N1', room => {
+			const core = findRoomCore(room);
+			assert.strictEqual(core.spawning, null, 'spawning record clears once the defender spawns');
+			const def = findCreep(room, 'def');
+			assert.ok(def, 'defender survives the spawn');
+			assert.strictEqual(def.spawning, false, 'defender has finished spawning');
+			assert.ok(!def.pos.isEqualTo(corePos), 'spawned defender steps off the core tile');
+			assert.strictEqual(def.pos.getRangeTo(corePos), 1, 'spawned defender lands adjacent to the core');
+		});
+	}));
+
+	// All eight neighbors occupied by friendly (non-stompable) creeps: the spawn can find no open
+	// tile and must keep retrying without dropping the defender.
+	const blockedScene = spawnScene(5, room => {
+		for (const pos of iterateNeighbors(corePos)) {
+			room['#insertObject'](createCreep(pos, [ C.MOVE ], `block_${pos.x}_${pos.y}`, '2'));
+		}
+	});
+
+	test('a fully blocked core keeps the spawn pending, then spawns when a tile frees', () => blockedScene(async ({ shard, tick, peekRoom, poke }) => {
+		const coreId = await peekRoom('W1N1', room => findRoomCore(room).id);
+		await requestCreep(shard, coreId);
+		await tick(4);
+		await peekRoom('W1N1', room => {
+			const core = findRoomCore(room);
+			assert.ok(core.spawning, 'spawn stays pending while every neighbor is blocked');
+			assert.ok(findCreep(room, 'def')!.spawning, 'defender keeps incubating on the core tile');
+			assert.ok(findCreep(room, 'def')!.pos.isEqualTo(corePos), 'blocked defender has not moved off the core');
+		});
+		// Free one neighbor; the next tick should spawn the defender into the opening.
+		await poke('W1N1', undefined, (Game, room) => room['#removeObject'](findCreep(room, 'block_26_25')!));
+		await tick(2);
+		await peekRoom('W1N1', room => {
+			const core = findRoomCore(room);
+			assert.strictEqual(core.spawning, null, 'spawn completes once a tile opens');
+			const def = findCreep(room, 'def')!;
+			assert.strictEqual(def.spawning, false, 'defender finished spawning');
+			assert.ok(def.pos.isEqualTo(new RoomPosition(26, 25, 'W1N1')), 'defender spawns into the freed tile');
+		});
+	}));
+
+	test('createCreep is rejected while the core is already spawning', () => spawnScene()(async ({ shard, tick, peekRoom, poke }) => {
+		const coreId = await peekRoom('W1N1', room => findRoomCore(room).id);
+		await requestCreep(shard, coreId);
+		await tick();
+		const result = await poke('W1N1', '2', (Game, room) => findRoomCore(room)['#createCreep'](body, 'other'));
+		assert.strictEqual(result, C.ERR_BUSY, 'a busy core rejects a second createCreep');
+	}));
+
+	test('createCreep is rejected on a core level that cannot spawn', () => spawnScene(1)(async ({ poke }) => {
+		// `INVADER_CORE_CREEP_SPAWN_TIME[1] === 0` — level 1 cores never spawn defenders.
+		const result = await poke('W1N1', '2', (Game, room) => findRoomCore(room)['#createCreep'](body, 'def'));
+		assert.strictEqual(result, C.ERR_INVALID_TARGET, 'a non-spawning level is rejected');
+	}));
 });

--- a/packages/xxscreeps/mods/spawn/processor.ts
+++ b/packages/xxscreeps/mods/spawn/processor.ts
@@ -1,3 +1,4 @@
+import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { Direction } from 'xxscreeps/game/position.js';
 import type { PartType } from 'xxscreeps/mods/creep/creep.js';
 import { registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
@@ -18,7 +19,7 @@ import { createRuin } from 'xxscreeps/mods/structure/ruin.js';
 import { OwnedStructure, checkMyStructure, lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { StructureExtension } from './extension.js';
-import { StructureSpawn, calculateRenewAmount, calculateRenewCost, checkDirections, checkRecycleCreep, checkRenewCreep, checkSpawnCreep, create } from './spawn.js';
+import { Spawning, StructureSpawn, calculateRenewAmount, calculateRenewCost, checkDirections, checkRecycleCreep, checkRenewCreep, checkSpawnCreep, create } from './spawn.js';
 
 type EnergyStructure = StructureExtension | StructureSpawn;
 function getEnergyStructures(spawn: StructureSpawn, ids?: string[]) {
@@ -192,71 +193,88 @@ const intents = [
 	}),
 ];
 
+// A structure that incubates a creep through a `Spawning` record: `StructureSpawn` or `StructureInvaderCore`.
+interface SpawningOwner {
+	spawning: Spawning | null;
+	room: Room;
+}
+
+// Complete a pending spawn whose timer has elapsed: place the incubating creep on the first open
+// adjacent tile (preferring `spawning.directions`, stomping a lone blocking hostile as a last
+// resort), stamp its real age, and clear the record. A fully blocked owner retries next tick. Shared
+// by `StructureSpawn` and `StructureInvaderCore`, which differ only in how the spawned creep ages.
+export function birthSpawnCreep(
+	owner: SpawningOwner,
+	context: ProcessorContext,
+	ageTimeFor: (creep: Creep) => number,
+) {
+	const spawning = owner.spawning!;
+	const creep = Game.getObjectById<Creep>(spawning['#spawningCreepId']);
+	if (creep && creep instanceof Creep) {
+		// Look for spawn direction
+		const check = makePositionChecker({
+			checkTerrain: true,
+			room: owner.room,
+			user: creep['#user'],
+		});
+		const directions = new Set(spawning.directions ?? ALL_DIRECTIONS);
+
+		// Find first open preferred direction, remembering first hostile encountered
+		let spawnPos: RoomPosition | undefined;
+		let hostileCreep: Creep | undefined;
+		for (const dir of directions) {
+			const pos = getPositionInDirection(creep.pos, dir);
+			if (!pos) {
+				continue;
+			} else if (check(pos)) {
+				spawnPos = pos;
+				break;
+			}
+			if (!hostileCreep) {
+				const hostile = creep.room['#lookAt'](pos).find(
+					object => object instanceof Creep && object['#user'] !== creep['#user']);
+				if (hostile) {
+					hostileCreep = hostile as Creep;
+				}
+			}
+		}
+
+		// All preferred directions blocked — only stomp if non-preferred are also blocked
+		if (!spawnPos && hostileCreep) {
+			const hasOtherDirection = Fn.pipe(
+				ALL_DIRECTIONS,
+				$$ => Fn.reject($$, dir => directions.has(dir)),
+				$$ => Fn.map($$, dir => getPositionInDirection(creep.pos, dir)),
+				$$ => Fn.filter($$),
+				$$ => Fn.some($$, pos => check(pos)));
+			if (!hasOtherDirection) {
+				spawnPos = hostileCreep.pos;
+				buryCreep(hostileCreep);
+			}
+		}
+
+		if (!spawnPos) {
+			// No valid position — retry next tick
+			spawning['#spawnTime'] = Game.time + 1;
+			context.setActive();
+			return;
+		}
+
+		// Place the creep
+		creep['#ageTime'] = ageTimeFor(creep);
+		creep.room['#moveObject'](creep, spawnPos);
+	}
+	owner.spawning = null;
+	context.setActive();
+}
+
 registerObjectTickProcessor(StructureSpawn, (spawn, context) => {
 
 	// Check creep spawning
-	(() => {
-		if (spawn.spawning?.remainingTime === 0) {
-			const creep = Game.getObjectById<Creep>(spawn.spawning['#spawningCreepId']);
-			if (creep && creep instanceof Creep) {
-				// Look for spawn direction
-				const check = makePositionChecker({
-					checkTerrain: true,
-					room: spawn.room,
-					user: creep['#user'],
-				});
-				const directions = new Set(spawn.spawning.directions ?? ALL_DIRECTIONS);
-
-				// Find first open preferred direction, remembering first hostile encountered
-				let spawnPos: RoomPosition | undefined;
-				let hostileCreep: Creep | undefined;
-				for (const dir of directions) {
-					const pos = getPositionInDirection(creep.pos, dir);
-					if (!pos) {
-						continue;
-					} else if (check(pos)) {
-						spawnPos = pos;
-						break;
-					}
-					if (!hostileCreep) {
-						const hostile = creep.room['#lookAt'](pos).find(
-							object => object instanceof Creep && object['#user'] !== spawn['#user']);
-						if (hostile) {
-							hostileCreep = hostile as Creep;
-						}
-					}
-				}
-
-				// All preferred directions blocked — only stomp if non-preferred are also blocked
-				if (!spawnPos && hostileCreep) {
-					const hasOtherDirection = Fn.pipe(
-						ALL_DIRECTIONS,
-						$$ => Fn.reject($$, dir => directions.has(dir)),
-						$$ => Fn.map($$, dir => getPositionInDirection(creep.pos, dir)),
-						$$ => Fn.filter($$),
-						$$ => Fn.some($$, pos => check(pos)));
-					if (!hasOtherDirection) {
-						spawnPos = hostileCreep.pos;
-						buryCreep(hostileCreep);
-					}
-				}
-
-				if (!spawnPos) {
-					// No valid position — retry next tick
-					spawn.spawning['#spawnTime'] = Game.time + 1;
-					context.setActive();
-					return;
-				}
-
-				// Place the creep
-				const hasClaim = creep.body.some(part => part.type === C.CLAIM);
-				creep['#ageTime'] = Game.time + (hasClaim ? C.CREEP_CLAIM_LIFE_TIME : C.CREEP_LIFE_TIME) - 1;
-				creep.room['#moveObject'](creep, spawnPos);
-			}
-			spawn.spawning = null;
-			context.setActive();
-		}
-	})();
+	if (spawn.spawning?.remainingTime === 0) {
+		birthSpawnCreep(spawn, context, creep =>
+			Game.time + (creep.body.some(part => part.type === C.CLAIM) ? C.CREEP_CLAIM_LIFE_TIME : C.CREEP_LIFE_TIME) - 1);
+	}
 
 	// Add 1 energy per tick to spawns in low energy rooms
 	if (spawn.isActive() && spawn.room.energyAvailable < C.SPAWN_ENERGY_CAPACITY && spawn.store.energy < C.SPAWN_ENERGY_CAPACITY) {

--- a/packages/xxscreeps/mods/spawn/spawn.ts
+++ b/packages/xxscreeps/mods/spawn/spawn.ts
@@ -24,8 +24,9 @@ interface SpawnCreepOptions {
 	memory?: unknown;
 }
 
-// `StructureSpawn.Spawning` format and definition
-const spawningFormat = struct({
+// `StructureSpawn.Spawning` format and definition. Exported because `StructureInvaderCore` reuses
+// the same record for its NPC defender spawns.
+export const spawningFormat = struct({
 	directions: optional(vector(withType<Direction>('int8'))),
 	needTime: 'int32',
 	'#spawnId': Id.format,
@@ -33,7 +34,7 @@ const spawningFormat = struct({
 	'#spawnTime': 'int32',
 });
 
-class Spawning extends withOverlay(BufferObject, spawningFormat) {
+export class Spawning extends withOverlay(BufferObject, spawningFormat) {
 	@enumerable get name() { return Game.getObjectById<Creep>(this['#spawningCreepId'])!.name; }
 	@enumerable get remainingTime() { return requiredExpiryTime(Game, this['#spawnTime']); }
 	@enumerable get spawn() { return Game.getObjectById<StructureSpawn>(this['#spawnId'])!; }


### PR DESCRIPTION
Continues the invader-core arc (after #215 and #251's NPC actions): gives
`StructureInvaderCore` the `createCreep` action and a spawning lifecycle. The
core incubates a defender on its own tile and materializes it on an open
adjacent tile once `INVADER_CORE_CREEP_SPAWN_TIME[level] × body.length` ticks
elapse.

`StructureSpawn` and the invader core finish a spawn the same way — find an
open adjacent tile (preferring requested directions, stomping a lone blocker,
else retrying next tick). That completion logic moves out of the spawn
processor into a shared `hatchSpawningCreep`; the two callers differ only in
how the hatched creep is aged. The core also reuses `StructureSpawn.Spawning`
for the record, so `invader-core` now depends on `mods/spawn`.

As with #251, `createCreep` lands ahead of its driver: the stronghold
population behaviors that select bodies/boosts, boost handling, and the
collapse-tied creep lifetime are later slices.

## Validation

- `mods/invader/test.ts` — added `Invader core spawning` (5 tests): records a
  spawning defender on the core tile; materializes it adjacent on completion;
  holds the spawn pending while every neighbour is blocked, then hatches when a
  tile frees; rejects a second `createCreep` while busy (`ERR_BUSY`); rejects a
  non-spawning level (`ERR_INVALID_TARGET`).
- Exercised end-to-end on a running multi-service server: the queued
  `createCreep` persisted `spawning` onto the room blob and the defender
  hatched onto an adjacent tile across a real save/load cycle.
