### PR TITLE
backend: add version hook for amending /api/version serverData

### DIFF
--- a/.changeset/version-serverdata-hook.md
+++ b/.changeset/version-serverdata-hook.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add a `version` backend hook so mods can amend the `serverData` bag advertised at `/api/version`. Register a handler to contribute fields the client needs at connect time, e.g. `hooks.register('version', serverData => { serverData.myFeature = 1; })`, instead of patching the response via koa middleware.

--- a/packages/xxscreeps/backend/endpoints/version.ts
+++ b/packages/xxscreeps/backend/endpoints/version.ts
@@ -1,28 +1,35 @@
 import type { Endpoint } from 'xxscreeps/backend/index.js';
+import { hooks } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
+
+// Lets mods amend the `serverData` bag advertised at `/api/version`, e.g. to
+// publish feature flags or settings the client needs at connect time.
+const decorateServerData = hooks.makeIterated('version');
 
 export const VersionEndpoint: Endpoint = {
 	path: '/api/version',
 
 	execute() {
+		const serverData: Record<string, unknown> = {
+			features: [
+				{ name: 'auth', version: 1 },
+				{ name: 'official-like', version: 1 },
+			],
+			customObjectTypes: {},
+			renderer: {
+				resources: {},
+				metadata: {},
+			},
+			shards: config.shards.map(shard => shard.name),
+		};
+		decorateServerData(serverData);
 		return {
 			ok: 1,
 			protocol: 14,
 			package: 160,
 			useNativeAuth: false,
 			users: 1,
-			serverData: {
-				features: [
-					{ name: 'auth', version: 1 },
-					{ name: 'official-like', version: 1 },
-				],
-				customObjectTypes: {},
-				renderer: {
-					resources: {},
-					metadata: {},
-				},
-				shards: config.shards.map(shard => shard.name),
-			},
+			serverData,
 			packageVersion: 'xxscreeps',
 		};
 	},

--- a/packages/xxscreeps/backend/symbols.ts
+++ b/packages/xxscreeps/backend/symbols.ts
@@ -16,6 +16,7 @@ export const hooks = makeHookRegistration<{
 	roomSocket: (shard: Shard, userId: string | undefined, roomName: string) =>
 		AsyncEffectAndResult<((time: number) => MaybePromise<object>) | undefined>;
 	sendUserInfo: (db: Database, userId: string, userInfo: Record<string, unknown>, privateSelf: boolean) => Promise<void>;
+	version: (serverData: Record<string, unknown>) => void;
 	route: Endpoint;
 	subscription: SubscriptionEndpoint;
 }>();


### PR DESCRIPTION
Hi,

I'm currently working on a room-history mod and it needs to add the historyChunkSize to the serverData dictionary in the version endpoint. I think it makes sense to have a hook for that so mods can easily add data.

Thanks ;)

Mods currently have to patch the /api/version response via koa middleware ordered before router.routes(). Add a dedicated `version` hook, mirroring the existing `sendUserInfo` pattern, so mods can amend the serverData bag directly with `hooks.register('version', serverData => { ... })`.