### PR TITLE
backend: stub user decorations-inventory, tutorial-done, money-history

### DIFF
--- a/.changeset/user-endpoint-stubs.md
+++ b/.changeset/user-endpoint-stubs.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Stub `user/decorations/inventory`, `user/tutorial-done`, and `user/money-history` to silence client 404s.

--- a/packages/xxscreeps/backend/endpoints/user/index.ts
+++ b/packages/xxscreeps/backend/endpoints/user/index.ts
@@ -1,4 +1,5 @@
-import { hooks } from 'xxscreeps/backend/index.js';
+import type { JSONSchemaType } from 'ajv';
+import { hooks, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import badge from './badge.js';
 import messages from './messages.js';
 import './auth.js';
@@ -18,4 +19,43 @@ hooks.register('route', {
 			list: [],
 		};
 	},
+});
+
+hooks.register('route', {
+	path: '/api/user/decorations/inventory',
+	execute() {
+		return {
+			ok: 1,
+			list: [],
+		};
+	},
+});
+
+hooks.register('route', {
+	path: '/api/user/tutorial-done',
+	method: 'post',
+	execute() {
+		return { ok: 1 };
+	},
+});
+
+interface MoneyHistoryRequest {
+	page?: string | null;
+}
+
+const moneyHistorySchema: JSONSchemaType<MoneyHistoryRequest> = {
+	type: 'object',
+	properties: {
+		page: { type: 'string', nullable: true },
+	},
+};
+
+hooks.register('route', {
+	path: '/api/user/money-history',
+	execute: makeValidatedQueryRoute(moneyHistorySchema, context => ({
+		ok: 1,
+		page: Number(context.request.query.page) || 0,
+		list: [],
+		hasMore: false,
+	})),
 });


### PR DESCRIPTION
Stubs three account-page endpoints the Steam client requests but the backend returns 404 for, tracked in #1:

- `GET /api/user/decorations/inventory` — returns `{ ok: 1, list: [] }`, mirroring the existing `decorations/themes` stub. The client reads `.list.filter(active)`, so an empty list is the correct empty state. Decorations are an MMO-only feature with no open-source backend.
- `POST /api/user/tutorial-done` — no-op returning `{ ok: 1 }`. The official handler is empty and the client fires-and-forgets.
- `GET /api/user/money-history` — returns `{ ok: 1, page, list: [], hasMore: false }`, echoing the requested `page` (the client reads `data.money.page` for prev/next navigation). The ledger is empty because there is no credits system yet; this can become a real implementation once a market backend exists.

## Validation

- `tsc -b` builds clean; verified the compiled `dist` registers all three routes.
- eslint is clean on the changed file with no new warnings.
- Confirmed the response shapes against the official client bundle: `decorations/inventory` (`.list.filter`), `money-history` (`data.money.page`), and `tutorial-done` (no body read). All return `ok: 1` so the client's API wrapper accepts them.
