### PR TITLE
engine: keep local worker ports open after connect

### DIFF
--- a/.changeset/local-worker-port-close.md
+++ b/.changeset/local-worker-port-close.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix local single-host worker ports closing immediately after connect.

--- a/packages/xxscreeps/engine/db/storage/local/port.ts
+++ b/packages/xxscreeps/engine/db/storage/local/port.ts
@@ -410,7 +410,8 @@ export async function makeWorkerPortConnection<Send, Receive>(name: string): Pro
 		name,
 		port: port2,
 	} satisfies WorkerConnectMessage, [ port2 ]);
-	await using shift = await Fn.shiftAsync(messagePortToIterable<Receive[] | WorkerConnectedMessage>(port1));
+	// `rest` is handed to the caller and must outlive this scope; auto-disposing closes `port1`.
+	const shift = await Fn.shiftAsync(messagePortToIterable<Receive[] | WorkerConnectedMessage>(port1));
 	const messages = function() {
 		if (shift.head) {
 			const message = shift.head as WorkerConnectedMessage | UnknownMessage;
@@ -429,6 +430,7 @@ export async function makeWorkerPortConnection<Send, Receive>(name: string): Pro
 			send: batchMessagePortSend(port1),
 		};
 	} else {
+		await shift[Symbol.asyncDispose]();
 		throw new Error(`Failed to connect to worker port ${name}.`);
 	}
 }


### PR DESCRIPTION
Any server using the default `local://` (single-host) storage providers fails to boot since `d06e1d3c`: the processor worker hangs on its first request and exits with code 13.

`makeWorkerPortConnection` hands `shift.rest` back to the caller as the connection's live message stream. `d06e1d3c` changed its `shiftAsync` handle to `await using`, but `shiftAsync`'s disposer closes the underlying iterator — and thus `port1` — when `rest` was never iterated, and `Fn.concatAsync` reads `rest` only lazily on the consumer's first pull. So the `await using` fired at function return with the stream still un-iterated, severing every worker→host port right after the connect handshake. The next real request (a pubsub `subscribe`) never gets its `ack`, the worker's event loop drains, and it exits 13 (unsettled top-level await). Redis is unaffected — it never goes through `makeWorkerPortConnection`.

Reverted that handle to `const shift` so ownership of `rest` transfers to the returned port, and dispose explicitly on the failure path (the pre-`d06e1d3c` code leaked there). The `shiftAsync` disposal contract itself is correct — its other two callers (`firstAsync` discards `rest`, `foldAsync` consumes it in-scope) are unaffected; this is the only site that hands `rest` to an owner outside the scope, where a scoped `await using` is wrong by construction.

## Validation

Reproduced with `xxscreeps start` on the default `local://` config: the processor worker stalled on its first `channel/game` subscribe and exited 13, taking the engine down. With the fix the `subscribe`→`ack` round-trip and keyval reads complete and the worker advances past connect into world init.
