### PR TITLE
Overwrite existing branch on clone-branch instead of erroring

### DIFF
--- a/.changeset/clone-branch-overwrite.md
+++ b/.changeset/clone-branch-overwrite.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix clone-branch to overwrite an existing branch instead of erroring.

--- a/packages/xxscreeps/backend/endpoints/user/code.ts
+++ b/packages/xxscreeps/backend/endpoints/user/code.ts
@@ -146,10 +146,8 @@ hooks.register('route', {
 		checkBranchName(newName);
 		const key = Code.branchManifestKey(userId);
 		const branches = await context.db.data.sMembers(key);
-		if (branches.length >= kMaxBranches) {
+		if (branches.length >= kMaxBranches && !branches.includes(newName)) {
 			throw new Error('Too many branches');
-		} else if (branches.includes(newName)) {
-			throw new Error('Branch already exists');
 		} else if (branch && !branches.includes(branch)) {
 			return;
 		}
@@ -176,7 +174,10 @@ hooks.register('route', {
 		if (!updated) {
 			throw new Error('Failed to copy');
 		}
-		await context.db.data.sAdd(Code.branchManifestKey(userId), [ newName ]);
+		await Promise.all([
+			context.db.data.sAdd(Code.branchManifestKey(userId), [ newName ]),
+			Code.getUserCodeChannel(context.db, userId).publish({ type: 'update', branch: newName }),
+		]);
 
 		return { ok: 1, timestamp };
 	}),


### PR DESCRIPTION
Caveat, it may be an intentional divergence that xxscreeps doesn't clobber an existing branch on clone, if so, I will update #1 accordingly.

`POST /api/user/clone-branch` returned 500 (`Branch already exists`) when `newName`
matched an existing branch. The official `@screeps/backend` route upserts instead
and skips the branch-count check when overwriting. Dropped the guard and gated
`Too many branches` on the name not already existing — the `copy`/`saveContent`
paths already replace the target (the redis provider passes `REPLACE`). Overwriting
a branch can now hit the *active* branch, so the handler also publishes a code-channel
`update` (like `saveContent`) to mark a running runner stale.

## Validation

Ran the redis-backed backend live: register → save `main`=v1 → clone→`alpha` →
save `main`=v2 → clone→`alpha` again. Pre-fix the second clone 500'd and `alpha`
kept v1; post-fix it returns 200 and `GET code?branch=alpha` shows v2. eslint on
the changed file: no new warnings.

Refs #1.
