### PR TITLE
Fix profile page rendering on private servers

### DIFF
--- a/.changeset/fix-profile-page-endpoints.md
+++ b/.changeset/fix-profile-page-endpoints.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix profile page: leaderboard/find returns ok without a season, and surface user gcl.

--- a/packages/xxscreeps/backend/endpoints/game/leaderboard.ts
+++ b/packages/xxscreeps/backend/endpoints/game/leaderboard.ts
@@ -15,11 +15,10 @@ const leaderboardFindSchema: JSONSchemaType<LeaderboardFindRequest> = {
 hooks.register('route', {
 	path: '/api/leaderboard/find',
 	execute: makeValidatedQueryRoute(leaderboardFindSchema, context => {
-		if (context.request.query.season === undefined) {
+		if (context.request.query.season !== undefined) {
 			return { error: 'Result not found' };
-		} else {
-			return { ok: 1, list: [] };
 		}
+		return { ok: 1, list: [] };
 	}),
 });
 

--- a/packages/xxscreeps/backend/symbols.ts
+++ b/packages/xxscreeps/backend/symbols.ts
@@ -15,7 +15,7 @@ export const hooks = makeHookRegistration<{
 	middleware: (koa: Koa<State, Context>, router: Router<State, Context>) => void;
 	roomSocket: (shard: Shard, userId: string | undefined, roomName: string) =>
 		AsyncEffectAndResult<((time: number) => MaybePromise<object>) | undefined>;
-	sendUserInfo: (db: Database, userId: string, userInfo: any, privateSelf: boolean) => Promise<void>;
+	sendUserInfo: (db: Database, userId: string, userInfo: Record<string, unknown>, privateSelf: boolean) => Promise<void>;
 	route: Endpoint;
 	subscription: SubscriptionEndpoint;
 }>();

--- a/packages/xxscreeps/mods/controller/backend.ts
+++ b/packages/xxscreeps/mods/controller/backend.ts
@@ -1,5 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import { bindMapRenderer, bindRenderer, bindTerrainRenderer, hooks, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
 import { userToIntentRoomsSetKey, userToPresenceRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import { StructureController } from './controller.js';
 import { controlledRoomKey as controlledRoomsKey, reservedRoomKey as reservedRoomsKey } from './processor.js';
@@ -33,6 +34,11 @@ bindRenderer(StructureController, (controller, next) => {
 			},
 		},
 	};
+});
+
+// Surface accumulated control points (GCL experience) so the client can display the Global Control Level.
+hooks.register('sendUserInfo', async (db, userId, userInfo) => {
+	userInfo.gcl = Number(await db.data.hGet(User.infoKey(userId), 'gcl')) || 0;
 });
 
 interface RoomStatusQuery {


### PR DESCRIPTION
The client's "View profile" page (`/profile/:username`) runs a resolve that batches several API calls, and the client's `Api.get` rejects any response whose body lacks `ok` — regardless of HTTP status. Two endpoints broke that resolve on a private server, so the route fell through to its "User not found" handler:

- `leaderboard/find` returned `{ error }` (no `ok`) when called **without** a `season` — which is exactly how the profile page calls it (`mode=world|power`, no season). The condition was inverted relative to `@screeps/backend`, which rejects only when a season *is* given. Flipped it.
- `user/find` omitted `gcl`, so the header and GCL widget couldn't populate. Added a `sendUserInfo` hook in the `controller` mod (which owns the `gcl` field) to surface it, mirroring powerspawn's existing `power` hook. Typing that hook's `userInfo` parameter (`any` → `Record<string, unknown>`) lets it and the sibling hooks drop the `any`.

## Validation
- `pnpm run build` clean; no new lint warnings (the `userInfo` typing removes 3 pre-existing unsafe-`any` warnings).
- Live server: `GET /api/leaderboard/find?username=X&mode=world` now returns `{"ok":1,"list":[]}` (was `{"error":"Result not found"}`); the same call with `&season=…` still returns the error, matching vanilla. `GET /api/user/find?username=X` now includes `gcl`. The official client's View profile page renders instead of "User not found".

Deferred: `user/find` accepts only `username`, not `id`; the official endpoint accepts both, which the client uses to resolve other players by id (separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
