### PR TITLE
Set terminal cooldown after `send`

### DIFF
--- a/.changeset/terminal-send-cooldown.md
+++ b/.changeset/terminal-send-cooldown.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Set the sending terminal's cooldown after `send` so it can't send every tick.

--- a/packages/xxscreeps/mods/market/index.ts
+++ b/packages/xxscreeps/mods/market/index.ts
@@ -5,5 +5,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/market/processor.ts
+++ b/packages/xxscreeps/mods/market/processor.ts
@@ -35,6 +35,7 @@ const intents = [
 						terminal.store['#subtract'](C.RESOURCE_ENERGY, energyCost);
 						terminal.store['#subtract'](resourceType, amount);
 					}
+					terminal['#cooldownTime'] = Game.time + C.TERMINAL_COOLDOWN - 1;
 					context.didUpdate();
 
 					// Send intent to destination room

--- a/packages/xxscreeps/mods/market/terminal.ts
+++ b/packages/xxscreeps/mods/market/terminal.ts
@@ -97,7 +97,7 @@ export function calculateEnergyCost(amount: number, range: number) {
 
 //
 // Construction implementation
-function create(pos: RoomPosition, owner: string) {
+export function create(pos: RoomPosition, owner: string) {
 	const terminal = assign(createObject(new StructureTerminal(), pos), {
 		hits: C.TERMINAL_HITS,
 		store: OpenStore['#create'](C.TERMINAL_CAPACITY),

--- a/packages/xxscreeps/mods/market/test.ts
+++ b/packages/xxscreeps/mods/market/test.ts
@@ -1,0 +1,56 @@
+import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { create as createTerminal } from './terminal.js';
+
+describe('Market', () => {
+
+	// =========================================================================
+	// send
+	// =========================================================================
+	describe('send', () => {
+		const sendSim = simulate({
+			W1N1: room => {
+				const terminal = createTerminal(new RoomPosition(25, 25, 'W1N1'), '100');
+				terminal.store['#add'](C.RESOURCE_ENERGY, 10000);
+				room['#insertObject'](terminal);
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+			},
+			W2N1: room => {
+				room['#insertObject'](createTerminal(new RoomPosition(25, 25, 'W2N1'), '100'));
+				room['#level'] = 8;
+				room['#user'] = room.controller!['#user'] = '100';
+			},
+		});
+
+		test('send sets the sender cooldown but not the receiver', () => sendSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
+				assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				const sender = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
+				const receiver = lookForStructures(Game.rooms.W2N1, C.STRUCTURE_TERMINAL)[0]!;
+				// Observable cooldown is TERMINAL_COOLDOWN - 1: the processor writes
+				// cooldownTime at gameTime = T and user code reads it at time = T + 1.
+				assert.strictEqual(sender.cooldown, C.TERMINAL_COOLDOWN - 1);
+				assert.strictEqual(receiver.cooldown, 0, 'only the sender cools down');
+			});
+		}));
+
+		test('a second send during cooldown returns ERR_TIRED', () => sendSim(async ({ player, tick }) => {
+			await player('100', Game => {
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
+				terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1');
+			});
+			await tick();
+			await player('100', Game => {
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
+				assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.ERR_TIRED);
+			});
+		}));
+	});
+});


### PR DESCRIPTION
The `send` processor deducted energy and forwarded the resource but never wrote
`#cooldownTime`, so `terminal.cooldown` stayed `0` forever: `checkSend`'s
`ERR_TIRED` guard never tripped (a terminal could send every tick) and the
client's `cooldownTime > gameTime` animation never fired.

Set `#cooldownTime` on the sender as `Game.time + TERMINAL_COOLDOWN - 1`, matching
the lab processors. `send` is the only transfer path — `deal`/`createOrder` are
still stubs.

## Validation

- Added `mods/market/test.ts`: a send sets the sender's cooldown to
  `TERMINAL_COOLDOWN - 1` (receiver stays `0`); a second send returns `ERR_TIRED`.
  Both failed pre-change.
- `npx xxscreeps test` 438/438, eslint clean.
