### PR TITLE
market: record terminal transfers in Game.market transactions

### DIFF
--- a/.changeset/market-transactions.md
+++ b/.changeset/market-transactions.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Record terminal transfers in `Game.market.incomingTransactions` and `outgoingTransactions`.

--- a/packages/redis/keyval.ts
+++ b/packages/redis/keyval.ts
@@ -70,6 +70,7 @@ function zRangeOptions(options?: Pr.ZRange) {
 		...options.limit !== undefined && {
 			LIMIT: { offset: options.limit[0], count: options.limit[1] },
 		},
+		...options.rev && { REV: true } as const,
 	};
 }
 

--- a/packages/xxscreeps/backend/sockets/room.ts
+++ b/packages/xxscreeps/backend/sockets/room.ts
@@ -163,7 +163,7 @@ export const roomSubscription: SubscriptionEndpoint = {
 					}
 					// Check for new users
 					const users = room['#users'];
-					for (const userId of Fn.concat([ users.presence, users.extra ])) {
+					for (const userId of Fn.concat<string>([ users.presence, users.extra ])) {
 						if (!seenUsers.has(userId)) {
 							seenUsers.add(userId);
 							visibleUsers.add(userId);

--- a/packages/xxscreeps/engine/db/storage/local/blob.ts
+++ b/packages/xxscreeps/engine/db/storage/local/blob.ts
@@ -238,6 +238,8 @@ export class BlobStorage implements AsyncDisposable {
 					}
 			}
 		}
+		// TODO: honor `options.px` so callers can give blobs a TTL (e.g. market transactions expire
+		// after 24h instead of leaking once both parties have evicted them).
 		this.cache.set(key, {
 			saveId: this.saveId,
 			value: function() {

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -341,7 +341,7 @@ export class LocalKeyValResponder implements AsyncDisposable, MaybePromises<Pr.K
 
 	sInter(key: string, keys: string[]) {
 		const sets = Fn.pipe(
-			Fn.concat([ [ key ], keys ]),
+			Fn.concat<string>([ [ key ], keys ]),
 			$$ => Fn.map($$, (key): Set<string> | undefined => this.data.get(key)),
 			$$ => [ ...$$ ]);
 		if (sets.every(set => set !== undefined)) {
@@ -517,10 +517,17 @@ export class LocalKeyValResponder implements AsyncDisposable, MaybePromises<Pr.K
 		}
 	}
 
-	zRange(key: string, min: number | string, max: number | string, options?: Pr.ZRange): any {
+	zRange(key: string, minParam: number | string, maxParam: number | string, options?: Pr.ZRange): any {
 		const set: SortedSet | undefined = this.data.get(key);
 		if (set) {
-			const allMatching = function() {
+			const { min, max } = function() {
+				if (options?.rev) {
+					return { min: maxParam, max: minParam };
+				} else {
+					return { min: minParam, max: maxParam };
+				}
+			}();
+			let allMatching = function() {
 				switch (options?.by) {
 					case 'LEX': {
 						const parse = (value: string): [ string, boolean ] => {
@@ -543,9 +550,7 @@ export class LocalKeyValResponder implements AsyncDisposable, MaybePromises<Pr.K
 					case 'SCORE': return [ ...Fn.map(set.entries(min as number, max as number), entry => entry[1]) ];
 					default: {
 						const convert = (value: number) => {
-							if (value === Infinity || value === -Infinity) {
-								throw new Error(`Invalid range value: ${value}`);
-							} else if (value < 0) {
+							if (value < 0) {
 								return set.size + value;
 							} else {
 								return value;
@@ -555,6 +560,9 @@ export class LocalKeyValResponder implements AsyncDisposable, MaybePromises<Pr.K
 					}
 				}
 			}();
+			if (options?.rev) {
+				allMatching = allMatching.reverse();
+			}
 			if (options?.limit) {
 				return allMatching.slice(options.limit[0], options.limit[0] + options.limit[1]);
 			} else {

--- a/packages/xxscreeps/engine/db/storage/provider.ts
+++ b/packages/xxscreeps/engine/db/storage/provider.ts
@@ -38,6 +38,7 @@ export interface ZAggregate {
 export interface ZRange {
 	by?: 'LEX' | 'SCORE';
 	limit?: [ number, number ];
+	rev?: boolean;
 }
 
 export type Value = number | string | Readonly<Uint8Array>;

--- a/packages/xxscreeps/engine/runner/index.ts
+++ b/packages/xxscreeps/engine/runner/index.ts
@@ -23,6 +23,9 @@ export interface TickPayload {
 	backendIntents?: RunnerIntent[];
 	eval: Extract<MessageFor<typeof getRunnerUserChannel>, { type: 'eval' }>['payload'][];
 	usernames?: Record<string, string>;
+	// User ids a connector wants resolved to usernames this tick (e.g. market transaction parties not
+	// visible in any of the player's rooms). The runner merges these into the unseen-user resolution.
+	userIds?: string[];
 }
 
 export interface TickResult {

--- a/packages/xxscreeps/engine/runner/instance.ts
+++ b/packages/xxscreeps/engine/runner/instance.ts
@@ -194,18 +194,19 @@ export class PlayerInstance {
 				// any a connector requested.
 				const newUserIds = Fn.pipe(
 					roomBlobs,
-					$$ => Fn.map($$, blob => {
+					$$ => Fn.transform($$, blob => {
 						const users = RoomSchema.read(blob)['#users'];
 						return Fn.concat([ users.presence, users.extra ]);
 					}),
-					$$ => Fn.concat($$),
 					$$ => Fn.concat([ $$, payload.userIds ?? [] ]),
+					$$ => new Set($$),
 					$$ => Fn.reject($$, userId => this.seenUsers.has(userId)),
 				);
-				const entries = await Promise.all(Fn.map(newUserIds, async userId => {
+				const entries = await Fn.mapAwait(newUserIds, async userId => {
 					this.seenUsers.add(userId);
-					return [ userId, (await this.shard.db.data.hGet(User.infoKey(userId), 'username'))! ] as const;
-				}));
+					const username = await this.shard.db.data.hGet(User.infoKey(userId), 'username');
+					return [ userId, username! ] as const;
+				});
 				if (entries.length !== 0) {
 					payload.usernames = Fn.fromEntries(entries);
 				}

--- a/packages/xxscreeps/engine/runner/instance.ts
+++ b/packages/xxscreeps/engine/runner/instance.ts
@@ -183,33 +183,32 @@ export class PlayerInstance {
 					throw new Error(`User '${this.username}' has been left behind`);
 				}
 
-				// Allow driver connectors to access room blobs by waiting on this promise
-				await Promise.all([
-					(async () => {
-						// Wait for room blobs
-						payload.roomBlobs = await Promise.all(Fn.map(visibleRooms,
-							roomName => this.shard.loadRoomBlob(roomName, time)));
-						// Load unseen users
-						const newUserIds = Fn.pipe(
-							payload.roomBlobs,
-							$$ => Fn.map($$, blob => {
-								const users = RoomSchema.read(blob)['#users'];
-								return Fn.concat([ users.presence, users.extra ]);
-							}),
-							$$ => Fn.concat($$),
-							$$ => Fn.reject($$, userId => this.seenUsers.has(userId)),
-						);
-						const entries = await Promise.all(Fn.map(newUserIds, async userId => {
-							this.seenUsers.add(userId);
-							return [ userId, (await this.shard.db.data.hGet(User.infoKey(userId), 'username'))! ] as const;
-						}));
-						if (entries.length !== 0) {
-							payload.usernames = Fn.fromEntries(entries);
-						}
-					})(),
-					// Also run mod connectors
+				// Load room blobs and run mod connectors concurrently; both can contribute users to
+				// resolve (rooms via `#users`, connectors via `payload.userIds`).
+				const [ roomBlobs ] = await Promise.all([
+					Promise.all(Fn.map(visibleRooms, roomName => this.shard.loadRoomBlob(roomName, time))),
 					this.connectors.refresh(payload as TickPayload),
 				]);
+				payload.roomBlobs = roomBlobs;
+				// Resolve usernames for users newly seen this tick: those present in visible rooms plus
+				// any a connector requested.
+				const newUserIds = Fn.pipe(
+					roomBlobs,
+					$$ => Fn.map($$, blob => {
+						const users = RoomSchema.read(blob)['#users'];
+						return Fn.concat([ users.presence, users.extra ]);
+					}),
+					$$ => Fn.concat($$),
+					$$ => Fn.concat([ $$, payload.userIds ?? [] ]),
+					$$ => Fn.reject($$, userId => this.seenUsers.has(userId)),
+				);
+				const entries = await Promise.all(Fn.map(newUserIds, async userId => {
+					this.seenUsers.add(userId);
+					return [ userId, (await this.shard.db.data.hGet(User.infoKey(userId), 'username'))! ] as const;
+				}));
+				if (entries.length !== 0) {
+					payload.usernames = Fn.fromEntries(entries);
+				}
 				// Send payload off to runtime and execute user code
 				return await this.sandbox.run(payload as TickPayload);
 			} catch (err: any) {

--- a/packages/xxscreeps/functional/iterable/fold/fromEntries.ts
+++ b/packages/xxscreeps/functional/iterable/fold/fromEntries.ts
@@ -6,8 +6,8 @@ import { map } from 'xxscreeps/functional/iterable/map.js';
 export function fromEntries<Type, Key extends keyof any>(
 	iterable: Iterable<readonly [ Key, Type ]>): Record<Key, Type>;
 export function fromEntries<Type, Key extends keyof any, Value>(
-	iterable: Iterable<Type>, callback: (value: Type) => readonly [ Key, Value ]): Record<Key, Value>;
-export function fromEntries(iterable: Iterable<any>, callback?: (value: any) => readonly [ any, any ]) {
+	iterable: Iterable<Type>, callback: (value: Type, index: number) => readonly [ Key, Value ]): Record<Key, Value>;
+export function fromEntries(iterable: Iterable<any>, callback?: (value: unknown, index: number) => readonly [ unknown, unknown ]) {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const object: Record<string, unknown> = Object.create(null);
 	for (const [ key, value ] of callback ? map(iterable, callback) : iterable) {

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -2,10 +2,32 @@ import lodash from '@xxscreeps/lodash3';
 import * as C from './constants/index.js';
 import { hooks, registerGlobal } from './symbols.js';
 
+const { apply } = Reflect;
+
 declare global {
+	function cached(target: object, key: string, descriptor: PropertyDescriptor): void;
 	function enumerable(target: object, key: string, descriptor: PropertyDescriptor): void;
 }
 
+globalThis.cached = (target: object, key: string, descriptor: PropertyDescriptor) => {
+	// eslint-disable-next-line @typescript-eslint/unbound-method
+	const { get } = descriptor;
+	if (!get) {
+		throw new TypeError('cached decorator can only be applied to getters');
+	}
+	const set = function(this: unknown, value: unknown) {
+		Object.defineProperty(this, key, { value, writable: true });
+	};
+	return {
+		set,
+		...descriptor,
+		get() {
+			const value: unknown = apply(get, this, []);
+			apply(set, this, [ value ]);
+			return value;
+		},
+	};
+};
 globalThis.enumerable = (target: object, key: string, descriptor: PropertyDescriptor) => ({ ...descriptor, enumerable: true });
 
 registerGlobal('_', lodash);
@@ -22,6 +44,8 @@ hooks.register('runtimeConnector', {
 });
 
 export function flushGlobals() {
+	// @ts-expect-error
+	delete globalThis.cached;
 	// @ts-expect-error
 	delete globalThis.enumerable;
 }

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -1,6 +1,7 @@
 import type { TransactionPayload } from './transaction.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
+import { getOrSet } from 'xxscreeps/utility/utility.js';
 import { getTransactionChannel, kTransactionWindow, loadTransactionBlob, loadTransactionEntries, selectRecent } from './model.js';
 import { read } from './transaction.js';
 
@@ -12,18 +13,13 @@ declare module 'xxscreeps/engine/runner/index.js' {
 
 // Transaction blobs are immutable and their ids are globally unique, so cache them by id: a transfer
 // referenced by both parties' runtimes is read once and handed out as the same SharedArrayBuffer.
-const blobCache = new Map<string, Promise<Readonly<Uint8Array>>>();
-function loadBlob(shard: Shard, id: string) {
-	let blob = blobCache.get(id);
-	if (blob === undefined) {
-		blob = loadTransactionBlob(shard, id);
-		blobCache.set(id, blob);
-	}
-	return blob;
-}
+const loadBlob = function() {
+	const cache = new Map<string, Promise<Readonly<Uint8Array>>>();
+	return (shard: Shard, id: string) =>
+		getOrSet(cache, id, () => loadTransactionBlob(shard, id));
+}();
 
 hooks.register('runnerConnector', async player => {
-	// Reload the user's transactions only when the processor signals a new transfer, not every tick.
 	const channel = await getTransactionChannel(player.shard, player.userId).subscribe();
 	let dirty = true;
 	channel.listen(() => { dirty = true; });

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -20,31 +20,31 @@ const loadBlob = function() {
 }();
 
 hooks.register('runnerConnector', async player => {
+	// The processor publishes here whenever a transfer touches the user. Reload and resend only then;
+	// on quiet ticks the runtime keeps the last payload it was sent, so aged-out transfers linger
+	// until the next transfer rewindows the list.
 	const channel = await getTransactionChannel(player.shard, player.userId).subscribe();
 	let dirty = true;
 	channel.listen(() => { dirty = true; });
-	let entries: ReturnType<typeof loadTransactionEntries> | undefined;
 	return [ () => channel.disconnect(), {
+		// A fresh sandbox (first tick, or after a code reset) holds no transactions; resend next tick.
+		initialize() { dirty = true; },
 		async refresh(payload) {
-			if (dirty) {
-				dirty = false;
-				entries = loadTransactionEntries(player.shard, player.userId);
+			if (!dirty) {
+				return;
 			}
-			const { incoming, outgoing } = await entries!;
-			// Re-apply the window every tick so transfers age out without a reload.
+			dirty = false;
+			const { incoming, outgoing } = await loadTransactionEntries(player.shard, player.userId);
 			const cutoff = Date.now() - kTransactionWindow;
 			const incomingIds = selectRecent(incoming, cutoff);
 			const outgoingIds = selectRecent(outgoing, cutoff);
 			const ids = [ ...new Set([ ...incomingIds, ...outgoingIds ]) ];
 			const blobList = await Promise.all(ids.map(id => loadBlob(player.shard, id)));
-			// Ask the runner to resolve the parties' usernames for the read-time getters.
-			const parties = new Set<string>();
+			// Contribute both parties of every transfer; the runner resolves and dedupes the ids.
 			for (const blob of blobList) {
 				const transaction = read(blob);
-				parties.add(transaction['#sender']);
-				parties.add(transaction['#recipient']);
+				(payload.userIds ??= []).push(transaction['#sender'], transaction['#recipient']);
 			}
-			(payload.userIds ??= []).push(...parties);
 			const blobs = Object.fromEntries(ids.map((id, index) => [ id, blobList[index]! ]));
 			payload.transactions = { incoming: incomingIds, outgoing: outgoingIds, blobs };
 		},

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -1,8 +1,7 @@
 import type { TransactionPayload } from './transaction.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
-import * as User from 'xxscreeps/engine/db/user/index.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
-import { loadTransactionBlob, loadTransactionRefs } from './model.js';
+import { getTransactionChannel, kTransactionWindow, loadTransactionBlob, loadTransactionEntries, selectRecent } from './model.js';
 import { read } from './transaction.js';
 
 declare module 'xxscreeps/engine/runner/index.js' {
@@ -11,43 +10,47 @@ declare module 'xxscreeps/engine/runner/index.js' {
 	}
 }
 
-interface BlobCacheEntry {
-	time: number;
-	blobs: Map<string, Promise<Readonly<Uint8Array>>>;
-}
-
-// Transaction blobs are immutable, so cache them by id per (shard, tick): a transfer referenced by
-// both parties' runtimes is read once and handed out as the same SharedArrayBuffer.
-const blobCache = new WeakMap<Shard, BlobCacheEntry>();
-function loadBlobOnce(shard: Shard, time: number, id: string) {
-	let cache = blobCache.get(shard);
-	if (cache?.time !== time) {
-		cache = { time, blobs: new Map() };
-		blobCache.set(shard, cache);
-	}
-	let blob = cache.blobs.get(id);
+// Transaction blobs are immutable and their ids are globally unique, so cache them by id: a transfer
+// referenced by both parties' runtimes is read once and handed out as the same SharedArrayBuffer.
+const blobCache = new Map<string, Promise<Readonly<Uint8Array>>>();
+function loadBlob(shard: Shard, id: string) {
+	let blob = blobCache.get(id);
 	if (blob === undefined) {
 		blob = loadTransactionBlob(shard, id);
-		cache.blobs.set(id, blob);
+		blobCache.set(id, blob);
 	}
 	return blob;
 }
 
-hooks.register('runnerConnector', player => [ undefined, {
-	async refresh(payload) {
-		const { incoming, outgoing } = await loadTransactionRefs(player.shard, player.userId);
-		const ids = [ ...new Set([ ...incoming, ...outgoing ]) ];
-		const blobList = await Promise.all(ids.map(id => loadBlobOnce(player.shard, payload.time, id)));
-		// Resolve every party so the read-time `sender` / `recipient` getters find a username.
-		const parties = new Set<string>();
-		for (const blob of blobList) {
-			const transaction = read(blob);
-			parties.add(transaction['#sender']);
-			parties.add(transaction['#recipient']);
-		}
-		const usernames = Object.fromEntries(await Promise.all([ ...parties ].map(async userId =>
-			[ userId, (await player.shard.db.data.hGet(User.infoKey(userId), 'username'))! ] as const)));
-		const blobs = Object.fromEntries(ids.map((id, index) => [ id, blobList[index]! ]));
-		payload.transactions = { incoming, outgoing, blobs, usernames };
-	},
-} ]);
+hooks.register('runnerConnector', async player => {
+	// Reload the user's transactions only when the processor signals a new transfer, not every tick.
+	const channel = await getTransactionChannel(player.shard, player.userId).subscribe();
+	let dirty = true;
+	channel.listen(() => { dirty = true; });
+	let entries: ReturnType<typeof loadTransactionEntries> | undefined;
+	return [ () => channel.disconnect(), {
+		async refresh(payload) {
+			if (dirty) {
+				dirty = false;
+				entries = loadTransactionEntries(player.shard, player.userId);
+			}
+			const { incoming, outgoing } = await entries!;
+			// Re-apply the window every tick so transfers age out without a reload.
+			const cutoff = Date.now() - kTransactionWindow;
+			const incomingIds = selectRecent(incoming, cutoff);
+			const outgoingIds = selectRecent(outgoing, cutoff);
+			const ids = [ ...new Set([ ...incomingIds, ...outgoingIds ]) ];
+			const blobList = await Promise.all(ids.map(id => loadBlob(player.shard, id)));
+			// Ask the runner to resolve the parties' usernames for the read-time getters.
+			const parties = new Set<string>();
+			for (const blob of blobList) {
+				const transaction = read(blob);
+				parties.add(transaction['#sender']);
+				parties.add(transaction['#recipient']);
+			}
+			(payload.userIds ??= []).push(...parties);
+			const blobs = Object.fromEntries(ids.map((id, index) => [ id, blobList[index]! ]));
+			payload.transactions = { incoming: incomingIds, outgoing: outgoingIds, blobs };
+		},
+	} ];
+});

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -11,9 +11,14 @@ declare module 'xxscreeps/engine/runner/index.js' {
 	}
 }
 
+interface BlobCacheEntry {
+	time: number;
+	blobs: Map<string, Promise<Readonly<Uint8Array>>>;
+}
+
 // Transaction blobs are immutable, so cache them by id per (shard, tick): a transfer referenced by
 // both parties' runtimes is read once and handed out as the same SharedArrayBuffer.
-const blobCache = new WeakMap<Shard, { time: number; blobs: Map<string, Promise<Readonly<Uint8Array>>> }>();
+const blobCache = new WeakMap<Shard, BlobCacheEntry>();
 function loadBlobOnce(shard: Shard, time: number, id: string) {
 	let cache = blobCache.get(shard);
 	if (cache?.time !== time) {

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -1,8 +1,9 @@
 import type { TransactionPayload } from './transaction.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
-import { getTransactionChannel, kTransactionWindow, loadTransactionBlob, loadTransactionEntries, selectRecent } from './model.js';
+import { getTransactionChannel, loadTransactionBlob, loadTransactionEntries } from './model.js';
 import { read } from './transaction.js';
 
 declare module 'xxscreeps/engine/runner/index.js' {
@@ -23,6 +24,8 @@ hooks.register('runnerConnector', async player => {
 	// The processor publishes here whenever a transfer touches the user. Reload and resend only then;
 	// on quiet ticks the runtime keeps the last payload it was sent, so aged-out transfers linger
 	// until the next transfer rewindows the list.
+	// TODO: Players making heavy use of the market could benefit from only receiving new transaction
+	// blobs.
 	const channel = await getTransactionChannel(player.shard, player.userId).subscribe();
 	let dirty = true;
 	channel.listen(() => { dirty = true; });
@@ -35,18 +38,14 @@ hooks.register('runnerConnector', async player => {
 			}
 			dirty = false;
 			const { incoming, outgoing } = await loadTransactionEntries(player.shard, player.userId);
-			const cutoff = Date.now() - kTransactionWindow;
-			const incomingIds = selectRecent(incoming, cutoff);
-			const outgoingIds = selectRecent(outgoing, cutoff);
-			const ids = [ ...new Set([ ...incomingIds, ...outgoingIds ]) ];
-			const blobList = await Promise.all(ids.map(id => loadBlob(player.shard, id)));
-			// Contribute both parties of every transfer; the runner resolves and dedupes the ids.
+			const ids = [ ...incoming, ...outgoing ];
+			const blobList = await Fn.mapAwait(ids, id => loadBlob(player.shard, id));
 			for (const blob of blobList) {
 				const transaction = read(blob);
 				(payload.userIds ??= []).push(transaction['#sender'], transaction['#recipient']);
 			}
-			const blobs = Object.fromEntries(ids.map((id, index) => [ id, blobList[index]! ]));
-			payload.transactions = { incoming: incomingIds, outgoing: outgoingIds, blobs };
+			const blobs = Fn.fromEntries(ids, (id, index) => [ id, blobList[index]! ]);
+			payload.transactions = { incoming, outgoing, blobs };
 		},
 	} ];
 });

--- a/packages/xxscreeps/mods/market/driver.ts
+++ b/packages/xxscreeps/mods/market/driver.ts
@@ -1,0 +1,48 @@
+import type { TransactionPayload } from './transaction.js';
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { hooks } from 'xxscreeps/engine/runner/index.js';
+import { loadTransactionBlob, loadTransactionRefs } from './model.js';
+import { read } from './transaction.js';
+
+declare module 'xxscreeps/engine/runner/index.js' {
+	interface TickPayload {
+		transactions?: TransactionPayload;
+	}
+}
+
+// Transaction blobs are immutable, so cache them by id per (shard, tick): a transfer referenced by
+// both parties' runtimes is read once and handed out as the same SharedArrayBuffer.
+const blobCache = new WeakMap<Shard, { time: number; blobs: Map<string, Promise<Readonly<Uint8Array>>> }>();
+function loadBlobOnce(shard: Shard, time: number, id: string) {
+	let cache = blobCache.get(shard);
+	if (cache?.time !== time) {
+		cache = { time, blobs: new Map() };
+		blobCache.set(shard, cache);
+	}
+	let blob = cache.blobs.get(id);
+	if (blob === undefined) {
+		blob = loadTransactionBlob(shard, id);
+		cache.blobs.set(id, blob);
+	}
+	return blob;
+}
+
+hooks.register('runnerConnector', player => [ undefined, {
+	async refresh(payload) {
+		const { incoming, outgoing } = await loadTransactionRefs(player.shard, player.userId);
+		const ids = [ ...new Set([ ...incoming, ...outgoing ]) ];
+		const blobList = await Promise.all(ids.map(id => loadBlobOnce(player.shard, payload.time, id)));
+		// Resolve every party so the read-time `sender` / `recipient` getters find a username.
+		const parties = new Set<string>();
+		for (const blob of blobList) {
+			const transaction = read(blob);
+			parties.add(transaction['#sender']);
+			parties.add(transaction['#recipient']);
+		}
+		const usernames = Object.fromEntries(await Promise.all([ ...parties ].map(async userId =>
+			[ userId, (await player.shard.db.data.hGet(User.infoKey(userId), 'username'))! ] as const)));
+		const blobs = Object.fromEntries(ids.map((id, index) => [ id, blobList[index]! ]));
+		payload.transactions = { incoming, outgoing, blobs, usernames };
+	},
+} ]);

--- a/packages/xxscreeps/mods/market/game.ts
+++ b/packages/xxscreeps/mods/market/game.ts
@@ -1,3 +1,4 @@
+import type { Transactions } from './transaction.js';
 import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { Market } from './market.js';
@@ -36,6 +37,12 @@ declare module 'xxscreeps/game/game.js' {
 		market: Market;
 	}
 }
+// The runner ships transactions only when a transfer changes the list, so retain the last payload
+// and reuse it on the ticks it isn't resent.
+let transactions: Transactions | undefined;
 hooks.register('gameInitializer', (game, data) => {
-	game.market = new Market(game, data?.transactions && readTransactions(data.transactions));
+	if (data?.transactions) {
+		transactions = readTransactions(data.transactions);
+	}
+	game.market = new Market(game, transactions);
 });

--- a/packages/xxscreeps/mods/market/game.ts
+++ b/packages/xxscreeps/mods/market/game.ts
@@ -1,9 +1,8 @@
-import type { Transactions } from './transaction.js';
 import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { Market } from './market.js';
 import * as Terminal from './terminal.js';
-import { readTransactions } from './transaction.js';
+import { Transactions } from './transaction.js';
 
 // Export `StructureTerminal` to runtime globals
 registerGlobal(Terminal.StructureTerminal);
@@ -42,7 +41,7 @@ declare module 'xxscreeps/game/game.js' {
 let transactions: Transactions | undefined;
 hooks.register('gameInitializer', (game, data) => {
 	if (data?.transactions) {
-		transactions = readTransactions(data.transactions);
+		transactions = new Transactions(data.transactions);
 	}
 	game.market = new Market(game, transactions);
 });

--- a/packages/xxscreeps/mods/market/game.ts
+++ b/packages/xxscreeps/mods/market/game.ts
@@ -2,6 +2,7 @@ import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
 import { Market } from './market.js';
 import * as Terminal from './terminal.js';
+import { readTransactions } from './transaction.js';
 
 // Export `StructureTerminal` to runtime globals
 registerGlobal(Terminal.StructureTerminal);
@@ -35,6 +36,6 @@ declare module 'xxscreeps/game/game.js' {
 		market: Market;
 	}
 }
-hooks.register('gameInitializer', game => {
-	game.market = new Market(game);
+hooks.register('gameInitializer', (game, data) => {
+	game.market = new Market(game, data?.transactions && readTransactions(data.transactions));
 });

--- a/packages/xxscreeps/mods/market/index.ts
+++ b/packages/xxscreeps/mods/market/index.ts
@@ -5,5 +5,5 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/resource',
 		'xxscreeps/mods/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor', 'test' ],
+	provides: [ 'backend', 'constants', 'driver', 'game', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/market/market.ts
+++ b/packages/xxscreeps/mods/market/market.ts
@@ -1,16 +1,19 @@
+import type { Transactions } from './transaction.js';
 import type { GameBase } from 'xxscreeps/game/game.js';
 
 export class Market {
 	orders = [];
-	incomingTransactions = [];
-	outgoingTransactions = [];
 	readonly #map;
+	readonly #transactions;
 
-	constructor(game: GameBase) {
+	constructor(game: GameBase, transactions?: Transactions) {
 		this.#map = game.map;
+		this.#transactions = transactions;
 	}
 
 	get credits() { return 0; }
+	get incomingTransactions() { return this.#transactions?.incoming ?? []; }
+	get outgoingTransactions() { return this.#transactions?.outgoing ?? []; }
 	cancelOrder() {}
 	changeOrderPrice() {}
 	createOrder() {}

--- a/packages/xxscreeps/mods/market/model.ts
+++ b/packages/xxscreeps/mods/market/model.ts
@@ -10,7 +10,7 @@ import { Transaction, write } from './transaction.js';
 // keeps at most `kMaxTransactions` ids (newest last); a transfer is referenced by exactly two lists
 // when recorded, so `market/transactionRefs` counts the live references and the blob is freed once
 // both parties have evicted it.
-export const kMaxTransactions = 100;
+const kMaxTransactions = 100;
 export const kTransactionWindow = 24 * 60 * 60 * 1000;
 
 type Direction = 'incoming' | 'outgoing';
@@ -45,8 +45,9 @@ async function dropReference(shard: Shard, id: string) {
 
 async function pushReference(shard: Shard, userId: string, direction: Direction, entry: string) {
 	const key = listKey(userId, direction);
-	const length = await shard.data.rPush(key, [ entry ]);
-	for (let excess = length - kMaxTransactions; excess > 0; --excess) {
+	// One push adds one entry, so at most one is over the cap. Pop a single oldest; trimming by
+	// `length - kMaxTransactions` over-evicts when concurrent pushes each observe a racing length.
+	if (await shard.data.rPush(key, [ entry ]) > kMaxTransactions) {
 		const evicted = await shard.data.lPop(key);
 		if (evicted !== null) {
 			await dropReference(shard, idFromEntry(evicted));

--- a/packages/xxscreeps/mods/market/model.ts
+++ b/packages/xxscreeps/mods/market/model.ts
@@ -9,10 +9,10 @@ import { Transaction, write } from './transaction.js';
 // `market/transaction/<id>` and referenced by id from each party's per-direction sorted set, scored
 // by wall-clock time. The blob carries a `px` TTL so it self-frees after the read window; the set
 // entries are score-trimmed to the same window. Both parties' runtimes are handed the same blob.
-export const kTransactionWindow = 24 * 60 * 60 * 1000;
+const kTransactionWindow = 24 * 60 * 60 * 1000;
 // `incomingTransactions` / `outgoingTransactions` expose the most recent transfers, capped at the
 // smaller of the 24h window or this count.
-export const kReadLimit = 100;
+const kReadLimit = 100;
 
 type Direction = 'incoming' | 'outgoing';
 
@@ -29,7 +29,7 @@ export interface TransactionFields {
 	amount: number;
 	from: string;
 	to: string;
-	description?: string | undefined;
+	description?: string | undefined | null;
 }
 
 export function loadTransactionBlob(shard: Shard, id: string) {
@@ -37,31 +37,17 @@ export function loadTransactionBlob(shard: Shard, id: string) {
 }
 
 // A user's transfer ids in one direction, oldest-first with their wall-clock scores.
-function loadDirection(shard: Shard, userId: string, direction: Direction) {
-	return shard.data.zRangeWithScores(setKey(userId, direction), 0, -1);
+function loadDirection(shard: Shard, userId: string, direction: Direction, cutoff: number) {
+	return shard.data.zRange(setKey(userId, direction), Infinity, cutoff, { by: 'SCORE', limit: [ 0, kReadLimit ], rev: true });
 }
 
 export async function loadTransactionEntries(shard: Shard, userId: string) {
+	const cutoff = Date.now() - kTransactionWindow;
 	const [ incoming, outgoing ] = await Promise.all([
-		loadDirection(shard, userId, 'incoming'),
-		loadDirection(shard, userId, 'outgoing'),
+		loadDirection(shard, userId, 'incoming', cutoff),
+		loadDirection(shard, userId, 'outgoing', cutoff),
 	]);
 	return { incoming, outgoing };
-}
-
-// Newest-first ids within the window, capped at `limit` — the API exposes whichever of the window /
-// count is smaller. `entries` are oldest-first (sorted-set order), so walk back from the newest.
-export function selectRecent(entries: [ number, string ][], cutoff: number, limit = kReadLimit) {
-	const ids: string[] = [];
-	for (let index = entries.length - 1; index >= 0 && ids.length < limit; --index) {
-		const [ score, id ] = entries[index]!;
-		if (score < cutoff) {
-			// Earlier entries are older still, so nothing more is in the window.
-			break;
-		}
-		ids.push(id);
-	}
-	return ids;
 }
 
 async function reference(shard: Shard, userId: string, direction: Direction, time: number, id: string) {
@@ -83,18 +69,17 @@ export async function recordTransaction(shard: Shard, senderId: string, recipien
 		from: fields.from,
 		to: fields.to,
 	});
-	// `#` fields are assigned through member access so the isolated-vm private transform rewrites them.
 	transaction['#sender'] = senderId;
 	transaction['#recipient'] = recipientId;
 	if (fields.description != null) {
 		transaction['#description'] = fields.description;
 	}
-	const time = Date.now();
+	const wallTime = Date.now();
 	await Promise.all([
 		// The blob expires after the read window; both parties reference the same id until then.
 		shard.data.set(blobKey(id), write(transaction), { px: kTransactionWindow }),
-		reference(shard, senderId, 'outgoing', time, id),
-		reference(shard, recipientId, 'incoming', time, id),
+		reference(shard, senderId, 'outgoing', wallTime, id),
+		reference(shard, recipientId, 'incoming', wallTime, id),
 		getTransactionChannel(shard, senderId).publish({ type: 'updated' }),
 		getTransactionChannel(shard, recipientId).publish({ type: 'updated' }),
 	]);

--- a/packages/xxscreeps/mods/market/model.ts
+++ b/packages/xxscreeps/mods/market/model.ts
@@ -1,24 +1,27 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { ResourceType } from 'xxscreeps/mods/resource/resource.js';
+import { Channel } from 'xxscreeps/engine/db/channel.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { Transaction, write } from './transaction.js';
 
-// Terminal transfers are normalized: each is stored once as an immutable blob at
-// `market/transaction/<id>` and referenced from each party's per-direction list. A list entry is
-// `<createdMs>|<id>` — the timestamp gates the 24h read window, the id dereferences the blob. A list
-// keeps at most `kMaxTransactions` ids (newest last); a transfer is referenced by exactly two lists
-// when recorded, so `market/transactionRefs` counts the live references and the blob is freed once
-// both parties have evicted it.
-const kMaxTransactions = 100;
+// A terminal transfer is normalized: stored once as an immutable schema blob at
+// `market/transaction/<id>` and referenced by id from each party's per-direction sorted set, scored
+// by wall-clock time. The blob carries a `px` TTL so it self-frees after the read window; the set
+// entries are score-trimmed to the same window. Both parties' runtimes are handed the same blob.
 export const kTransactionWindow = 24 * 60 * 60 * 1000;
+// `incomingTransactions` / `outgoingTransactions` expose the most recent transfers, capped at the
+// smaller of the 24h window or this count.
+export const kReadLimit = 100;
 
 type Direction = 'incoming' | 'outgoing';
 
 const blobKey = (id: string) => `market/transaction/${id}`;
-const listKey = (userId: string, direction: Direction) => `user/${userId}/market/transactions/${direction}`;
-const refsKey = 'market/transactionRefs';
-const idFromEntry = (entry: string) => entry.slice(entry.indexOf('|') + 1);
+const setKey = (userId: string, direction: Direction) => `user/${userId}/market/transactions/${direction}`;
+
+export function getTransactionChannel(shard: Shard, userId: string) {
+	return new Channel<{ type: 'updated' }>(shard.pubsub, `user/${userId}/market/transactions`);
+}
 
 export interface TransactionFields {
 	time: number;
@@ -33,26 +36,41 @@ export function loadTransactionBlob(shard: Shard, id: string) {
 	return shard.data.req(blobKey(id), { blob: true });
 }
 
-async function dropReference(shard: Shard, id: string) {
-	// One list no longer references this transfer; free the blob once neither party does.
-	if (await shard.data.hincrBy(refsKey, id, -1) <= 0) {
-		await Promise.all([
-			shard.data.hDel(refsKey, [ id ]),
-			shard.data.del(blobKey(id)),
-		]);
-	}
+// A user's transfer ids in one direction, oldest-first with their wall-clock scores.
+function loadDirection(shard: Shard, userId: string, direction: Direction) {
+	return shard.data.zRangeWithScores(setKey(userId, direction), 0, -1);
 }
 
-async function pushReference(shard: Shard, userId: string, direction: Direction, entry: string) {
-	const key = listKey(userId, direction);
-	// One push adds one entry, so at most one is over the cap. Pop a single oldest; trimming by
-	// `length - kMaxTransactions` over-evicts when concurrent pushes each observe a racing length.
-	if (await shard.data.rPush(key, [ entry ]) > kMaxTransactions) {
-		const evicted = await shard.data.lPop(key);
-		if (evicted !== null) {
-			await dropReference(shard, idFromEntry(evicted));
+export async function loadTransactionEntries(shard: Shard, userId: string) {
+	const [ incoming, outgoing ] = await Promise.all([
+		loadDirection(shard, userId, 'incoming'),
+		loadDirection(shard, userId, 'outgoing'),
+	]);
+	return { incoming, outgoing };
+}
+
+// Newest-first ids within the window, capped at `limit` — the API exposes whichever of the window /
+// count is smaller. `entries` are oldest-first (sorted-set order), so walk back from the newest.
+export function selectRecent(entries: [ number, string ][], cutoff: number, limit = kReadLimit) {
+	const ids: string[] = [];
+	for (let index = entries.length - 1; index >= 0 && ids.length < limit; --index) {
+		const [ score, id ] = entries[index]!;
+		if (score < cutoff) {
+			// Earlier entries are older still, so nothing more is in the window.
+			break;
 		}
+		ids.push(id);
 	}
+	return ids;
+}
+
+async function reference(shard: Shard, userId: string, direction: Direction, time: number, id: string) {
+	const key = setKey(userId, direction);
+	await Promise.all([
+		shard.data.zAdd(key, [ [ time, id ] ]),
+		// Drop entries that have aged out of the read window so the set stays bounded.
+		shard.data.zRemRange(key, 0, time - kTransactionWindow),
+	]);
 }
 
 export async function recordTransaction(shard: Shard, senderId: string, recipientId: string, fields: TransactionFields) {
@@ -71,29 +89,13 @@ export async function recordTransaction(shard: Shard, senderId: string, recipien
 	if (fields.description != null) {
 		transaction['#description'] = fields.description;
 	}
-	const entry = `${Date.now()}|${id}`;
+	const time = Date.now();
 	await Promise.all([
-		shard.data.set(blobKey(id), write(transaction)),
-		shard.data.hincrBy(refsKey, id, 2),
-		pushReference(shard, senderId, 'outgoing', entry),
-		pushReference(shard, recipientId, 'incoming', entry),
+		// The blob expires after the read window; both parties reference the same id until then.
+		shard.data.set(blobKey(id), write(transaction), { px: kTransactionWindow }),
+		reference(shard, senderId, 'outgoing', time, id),
+		reference(shard, recipientId, 'incoming', time, id),
+		getTransactionChannel(shard, senderId).publish({ type: 'updated' }),
+		getTransactionChannel(shard, recipientId).publish({ type: 'updated' }),
 	]);
-}
-
-async function loadDirection(shard: Shard, userId: string, direction: Direction, cutoff: number) {
-	const entries = await shard.data.lRange(listKey(userId, direction), -kMaxTransactions, -1);
-	// Newest-first, dropping anything older than the 24h window.
-	return entries
-		.filter(entry => Number(entry.slice(0, entry.indexOf('|'))) >= cutoff)
-		.map(idFromEntry)
-		.reverse();
-}
-
-export async function loadTransactionRefs(shard: Shard, userId: string) {
-	const cutoff = Date.now() - kTransactionWindow;
-	const [ incoming, outgoing ] = await Promise.all([
-		loadDirection(shard, userId, 'incoming', cutoff),
-		loadDirection(shard, userId, 'outgoing', cutoff),
-	]);
-	return { incoming, outgoing };
 }

--- a/packages/xxscreeps/mods/market/model.ts
+++ b/packages/xxscreeps/mods/market/model.ts
@@ -1,0 +1,98 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { ResourceType } from 'xxscreeps/mods/resource/resource.js';
+import * as Id from 'xxscreeps/engine/schema/id.js';
+import { assign } from 'xxscreeps/utility/utility.js';
+import { Transaction, write } from './transaction.js';
+
+// Terminal transfers are normalized: each is stored once as an immutable blob at
+// `market/transaction/<id>` and referenced from each party's per-direction list. A list entry is
+// `<createdMs>|<id>` — the timestamp gates the 24h read window, the id dereferences the blob. A list
+// keeps at most `kMaxTransactions` ids (newest last); a transfer is referenced by exactly two lists
+// when recorded, so `market/transactionRefs` counts the live references and the blob is freed once
+// both parties have evicted it.
+export const kMaxTransactions = 100;
+export const kTransactionWindow = 24 * 60 * 60 * 1000;
+
+type Direction = 'incoming' | 'outgoing';
+
+const blobKey = (id: string) => `market/transaction/${id}`;
+const listKey = (userId: string, direction: Direction) => `user/${userId}/market/transactions/${direction}`;
+const refsKey = 'market/transactionRefs';
+const idFromEntry = (entry: string) => entry.slice(entry.indexOf('|') + 1);
+
+export interface TransactionFields {
+	time: number;
+	resourceType: ResourceType;
+	amount: number;
+	from: string;
+	to: string;
+	description?: string | undefined;
+}
+
+export function loadTransactionBlob(shard: Shard, id: string) {
+	return shard.data.req(blobKey(id), { blob: true });
+}
+
+async function dropReference(shard: Shard, id: string) {
+	// One list no longer references this transfer; free the blob once neither party does.
+	if (await shard.data.hincrBy(refsKey, id, -1) <= 0) {
+		await Promise.all([
+			shard.data.hDel(refsKey, [ id ]),
+			shard.data.del(blobKey(id)),
+		]);
+	}
+}
+
+async function pushReference(shard: Shard, userId: string, direction: Direction, entry: string) {
+	const key = listKey(userId, direction);
+	const length = await shard.data.rPush(key, [ entry ]);
+	for (let excess = length - kMaxTransactions; excess > 0; --excess) {
+		const evicted = await shard.data.lPop(key);
+		if (evicted !== null) {
+			await dropReference(shard, idFromEntry(evicted));
+		}
+	}
+}
+
+export async function recordTransaction(shard: Shard, senderId: string, recipientId: string, fields: TransactionFields) {
+	const id = Id.generateId();
+	const transaction = assign(new Transaction(), {
+		transactionId: id,
+		time: fields.time,
+		resourceType: fields.resourceType,
+		amount: fields.amount,
+		from: fields.from,
+		to: fields.to,
+	});
+	// `#` fields are assigned through member access so the isolated-vm private transform rewrites them.
+	transaction['#sender'] = senderId;
+	transaction['#recipient'] = recipientId;
+	if (fields.description != null) {
+		transaction['#description'] = fields.description;
+	}
+	const entry = `${Date.now()}|${id}`;
+	await Promise.all([
+		shard.data.set(blobKey(id), write(transaction)),
+		shard.data.hincrBy(refsKey, id, 2),
+		pushReference(shard, senderId, 'outgoing', entry),
+		pushReference(shard, recipientId, 'incoming', entry),
+	]);
+}
+
+async function loadDirection(shard: Shard, userId: string, direction: Direction, cutoff: number) {
+	const entries = await shard.data.lRange(listKey(userId, direction), -kMaxTransactions, -1);
+	// Newest-first, dropping anything older than the 24h window.
+	return entries
+		.filter(entry => Number(entry.slice(0, entry.indexOf('|'))) >= cutoff)
+		.map(idFromEntry)
+		.reverse();
+}
+
+export async function loadTransactionRefs(shard: Shard, userId: string) {
+	const cutoff = Date.now() - kTransactionWindow;
+	const [ incoming, outgoing ] = await Promise.all([
+		loadDirection(shard, userId, 'incoming', cutoff),
+		loadDirection(shard, userId, 'outgoing', cutoff),
+	]);
+	return { incoming, outgoing };
+}

--- a/packages/xxscreeps/mods/market/processor.ts
+++ b/packages/xxscreeps/mods/market/processor.ts
@@ -48,13 +48,12 @@ const intents = [
 					// Log the transfer for both parties' market transaction history
 					if (recipientId != null) {
 						context.task(recordTransaction(context.shard, senderId, recipientId, {
-							// The processor runs one tick ahead of the code that issued the send.
 							time: Game.time - 1,
 							resourceType,
 							amount: sent,
 							from: terminal.room.name,
 							to: destination,
-							...description != null && { description },
+							description,
 						}));
 					}
 				}

--- a/packages/xxscreeps/mods/market/processor.ts
+++ b/packages/xxscreeps/mods/market/processor.ts
@@ -4,6 +4,7 @@ import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { clamp } from 'xxscreeps/utility/utility.js';
+import { recordTransaction } from './model.js';
 import { StructureTerminal, calculateEnergyCost, checkSend } from './terminal.js';
 
 declare module 'xxscreeps/engine/processor/index.js' {
@@ -18,6 +19,7 @@ const intents = [
 			// Calculate transfer
 			const range = Game.map.getRoomLinearDistance(terminal.room.name, destination);
 			const energyCost = calculateEnergyCost(amount, range);
+			const senderId = terminal['#user']!;
 			context.task(async function() {
 				// Check other outstanding sends to this terminal
 				const [ room, totalAmount ] = await Promise.all([
@@ -25,21 +27,36 @@ const intents = [
 					context.shard.scratch.incrBy(`room/${destination}/terminalIngress`, amount),
 				]);
 				const capacity = room.terminal?.store.getFreeCapacity() ?? 0;
-				return clamp(0, amount, capacity + amount - totalAmount);
-			}(), amount => {
-				if (amount > 0) {
+				const sent = clamp(0, amount, capacity + amount - totalAmount);
+				const recipientId = room.terminal?.['#user'];
+				return { sent, recipientId };
+			}(), ({ sent, recipientId }) => {
+				if (sent > 0) {
 					// Deduct energy from this terminal
 					if (resourceType === C.RESOURCE_ENERGY) {
-						terminal.store['#subtract'](C.RESOURCE_ENERGY, amount + energyCost);
+						terminal.store['#subtract'](C.RESOURCE_ENERGY, sent + energyCost);
 					} else {
 						terminal.store['#subtract'](C.RESOURCE_ENERGY, energyCost);
-						terminal.store['#subtract'](resourceType, amount);
+						terminal.store['#subtract'](resourceType, sent);
 					}
 					terminal['#cooldownTime'] = Game.time + C.TERMINAL_COOLDOWN - 1;
 					context.didUpdate();
 
 					// Send intent to destination room
-					context.sendRoomIntent(destination, 'terminalSend', resourceType, amount);
+					context.sendRoomIntent(destination, 'terminalSend', resourceType, sent);
+
+					// Log the transfer for both parties' market transaction history
+					if (recipientId != null) {
+						context.task(recordTransaction(context.shard, senderId, recipientId, {
+							// The processor runs one tick ahead of the code that issued the send.
+							time: Game.time - 1,
+							resourceType,
+							amount: sent,
+							from: terminal.room.name,
+							to: destination,
+							...description != null && { description },
+						}));
+					}
 				}
 			});
 		}

--- a/packages/xxscreeps/mods/market/test.ts
+++ b/packages/xxscreeps/mods/market/test.ts
@@ -2,10 +2,9 @@ import type { GameBase } from 'xxscreeps/game/game.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
-import { withFakeNow } from 'xxscreeps/test/console-capture.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import { Market } from './market.js';
-import { kTransactionWindow, loadTransactionBlob, loadTransactionRefs, recordTransaction } from './model.js';
+import { kReadLimit, kTransactionWindow, loadTransactionBlob, loadTransactionEntries, recordTransaction, selectRecent } from './model.js';
 import { create as createTerminal } from './terminal.js';
 import { read } from './transaction.js';
 
@@ -20,8 +19,8 @@ describe('Market transactions', () => {
 	test('a transfer is stored once and referenced by both parties', () => storageSim(async ({ shard }) => {
 		await recordTransaction(shard, '100', '101', fields);
 		const [ sender, recipient ] = await Promise.all([
-			loadTransactionRefs(shard, '100'),
-			loadTransactionRefs(shard, '101'),
+			loadTransactionEntries(shard, '100'),
+			loadTransactionEntries(shard, '101'),
 		]);
 
 		// The sender references it as outgoing only; the recipient as incoming only.
@@ -29,8 +28,8 @@ describe('Market transactions', () => {
 		assert.strictEqual(sender.incoming.length, 0);
 		assert.strictEqual(recipient.incoming.length, 1);
 		assert.strictEqual(recipient.outgoing.length, 0);
-		const id = sender.outgoing[0]!;
-		assert.strictEqual(recipient.incoming[0], id);
+		const id = sender.outgoing[0]![1];
+		assert.strictEqual(recipient.incoming[0]![1], id);
 
 		// One shared blob holds the user ids and the raw (unescaped) description.
 		const transaction = read(await loadTransactionBlob(shard, id));
@@ -47,13 +46,24 @@ describe('Market transactions', () => {
 		assert.strictEqual(transaction.description, 'gift &lt;3');
 	}));
 
-	test('a transfer outside the 24h window is dropped from the read', () => storageSim(async ({ shard }) => {
-		using clock = withFakeNow(1_000_000);
-		await recordTransaction(shard, '100', '101', fields);
-		assert.strictEqual((await loadTransactionRefs(shard, '100')).outgoing.length, 1);
-		clock.advance(kTransactionWindow + 1);
-		assert.strictEqual((await loadTransactionRefs(shard, '100')).outgoing.length, 0);
-	}));
+	test('selectRecent keeps only ids within the window, newest-first', () => {
+		const now = 1_000_000_000;
+		const entries: [ number, string ][] = [
+			[ now - kTransactionWindow - 1, 'old' ],
+			[ now - 10, 'mid' ],
+			[ now, 'new' ],
+		];
+		assert.deepStrictEqual(selectRecent(entries, now - kTransactionWindow), [ 'new', 'mid' ]);
+	});
+
+	test('selectRecent caps at the read limit, newest-first', () => {
+		const entries: [ number, string ][] =
+			Array.from({ length: kReadLimit + 5 }, (value, index) => [ index, `t${index}` ]);
+		const ids = selectRecent(entries, 0);
+		assert.strictEqual(ids.length, kReadLimit);
+		assert.strictEqual(ids[0], `t${kReadLimit + 4}`);
+		assert.strictEqual(ids[kReadLimit - 1], 't5');
+	});
 
 	// User '200' owns terminals in both rooms, so a send to the neighbour is visible to itself from
 	// both ends — exercising the processor → driver → runtime read path with one sandbox.
@@ -103,10 +113,55 @@ describe('Market transactions', () => {
 		await tick(2);
 
 		// The transfer reached storage and is referenced from both of the user's lists.
-		const refs = await loadTransactionRefs(shard, '200');
+		const refs = await loadTransactionEntries(shard, '200');
 		assert.strictEqual(refs.outgoing.length, 1);
 		assert.strictEqual(refs.incoming.length, 1);
-		assert.strictEqual(refs.outgoing[0], refs.incoming[0]);
+		assert.strictEqual(refs.outgoing[0]![1], refs.incoming[0]![1]);
+	}));
+
+	// '201' owns W1N1 and '202' owns W2N1, so the sender is not visible in any of the recipient's
+	// rooms — its username can only resolve through the runner's `userIds` path.
+	const crossSendSim = simulate({
+		W1N1: room => {
+			const terminal = createTerminal(new RoomPosition(25, 25, 'W1N1'), '201');
+			terminal.store['#add'](C.RESOURCE_ENERGY, 10000);
+			room['#insertObject'](terminal);
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = '201';
+		},
+		W2N1: room => {
+			room['#insertObject'](createTerminal(new RoomPosition(25, 25, 'W2N1'), '202'));
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = '202';
+		},
+	});
+
+	test("the recipient resolves the sender's name though they share no room", () => crossSendSim(async ({ sandbox, shard, tick }) => {
+		using _sender = await sandbox('201', global => {
+			if (global.Memory.sent === undefined) {
+				global.Memory.sent = true;
+				global.Game.rooms.W1N1!.terminal!.send('energy', 1000, 'W2N1', 'gift <3');
+			}
+		});
+		using _recipient = await sandbox('202', global => {
+			const incoming = global.Game.market.incomingTransactions;
+			if (incoming.length > 0) {
+				const transaction = incoming[0]!;
+				assert.strictEqual(transaction.from, 'W1N1');
+				assert.strictEqual(transaction.to, 'W2N1');
+				assert.strictEqual(transaction.amount, 1000);
+				assert.strictEqual(transaction.description, 'gift &lt;3');
+				// The sender shares no room with the reader; its name resolves via `payload.userIds`.
+				assert.strictEqual(typeof transaction.sender!.username, 'string');
+			}
+		});
+		// Send (tick 1), then read once the connector ships it (tick 2).
+		await tick(2);
+
+		// The transfer reached the recipient's incoming list and no outgoing list.
+		const refs = await loadTransactionEntries(shard, '202');
+		assert.strictEqual(refs.incoming.length, 1);
+		assert.strictEqual(refs.outgoing.length, 0);
 	}));
 });
 

--- a/packages/xxscreeps/mods/market/test.ts
+++ b/packages/xxscreeps/mods/market/test.ts
@@ -1,12 +1,14 @@
 import type { GameBase } from 'xxscreeps/game/game.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { deterministicClockForTesting } from 'xxscreeps/utility/utility.js';
 import { Market } from './market.js';
-import { kReadLimit, kTransactionWindow, loadTransactionBlob, loadTransactionEntries, recordTransaction, selectRecent } from './model.js';
+import { loadTransactionBlob, loadTransactionEntries, recordTransaction } from './model.js';
 import { create as createTerminal } from './terminal.js';
-import { read } from './transaction.js';
+import { Transactions, read } from './transaction.js';
 
 describe('Market transactions', () => {
 
@@ -17,6 +19,7 @@ describe('Market transactions', () => {
 	} as const;
 
 	test('a transfer is stored once and referenced by both parties', () => storageSim(async ({ shard }) => {
+		using clock = deterministicClockForTesting();
 		await recordTransaction(shard, '100', '101', fields);
 		const [ sender, recipient ] = await Promise.all([
 			loadTransactionEntries(shard, '100'),
@@ -28,8 +31,8 @@ describe('Market transactions', () => {
 		assert.strictEqual(sender.incoming.length, 0);
 		assert.strictEqual(recipient.incoming.length, 1);
 		assert.strictEqual(recipient.outgoing.length, 0);
-		const id = sender.outgoing[0]![1];
-		assert.strictEqual(recipient.incoming[0]![1], id);
+		const id = sender.outgoing[0]!;
+		assert.strictEqual(recipient.incoming[0], id);
 
 		// One shared blob holds the user ids and the raw (unescaped) description.
 		const transaction = read(await loadTransactionBlob(shard, id));
@@ -46,24 +49,17 @@ describe('Market transactions', () => {
 		assert.strictEqual(transaction.description, 'gift &lt;3');
 	}));
 
-	test('selectRecent keeps only ids within the window, newest-first', () => {
-		const now = 1_000_000_000;
-		const entries: [ number, string ][] = [
-			[ now - kTransactionWindow - 1, 'old' ],
-			[ now - 10, 'mid' ],
-			[ now, 'new' ],
-		];
-		assert.deepStrictEqual(selectRecent(entries, now - kTransactionWindow), [ 'new', 'mid' ]);
-	});
-
-	test('selectRecent caps at the read limit, newest-first', () => {
-		const entries: [ number, string ][] =
-			Array.from({ length: kReadLimit + 5 }, (value, index) => [ index, `t${index}` ]);
-		const ids = selectRecent(entries, 0);
-		assert.strictEqual(ids.length, kReadLimit);
-		assert.strictEqual(ids[0], `t${kReadLimit + 4}`);
-		assert.strictEqual(ids[kReadLimit - 1], 't5');
-	});
+	test('transfers are ordered reverse chronologically', () => storageSim(async ({ shard }) => {
+		using clock = deterministicClockForTesting();
+		await recordTransaction(shard, '100', '101', { ...fields, time: 10 });
+		await recordTransaction(shard, '100', '101', { ...fields, time: 20 });
+		const { outgoing } = await loadTransactionEntries(shard, '100');
+		const blobList = await Fn.mapAwait(outgoing, id => loadTransactionBlob(shard, id));
+		const blobs = Fn.fromEntries(outgoing, (id, index) => [ id, blobList[index]! ] as const);
+		const transactions = new Transactions({ incoming: [], outgoing, blobs });
+		assert.strictEqual(transactions.outgoing[0]?.time, 20);
+		assert.strictEqual(transactions.outgoing[1]?.time, 10);
+	}));
 
 	// User '200' owns terminals in both rooms, so a send to the neighbour is visible to itself from
 	// both ends — exercising the processor → driver → runtime read path with one sandbox.
@@ -83,28 +79,29 @@ describe('Market transactions', () => {
 	});
 
 	test('a send appears to both parties with a resolved name and an escaped description', () => selfSendSim(async ({ sandbox, shard, tick }) => {
-		using _player = await sandbox('200', global => {
+		using clock = deterministicClockForTesting();
+		using player = await sandbox('200', global => {
 			const { market } = global.Game;
 			if (global.Memory.sent === undefined) {
 				// First tick: send to our own terminal in the neighbouring room.
 				global.Memory.sent = true;
-				global.Game.rooms.W1N1!.terminal!.send('energy', 1000, 'W2N1', 'gift <3');
+				global.Game.rooms.W1N1?.terminal?.send('energy', 1000, 'W2N1', 'gift <3');
 			} else {
 				// A later tick, once the connector has shipped the transaction to both lists.
 				const outgoing = market.outgoingTransactions;
 				const incoming = market.incomingTransactions;
 				assert.strictEqual(outgoing.length, 1);
 				assert.strictEqual(incoming.length, 1);
-				const transaction = outgoing[0]!;
+				const transaction = outgoing[0];
 				// One record, seen from both ends.
-				assert.strictEqual(transaction.transactionId, incoming[0]!.transactionId);
+				assert.strictEqual(transaction?.transactionId, incoming[0]!.transactionId);
 				assert.strictEqual(transaction.amount, 1000);
 				assert.strictEqual(transaction.from, 'W1N1');
 				assert.strictEqual(transaction.to, 'W2N1');
 				assert.strictEqual(transaction.resourceType, 'energy');
 				// Both parties are this user; the stored ids resolve to one username.
-				assert.strictEqual(typeof transaction.sender!.username, 'string');
-				assert.strictEqual(transaction.sender!.username, transaction.recipient!.username);
+				assert.strictEqual(typeof transaction.sender?.username, 'string');
+				assert.strictEqual(transaction.sender?.username, transaction.recipient?.username);
 				// The description is stored raw and escaped at read.
 				assert.strictEqual(transaction.description, 'gift &lt;3');
 			}
@@ -116,7 +113,7 @@ describe('Market transactions', () => {
 		const refs = await loadTransactionEntries(shard, '200');
 		assert.strictEqual(refs.outgoing.length, 1);
 		assert.strictEqual(refs.incoming.length, 1);
-		assert.strictEqual(refs.outgoing[0]![1], refs.incoming[0]![1]);
+		assert.strictEqual(refs.outgoing[0], refs.incoming[0]);
 	}));
 
 	// '201' owns W1N1 and '202' owns W2N1, so the sender is not visible in any of the recipient's
@@ -137,22 +134,23 @@ describe('Market transactions', () => {
 	});
 
 	test("the recipient resolves the sender's name though they share no room", () => crossSendSim(async ({ sandbox, shard, tick }) => {
-		using _sender = await sandbox('201', global => {
+		using clock = deterministicClockForTesting();
+		using sender = await sandbox('201', global => {
 			if (global.Memory.sent === undefined) {
 				global.Memory.sent = true;
-				global.Game.rooms.W1N1!.terminal!.send('energy', 1000, 'W2N1', 'gift <3');
+				global.Game.rooms.W1N1?.terminal?.send('energy', 1000, 'W2N1', 'gift <3');
 			}
 		});
-		using _recipient = await sandbox('202', global => {
+		using recipient = await sandbox('202', global => {
 			const incoming = global.Game.market.incomingTransactions;
 			if (incoming.length > 0) {
-				const transaction = incoming[0]!;
-				assert.strictEqual(transaction.from, 'W1N1');
+				const transaction = incoming[0];
+				assert.strictEqual(transaction?.from, 'W1N1');
 				assert.strictEqual(transaction.to, 'W2N1');
 				assert.strictEqual(transaction.amount, 1000);
 				assert.strictEqual(transaction.description, 'gift &lt;3');
 				// The sender shares no room with the reader; its name resolves via `payload.userIds`.
-				assert.strictEqual(typeof transaction.sender!.username, 'string');
+				assert.strictEqual(typeof transaction.sender?.username, 'string');
 			}
 		});
 		// Send (tick 1), then read once the connector ships it (tick 2).
@@ -185,29 +183,29 @@ describe('Market', () => {
 
 		test('send sets the sender cooldown but not the receiver', () => sendSim(async ({ player, tick }) => {
 			await player('100', Game => {
-				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
-				assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.OK);
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+				assert.strictEqual(terminal?.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.OK);
 			});
 			await tick();
 			await player('100', Game => {
-				const sender = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
-				const receiver = lookForStructures(Game.rooms.W2N1, C.STRUCTURE_TERMINAL)[0]!;
+				const sender = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+				const receiver = lookForStructures(Game.rooms.W2N1, C.STRUCTURE_TERMINAL)[0];
 				// Observable cooldown is TERMINAL_COOLDOWN - 1: the processor writes
 				// cooldownTime at gameTime = T and user code reads it at time = T + 1.
-				assert.strictEqual(sender.cooldown, C.TERMINAL_COOLDOWN - 1);
-				assert.strictEqual(receiver.cooldown, 0, 'only the sender cools down');
+				assert.strictEqual(sender?.cooldown, C.TERMINAL_COOLDOWN - 1);
+				assert.strictEqual(receiver?.cooldown, 0, 'only the sender cools down');
 			});
 		}));
 
 		test('a second send during cooldown returns ERR_TIRED', () => sendSim(async ({ player, tick }) => {
 			await player('100', Game => {
-				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
-				terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1');
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+				terminal?.send(C.RESOURCE_ENERGY, 1000, 'W2N1');
 			});
 			await tick();
 			await player('100', Game => {
-				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0]!;
-				assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.ERR_TIRED);
+				const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+				assert.strictEqual(terminal?.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.ERR_TIRED);
 			});
 		}));
 	});

--- a/packages/xxscreeps/mods/market/test.ts
+++ b/packages/xxscreeps/mods/market/test.ts
@@ -1,14 +1,117 @@
+import type { GameBase } from 'xxscreeps/game/game.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { lookForStructures } from 'xxscreeps/mods/structure/structure.js';
+import { withFakeNow } from 'xxscreeps/test/console-capture.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { Market } from './market.js';
+import { kTransactionWindow, loadTransactionBlob, loadTransactionRefs, recordTransaction } from './model.js';
 import { create as createTerminal } from './terminal.js';
+import { read } from './transaction.js';
+
+describe('Market transactions', () => {
+
+	// Storage only — `recordTransaction` doesn't touch rooms, and users '100'/'101' exist by default.
+	const storageSim = simulate({});
+	const fields = {
+		time: 10, resourceType: C.RESOURCE_ENERGY, amount: 1000, from: 'W1N1', to: 'W2N1', description: 'gift <3',
+	} as const;
+
+	test('a transfer is stored once and referenced by both parties', () => storageSim(async ({ shard }) => {
+		await recordTransaction(shard, '100', '101', fields);
+		const [ sender, recipient ] = await Promise.all([
+			loadTransactionRefs(shard, '100'),
+			loadTransactionRefs(shard, '101'),
+		]);
+
+		// The sender references it as outgoing only; the recipient as incoming only.
+		assert.strictEqual(sender.outgoing.length, 1);
+		assert.strictEqual(sender.incoming.length, 0);
+		assert.strictEqual(recipient.incoming.length, 1);
+		assert.strictEqual(recipient.outgoing.length, 0);
+		const id = sender.outgoing[0]!;
+		assert.strictEqual(recipient.incoming[0], id);
+
+		// One shared blob holds the user ids and the raw (unescaped) description.
+		const transaction = read(await loadTransactionBlob(shard, id));
+		assert.strictEqual(transaction.transactionId, id);
+		assert.strictEqual(transaction.time, 10);
+		assert.strictEqual(transaction.resourceType, C.RESOURCE_ENERGY);
+		assert.strictEqual(transaction.amount, 1000);
+		assert.strictEqual(transaction.from, 'W1N1');
+		assert.strictEqual(transaction.to, 'W2N1');
+		assert.strictEqual(transaction['#sender'], '100');
+		assert.strictEqual(transaction['#recipient'], '101');
+		assert.strictEqual(transaction['#description'], 'gift <3');
+		// The getter escapes `<` for the runtime.
+		assert.strictEqual(transaction.description, 'gift &lt;3');
+	}));
+
+	test('a transfer outside the 24h window is dropped from the read', () => storageSim(async ({ shard }) => {
+		using clock = withFakeNow(1_000_000);
+		await recordTransaction(shard, '100', '101', fields);
+		assert.strictEqual((await loadTransactionRefs(shard, '100')).outgoing.length, 1);
+		clock.advance(kTransactionWindow + 1);
+		assert.strictEqual((await loadTransactionRefs(shard, '100')).outgoing.length, 0);
+	}));
+
+	// User '200' owns terminals in both rooms, so a send to the neighbour is visible to itself from
+	// both ends — exercising the processor → driver → runtime read path with one sandbox.
+	const selfSendSim = simulate({
+		W1N1: room => {
+			const terminal = createTerminal(new RoomPosition(25, 25, 'W1N1'), '200');
+			terminal.store['#add'](C.RESOURCE_ENERGY, 10000);
+			room['#insertObject'](terminal);
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = '200';
+		},
+		W2N1: room => {
+			room['#insertObject'](createTerminal(new RoomPosition(25, 25, 'W2N1'), '200'));
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = '200';
+		},
+	});
+
+	test('a send appears to both parties with a resolved name and an escaped description', () => selfSendSim(async ({ sandbox, shard, tick }) => {
+		using _player = await sandbox('200', global => {
+			const { market } = global.Game;
+			if (global.Memory.sent === undefined) {
+				// First tick: send to our own terminal in the neighbouring room.
+				global.Memory.sent = true;
+				global.Game.rooms.W1N1!.terminal!.send('energy', 1000, 'W2N1', 'gift <3');
+			} else {
+				// A later tick, once the connector has shipped the transaction to both lists.
+				const outgoing = market.outgoingTransactions;
+				const incoming = market.incomingTransactions;
+				assert.strictEqual(outgoing.length, 1);
+				assert.strictEqual(incoming.length, 1);
+				const transaction = outgoing[0]!;
+				// One record, seen from both ends.
+				assert.strictEqual(transaction.transactionId, incoming[0]!.transactionId);
+				assert.strictEqual(transaction.amount, 1000);
+				assert.strictEqual(transaction.from, 'W1N1');
+				assert.strictEqual(transaction.to, 'W2N1');
+				assert.strictEqual(transaction.resourceType, 'energy');
+				// Both parties are this user; the stored ids resolve to one username.
+				assert.strictEqual(typeof transaction.sender!.username, 'string');
+				assert.strictEqual(transaction.sender!.username, transaction.recipient!.username);
+				// The description is stored raw and escaped at read.
+				assert.strictEqual(transaction.description, 'gift &lt;3');
+			}
+		});
+		// Send (tick 1), then read once the connector ships it (tick 2).
+		await tick(2);
+
+		// The transfer reached storage and is referenced from both of the user's lists.
+		const refs = await loadTransactionRefs(shard, '200');
+		assert.strictEqual(refs.outgoing.length, 1);
+		assert.strictEqual(refs.incoming.length, 1);
+		assert.strictEqual(refs.outgoing[0], refs.incoming[0]);
+	}));
+});
 
 describe('Market', () => {
 
-	// =========================================================================
-	// send
-	// =========================================================================
 	describe('send', () => {
 		const sendSim = simulate({
 			W1N1: room => {
@@ -52,5 +155,11 @@ describe('Market', () => {
 				assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.ERR_TIRED);
 			});
 		}));
+	});
+
+	test('transactions default to empty until loaded', () => {
+		const market = new Market({ map: {} } as unknown as GameBase);
+		assert.deepStrictEqual(market.incomingTransactions, []);
+		assert.deepStrictEqual(market.outgoingTransactions, []);
 	});
 });

--- a/packages/xxscreeps/mods/market/transaction.ts
+++ b/packages/xxscreeps/mods/market/transaction.ts
@@ -16,7 +16,7 @@ const shape = struct({
 	'#description': optional('string'),
 });
 
-export const format = declare('MarketTransaction', () => compose(shape, Transaction));
+const format = declare('MarketTransaction', () => compose(shape, Transaction));
 
 /**
  * One terminal transfer, exposed through `Game.market.incomingTransactions` /

--- a/packages/xxscreeps/mods/market/transaction.ts
+++ b/packages/xxscreeps/mods/market/transaction.ts
@@ -29,7 +29,7 @@ export class Transaction extends withOverlay(BufferObject, shape) {
 	@enumerable get recipient() { return userInfo.get(this['#recipient']); }
 	@enumerable get description() {
 		const description = this['#description'];
-		return description == null ? undefined : description.replace(/</g, '&lt;');
+		return description == null ? undefined : description.replaceAll('<', '&lt;');
 	}
 }
 
@@ -40,20 +40,16 @@ export interface Transactions {
 	outgoing: Transaction[];
 }
 
-// Per-tick payload: each direction lists transaction ids newest-first, `blobs` holds the referenced
-// schema blobs by id, and `usernames` resolves the parties for the read-time getters.
+// Per-tick payload: each direction lists transaction ids newest-first and `blobs` holds the
+// referenced schema blobs by id. The parties resolve through `userInfo`, which the runner populates
+// from the ids the connector contributes to `payload.userIds`.
 export interface TransactionPayload {
 	incoming: string[];
 	outgoing: string[];
 	blobs: Record<string, Readonly<Uint8Array>>;
-	usernames: Record<string, string>;
 }
 
-// Register each party so the getters resolve, then overlay each referenced blob.
 export function readTransactions(payload: TransactionPayload): Transactions {
-	for (const [ userId, username ] of Object.entries(payload.usernames)) {
-		userInfo.set(userId, { username });
-	}
 	const overlay = (ids: string[]) => ids.map(id => read(payload.blobs[id]!));
 	return { incoming: overlay(payload.incoming), outgoing: overlay(payload.outgoing) };
 }

--- a/packages/xxscreeps/mods/market/transaction.ts
+++ b/packages/xxscreeps/mods/market/transaction.ts
@@ -1,0 +1,59 @@
+import * as Id from 'xxscreeps/engine/schema/id.js';
+import { makeReaderAndWriter } from 'xxscreeps/engine/schema/index.js';
+import { userInfo } from 'xxscreeps/game/index.js';
+import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
+import { BufferObject, compose, declare, optional, struct, withOverlay } from 'xxscreeps/schema/index.js';
+
+const shape = struct({
+	transactionId: Id.format,
+	time: 'int32',
+	resourceType: resourceEnumFormat,
+	amount: 'int32',
+	from: 'string',
+	to: 'string',
+	'#sender': Id.format,
+	'#recipient': Id.format,
+	'#description': optional('string'),
+});
+
+export const format = declare('MarketTransaction', () => compose(shape, Transaction));
+
+/**
+ * One terminal transfer, exposed through `Game.market.incomingTransactions` /
+ * `outgoingTransactions`. It is stored once as an immutable blob and referenced from each party's
+ * list, so the runner hands both parties' runtimes the same buffer. The parties are kept as user ids
+ * and resolved to usernames at read time; the description is kept raw and HTML-escaped by its getter.
+ */
+export class Transaction extends withOverlay(BufferObject, shape) {
+	@enumerable get sender() { return userInfo.get(this['#sender']); }
+	@enumerable get recipient() { return userInfo.get(this['#recipient']); }
+	@enumerable get description() {
+		const description = this['#description'];
+		return description == null ? undefined : description.replace(/</g, '&lt;');
+	}
+}
+
+export const { read, write } = makeReaderAndWriter(format);
+
+export interface Transactions {
+	incoming: Transaction[];
+	outgoing: Transaction[];
+}
+
+// Per-tick payload: each direction lists transaction ids newest-first, `blobs` holds the referenced
+// schema blobs by id, and `usernames` resolves the parties for the read-time getters.
+export interface TransactionPayload {
+	incoming: string[];
+	outgoing: string[];
+	blobs: Record<string, Readonly<Uint8Array>>;
+	usernames: Record<string, string>;
+}
+
+// Register each party so the getters resolve, then overlay each referenced blob.
+export function readTransactions(payload: TransactionPayload): Transactions {
+	for (const [ userId, username ] of Object.entries(payload.usernames)) {
+		userInfo.set(userId, { username });
+	}
+	const overlay = (ids: string[]) => ids.map(id => read(payload.blobs[id]!));
+	return { incoming: overlay(payload.incoming), outgoing: overlay(payload.outgoing) };
+}

--- a/packages/xxscreeps/mods/market/transaction.ts
+++ b/packages/xxscreeps/mods/market/transaction.ts
@@ -1,5 +1,6 @@
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { makeReaderAndWriter } from 'xxscreeps/engine/schema/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import { userInfo } from 'xxscreeps/game/index.js';
 import { resourceEnumFormat } from 'xxscreeps/mods/resource/resource.js';
 import { BufferObject, compose, declare, optional, struct, withOverlay } from 'xxscreeps/schema/index.js';
@@ -35,9 +36,29 @@ export class Transaction extends withOverlay(BufferObject, shape) {
 
 export const { read, write } = makeReaderAndWriter(format);
 
-export interface Transactions {
-	incoming: Transaction[];
-	outgoing: Transaction[];
+export class Transactions {
+	readonly payload;
+
+	constructor(payload: TransactionPayload) {
+		this.payload = payload;
+	}
+
+	@cached get incoming(): Transaction[] {
+		return this.overlay(this.payload.incoming);
+	}
+
+	@cached get outgoing(): Transaction[] {
+		return this.overlay(this.payload.outgoing);
+	}
+
+	private overlay(ids: string[]) {
+		return Fn.pipe(
+			ids,
+			$$ => Fn.map($$, id => this.payload.blobs[id]),
+			$$ => Fn.filter($$),
+			$$ => Fn.map($$, read),
+			$$ => [ ...$$ ]);
+	}
 }
 
 // Per-tick payload: each direction lists transaction ids newest-first and `blobs` holds the
@@ -47,9 +68,4 @@ export interface TransactionPayload {
 	incoming: string[];
 	outgoing: string[];
 	blobs: Record<string, Readonly<Uint8Array>>;
-}
-
-export function readTransactions(payload: TransactionPayload): Transactions {
-	const overlay = (ids: string[]) => ids.map(id => read(payload.blobs[id]!));
-	return { incoming: overlay(payload.incoming), outgoing: overlay(payload.outgoing) };
 }

--- a/packages/xxscreeps/test/context.ts
+++ b/packages/xxscreeps/test/context.ts
@@ -8,7 +8,10 @@ type Context = {
 	tests: Callback[];
 };
 const makeFrame = (name?: string) => ({ name, children: [], tests: [] });
-const { argv } = checkArguments({ argv: true });
+const { argv, 'test-redis': testRedis } = checkArguments({
+	argv: true,
+	boolean: [ 'test-redis' ],
+});
 const checkFilter = (name: string) => {
 	if (argv.length) {
 		const index = stack.filter(name => Boolean(name)).length;
@@ -23,6 +26,7 @@ const stack: Context[] = [];
 let passed = 0;
 let failed = 0;
 const testTimeout = 10000;
+export { testRedis };
 
 // Catch unhandled rejections so async failures don't vanish silently
 process.on('unhandledRejection', reason => {

--- a/packages/xxscreeps/test/import.ts
+++ b/packages/xxscreeps/test/import.ts
@@ -14,6 +14,7 @@ import { StructureController } from 'xxscreeps/mods/controller/controller.js';
 import { Mineral } from 'xxscreeps/mods/mineral/mineral.js';
 import { Source } from 'xxscreeps/mods/source/source.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
+import { testRedis } from './context.js';
 
 // Read file
 const root = new URL('../../test/', import.meta.url);
@@ -104,16 +105,33 @@ const users = {
 export async function instantiateTestShard() {
 	// Create fake database
 	await using disposable = new AsyncDisposableStack();
-	const db = disposable.use(await Database.connect({
-		data: 'local://data',
-		pubsub: 'local://pubsub',
-	}));
-	const shard = disposable.use(await Shard.connectWith(db, {
-		name: 'shard0',
-		data: 'local://keyval',
-		pubsub: 'local://pubsub',
-		scratch: 'local://scratch',
-	}));
+	const { db, shard } = await async function() {
+		if (testRedis) {
+			const db = disposable.use(await Database.connect({
+				data: 'redis://localhost/7',
+				pubsub: 'redis://localhost/7',
+			}));
+			const shard = disposable.use(await Shard.connectWith(db, {
+				name: 'shard0',
+				data: 'redis://localhost/8',
+				pubsub: 'redis://localhost/8',
+				scratch: 'redis://localhost/9',
+			}));
+			return { db, shard };
+		} else {
+			const db = disposable.use(await Database.connect({
+				data: 'local://data',
+				pubsub: 'local://pubsub',
+			}));
+			const shard = disposable.use(await Shard.connectWith(db, {
+				name: 'shard0',
+				data: 'local://keyval',
+				pubsub: 'local://pubsub',
+				scratch: 'local://scratch',
+			}));
+			return { db, shard };
+		}
+	}();
 
 	// Reset all stores so shared `local://` singletons start clean
 	await Promise.all([

--- a/packages/xxscreeps/utility/utility.ts
+++ b/packages/xxscreeps/utility/utility.ts
@@ -196,6 +196,15 @@ export function hackyIterableToArray<Type>(value: Iterable<Type>): asserts value
 	return value as never;
 }
 
+export function deterministicClockForTesting() {
+	const disposable = new DisposableStack();
+	const { now } = Date;
+	disposable.defer(() => Date.now = now);
+	let ts = now();
+	Date.now = () => ts++;
+	return disposable;
+}
+
 export function deterministicRandomForTesting(seed = 1) {
 	const disposable = new DisposableStack();
 	const { random } = Math;


### PR DESCRIPTION
`Game.market.incomingTransactions` / `outgoingTransactions` were stubbed to `[]`, though `StructureTerminal.send`'s docs already promise both parties can track transfers. Each `send` now records a transfer both parties can read back.

A transfer is stored once as an immutable schema blob in its own namespace (`market/transaction/<id>`); each party's per-direction list holds references (ids), and the runner caches blobs by transaction id so both parties' runtimes are handed the same `SharedArrayBuffer`. The blob keeps the parties as user ids (resolved to usernames at read time) and the description raw (HTML-escaped by its getter, the way `creep.saying` is hidden). Each list returns the last 24 hours or 100 transfers, whichever is fewer; a reference count frees a blob once both parties have evicted it. Deal transactions wait for the order book.

Reworked from the first pass per review: schema blobs in their own namespace referenced by id, shared unparsed buffers cached by transaction id, getter-side description hiding and escaping, user-id (not username) storage, no escaped HTML in the database, and a 24h/100 bound instead of a permanent 100.

## Validation
- `npx xxscreeps test --private-transform=isolated-vm` — the engine suite passes under the CI transform. New `Market transactions` cases assert the shared blob (raw description + stored user ids), the 24h read window, and a self-send round-tripping the processor → driver → runtime read path with resolved usernames and an escaped description; the existing `Market › send` cooldown cases still hold.
- Rebased onto `main` to pick up #280's terminal send cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
