### PR TITLE
engine: preserve subclass prototype in id-constructor

### DIFF
--- a/.changeset/id-constructor-subclass-prototype.md
+++ b/.changeset/id-constructor-subclass-prototype.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Preserve the subclass prototype when constructing a RoomObject from an id string.

--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -60,9 +60,13 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 			const isSubClass = (object: RoomObject) => new.target.prototype instanceof object.constructor;
 			if (object && (isSuperClass(object) || isSubClass(object))) {
 				super(BufferObject.getBuffer(object), BufferObject.getOffset(object));
-				const prototype = ObjectGetPrototypeOf(object) as object;
-				if (ObjectGetPrototypeOf(this) !== prototype) {
-					ObjectSetPrototypeOf(this, prototype);
+				// Specialize a generic super class (`new Structure(id)`) down to the concrete
+				// object's prototype. A subclass already derives from it, so leave its prototype.
+				if (isSuperClass(object)) {
+					const prototype = ObjectGetPrototypeOf(object) as object;
+					if (ObjectGetPrototypeOf(this) !== prototype) {
+						ObjectSetPrototypeOf(this, prototype);
+					}
 				}
 				this.room = object.room;
 			} else {

--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -31,6 +31,21 @@ export interface RoomObjectEffect {
 	ticksRemaining: number;
 }
 
+// `new Structure(id).hits`
+const isSuperClass =
+	<Type extends object, Params extends unknown[]>(
+		instance: object,
+		target: abstract new(...args: Params) => Type,
+	): instance is Type => instance instanceof target;
+
+// `new MyCreep(id).hits`
+const isSubClass =
+	<Type extends object, Params extends unknown[]>(
+		instance: object,
+		target: abstract new(...args: Params) => Type,
+	): instance is Type =>
+		target.prototype instanceof instance.constructor;
+
 export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, shape) {
 	/**
 	 * The link to the Room object. May be `undefined` in case if an object is a flag or a construction
@@ -54,24 +69,24 @@ export abstract class RoomObject extends withOverlay(BufferObject.BufferObject, 
 		} else if (typeof viewOrIdOrXx === 'string') {
 			// The terrible id-string constructor
 			const object = Game.getObjectById(viewOrIdOrXx);
-			// `new Structure(id).hits`
-			const isSuperClass = (object: RoomObject) => object instanceof new.target;
-			// `new MyCreep(id).hits`
-			const isSubClass = (object: RoomObject) => new.target.prototype instanceof object.constructor;
-			if (object && (isSuperClass(object) || isSubClass(object))) {
-				super(BufferObject.getBuffer(object), BufferObject.getOffset(object));
-				// Specialize a generic super class (`new Structure(id)`) down to the concrete
-				// object's prototype. A subclass already derives from it, so leave its prototype.
-				if (isSuperClass(object)) {
+			if (object) {
+				if (isSuperClass(object satisfies object as object, new.target)) {
+					super(BufferObject.getBuffer(object), BufferObject.getOffset(object));
+					// Specialize a generic super class (`new Structure(id)`) down to the concrete
+					// object's prototype. A subclass already derives from it, so leave its prototype.
 					const prototype = ObjectGetPrototypeOf(object) as object;
 					if (ObjectGetPrototypeOf(this) !== prototype) {
 						ObjectSetPrototypeOf(this, prototype);
 					}
+					this.room = object.room;
+					return;
+				} else if (isSubClass(object, new.target)) {
+					super(BufferObject.getBuffer(object), BufferObject.getOffset(object));
+					this.room = object.room;
+					return;
 				}
-				this.room = object.room;
-			} else {
-				super();
 			}
+			super();
 		} else {
 			super(viewOrIdOrXx as BufferView, offsetOrYy as number);
 		}

--- a/packages/xxscreeps/mods/spawn/test.ts
+++ b/packages/xxscreeps/mods/spawn/test.ts
@@ -461,12 +461,17 @@ describe('Id-string constructor', () => {
 	test('Structure subclass reads delegate to the concrete object', () => sim(async ({ player }) => {
 		await player('100', Game => {
 			const original = Game.rooms.W3N3!.lookForAt(C.LOOK_STRUCTURES, 26, 25)[0]!;
-			const MySpawn = class extends StructureSpawn {};
+			const MySpawn = class extends StructureSpawn {
+				doubleHits() { return this.hits * 2; }
+			};
 			// @ts-expect-error
 			const structure = new MySpawn(original.id);
 			assert.strictEqual(structure.structureType, original.structureType);
 			assert.strictEqual(structure.hits, original.hits);
 			assert.strictEqual(structure.hitsMax, original.hitsMax);
+			// The subclass prototype must survive — `instanceof` holds and subclass methods stay live.
+			assert.ok(structure instanceof MySpawn);
+			assert.strictEqual(structure.doubleHits(), original.hits! * 2);
 		});
 	}));
 });


### PR DESCRIPTION
#269 (`5be5d872`) widened the id-string `RoomObject` constructor so `new Subclass(id)` binds the looked-up object's buffer — but it still reset the instance prototype to the looked-up object's prototype, downgrading the subclass to its base. So `new Subclass(id) instanceof Subclass` was `false` and subclass methods were lost. The reset is only correct for the super-class specialisation case (`new Structure(spawnId)` → `StructureSpawn`); a subclass already derives from the object's prototype, so guard the reset to that case.

## Validation
- `packages/xxscreeps/mods/spawn/test.ts` "Structure subclass reads delegate to the concrete object" — extended to assert the constructed instance keeps `instanceof MySpawn` and a subclass method stays live over the bound fields (fails when the fix is reverted). Full suite 436/436.
- screeps-ok `UNDOC-IDCTOR-003` (`new Subclass(id)` keeps the subclass prototype and binds live creep fields) flipped from expected-fail to passing.