### PR TITLE
notifications: add /api/user/notify-prefs endpoint and expose prefs on /api/auth/me

### DIFF
--- a/packages/xxscreeps/backend/index.ts
+++ b/packages/xxscreeps/backend/index.ts
@@ -69,6 +69,9 @@ declare module 'xxscreeps/game/object.js' {
 // Note: `ajv` doesn't properly support `undefined`....
 // https://github.com/ajv-validator/ajv/issues/2040
 const ajv = new Ajv();
+// Separate instance for routes that opt into `coerceTypes` (e.g. the official client sends numeric
+// fields as strings). `coerceTypes` is an Ajv constructor option, so it can't be set per-schema.
+const coercingAjv = new Ajv({ coerceTypes: true });
 
 // Backend render hooks
 export function bindRenderer<Type extends RoomObject>(
@@ -93,8 +96,11 @@ export function bindTerrainRenderer<Type extends RoomObject>(object: Implementat
 export function makeValidatedPayloadRoute<Body>(
 	schema: JSONSchemaType<Body>,
 	execute: ValidatedExecuteRoute<ValidatedPayloadRequest<Body>>,
+	options?: { coerceTypes?: boolean },
 ): ExecuteRoute {
-	const validate = ajv.compile(schema);
+	// When `coerceTypes` is set the compiled validator mutates the body in place (e.g. "180" → 180),
+	// so `execute` sees the coerced values.
+	const validate = (options?.coerceTypes ? coercingAjv : ajv).compile(schema);
 	return context => {
 		if (validate(context.request.body)) {
 			return execute(context as RouterContext<State, ValidatedRequestContext<ValidatedPayloadRequest<Body>>>);

--- a/packages/xxscreeps/mods/controller/test.ts
+++ b/packages/xxscreeps/mods/controller/test.ts
@@ -454,7 +454,7 @@ describe('Controller', () => {
 			() => aboutToDowngrade(async ({ tick, poke, shard }) => {
 				using stdout = captureConsoleLog();
 				// Drop the per-user throttle so the re-armed warning delivers alongside the downgrade.
-				await setNotifyPrefs(shard, '100', { interval: 0 });
+				await setNotifyPrefs(shard.db, '100', { interval: 0 });
 				await tick();
 				// Re-arm: place downgradeTime back on the warn boundary for the next processed tick (Game.time = 2).
 				await poke('W3N3', undefined, (_Game, room) => {

--- a/packages/xxscreeps/mods/notifications/backend.ts
+++ b/packages/xxscreeps/mods/notifications/backend.ts
@@ -1,7 +1,6 @@
-import type { JSONSchemaType } from 'ajv';
 import type { NotifyPrefs } from './prefs.js';
-import { Ajv } from 'ajv';
-import { hooks } from 'xxscreeps/backend/index.js';
+import type { JSONSchemaType } from 'ajv';
+import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { getNotifyPrefs, setNotifyPrefs } from './prefs.js';
 
 // Mirrors the allowed values from the original screeps-server `/api/user/notify-prefs` handler.
@@ -18,9 +17,8 @@ interface NotifyPrefsRequest {
 }
 
 // Note: unlike vanilla (which coerces booleans with `!!`, so "false" becomes true), these are
-// validated as real JSON booleans. coerceTypes handles numeric fields sent as strings (e.g. the
+// validated as real JSON booleans. `coerceTypes` handles numeric fields sent as strings (e.g. the
 // official client sends interval as "180" rather than 180).
-const ajv = new Ajv({ coerceTypes: true });
 const notifyPrefsRequestSchema: JSONSchemaType<NotifyPrefsRequest> = {
 	type: 'object',
 	properties: {
@@ -32,22 +30,17 @@ const notifyPrefsRequestSchema: JSONSchemaType<NotifyPrefsRequest> = {
 	},
 	additionalProperties: false,
 };
-const validatePrefsRequest = ajv.compile(notifyPrefsRequestSchema);
 
 hooks.register('route', {
 	path: '/api/user/notify-prefs',
 	method: 'post',
 
-	execute: async context => {
+	execute: makeValidatedPayloadRoute(notifyPrefsRequestSchema, async context => {
 		const { userId } = context.state;
 		if (userId == null) {
 			return;
 		}
-		// validatePrefsRequest mutates in place when coercing (e.g. "180" → 180).
-		if (!validatePrefsRequest(context.request.body)) {
-			return { error: 'invalid' };
-		}
-		const body = context.request.body as NotifyPrefsRequest;
+		const body = context.request.body;
 		const prefs: Partial<NotifyPrefs> = {};
 		if (body.disabled != null) {
 			prefs.disabled = body.disabled;
@@ -67,7 +60,7 @@ hooks.register('route', {
 		}
 		await setNotifyPrefs(context.db, userId, prefs);
 		return { ok: 1 };
-	},
+	}, { coerceTypes: true }),
 });
 
 // Surface the user's own notification prefs on `/api/auth/me` so the account UI can render the

--- a/packages/xxscreeps/mods/notifications/backend.ts
+++ b/packages/xxscreeps/mods/notifications/backend.ts
@@ -1,0 +1,73 @@
+import type { JSONSchemaType } from 'ajv';
+import type { NotifyPrefs } from './prefs.js';
+import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { getNotifyPrefs, setNotifyPrefs } from './prefs.js';
+
+// Mirrors the allowed values from the original screeps-server `/api/user/notify-prefs` handler.
+// Out-of-range values are silently ignored rather than rejected, matching vanilla behavior.
+const kIntervalValues = new Set([ 5, 10, 30, 60, 180, 360, 720, 1440, 4320 ]);
+const kErrorsIntervalValues = new Set([ 0, 5, 10, 30, 60, 180, 360, 720, 1440, 4320, 100000 ]);
+
+interface NotifyPrefsRequest {
+	disabled?: boolean | null;
+	disabledOnMessages?: boolean | null;
+	sendOnline?: boolean | null;
+	interval?: number | null;
+	errorsInterval?: number | null;
+}
+
+// Note: unlike vanilla (which coerces with `!!`, so a string "false" becomes true), these are
+// validated as real JSON booleans. A client sending strings will get `{ error: 'invalid' }`.
+const notifyPrefsRequestSchema: JSONSchemaType<NotifyPrefsRequest> = {
+	type: 'object',
+	properties: {
+		disabled: { type: 'boolean', nullable: true },
+		disabledOnMessages: { type: 'boolean', nullable: true },
+		sendOnline: { type: 'boolean', nullable: true },
+		interval: { type: 'number', nullable: true },
+		errorsInterval: { type: 'number', nullable: true },
+	},
+	additionalProperties: false,
+};
+
+hooks.register('route', {
+	path: '/api/user/notify-prefs',
+	method: 'post',
+
+	execute: makeValidatedPayloadRoute(notifyPrefsRequestSchema, async context => {
+		const { userId } = context.state;
+		if (userId == null) {
+			return;
+		}
+
+		const body = context.request.body;
+		const prefs: Partial<NotifyPrefs> = {};
+		if (body.disabled != null) {
+			prefs.disabled = body.disabled;
+		}
+		if (body.disabledOnMessages != null) {
+			prefs.disabledOnMessages = body.disabledOnMessages;
+		}
+		if (body.sendOnline != null) {
+			prefs.sendOnline = body.sendOnline;
+		}
+		// Invalid interval values are silently ignored, as in the original server.
+		if (body.interval != null && kIntervalValues.has(body.interval)) {
+			prefs.interval = body.interval;
+		}
+		if (body.errorsInterval != null && kErrorsIntervalValues.has(body.errorsInterval)) {
+			prefs.errorsInterval = body.errorsInterval;
+		}
+
+		await setNotifyPrefs(context.db, userId, prefs);
+		return { ok: 1 };
+	}),
+});
+
+// Surface the user's own notification prefs on `/api/auth/me` so the account UI can render the
+// current toggle/interval state. The client reads `Me.notifyPrefs.*` to decide what to flip.
+hooks.register('sendUserInfo', async (db, userId, userInfo, privateSelf) => {
+	if (privateSelf) {
+		userInfo.notifyPrefs = await getNotifyPrefs(db, userId);
+	}
+});

--- a/packages/xxscreeps/mods/notifications/backend.ts
+++ b/packages/xxscreeps/mods/notifications/backend.ts
@@ -1,6 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
 import type { NotifyPrefs } from './prefs.js';
-import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { Ajv } from 'ajv';
+import { hooks } from 'xxscreeps/backend/index.js';
 import { getNotifyPrefs, setNotifyPrefs } from './prefs.js';
 
 // Mirrors the allowed values from the original screeps-server `/api/user/notify-prefs` handler.
@@ -16,8 +17,10 @@ interface NotifyPrefsRequest {
 	errorsInterval?: number | null;
 }
 
-// Note: unlike vanilla (which coerces with `!!`, so a string "false" becomes true), these are
-// validated as real JSON booleans. A client sending strings will get `{ error: 'invalid' }`.
+// Note: unlike vanilla (which coerces booleans with `!!`, so "false" becomes true), these are
+// validated as real JSON booleans. coerceTypes handles numeric fields sent as strings (e.g. the
+// official client sends interval as "180" rather than 180).
+const ajv = new Ajv({ coerceTypes: true });
 const notifyPrefsRequestSchema: JSONSchemaType<NotifyPrefsRequest> = {
 	type: 'object',
 	properties: {
@@ -29,18 +32,22 @@ const notifyPrefsRequestSchema: JSONSchemaType<NotifyPrefsRequest> = {
 	},
 	additionalProperties: false,
 };
+const validatePrefsRequest = ajv.compile(notifyPrefsRequestSchema);
 
 hooks.register('route', {
 	path: '/api/user/notify-prefs',
 	method: 'post',
 
-	execute: makeValidatedPayloadRoute(notifyPrefsRequestSchema, async context => {
+	execute: async context => {
 		const { userId } = context.state;
 		if (userId == null) {
 			return;
 		}
-
-		const body = context.request.body;
+		// validatePrefsRequest mutates in place when coercing (e.g. "180" → 180).
+		if (!validatePrefsRequest(context.request.body)) {
+			return { error: 'invalid' };
+		}
+		const body = context.request.body as NotifyPrefsRequest;
 		const prefs: Partial<NotifyPrefs> = {};
 		if (body.disabled != null) {
 			prefs.disabled = body.disabled;
@@ -58,10 +65,9 @@ hooks.register('route', {
 		if (body.errorsInterval != null && kErrorsIntervalValues.has(body.errorsInterval)) {
 			prefs.errorsInterval = body.errorsInterval;
 		}
-
 		await setNotifyPrefs(context.db, userId, prefs);
 		return { ok: 1 };
-	}),
+	},
 });
 
 // Surface the user's own notification prefs on `/api/auth/me` so the account UI can render the

--- a/packages/xxscreeps/mods/notifications/index.ts
+++ b/packages/xxscreeps/mods/notifications/index.ts
@@ -2,5 +2,5 @@ import type { Manifest } from 'xxscreeps/config/mods.js';
 
 export const manifest: Manifest = {
 	dependencies: [ 'xxscreeps/mods/creep', 'xxscreeps/mods/structure' ],
-	provides: [ 'driver', 'game', 'main', 'processor', 'test' ],
+	provides: [ 'backend', 'driver', 'game', 'main', 'processor', 'test' ],
 };

--- a/packages/xxscreeps/mods/notifications/main.ts
+++ b/packages/xxscreeps/mods/notifications/main.ts
@@ -8,7 +8,7 @@ import './transport-stdout.js';
 
 async function drainUser(shard: Shard, userId: string) {
 	const [ prefs, lastNotifyDate ] = await Promise.all([
-		getNotifyPrefs(shard, userId),
+		getNotifyPrefs(shard.db, userId),
 		getLastNotifyDate(shard, userId),
 	]);
 	if (prefs.disabled) {

--- a/packages/xxscreeps/mods/notifications/prefs.ts
+++ b/packages/xxscreeps/mods/notifications/prefs.ts
@@ -1,4 +1,4 @@
-import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { Database, Shard } from 'xxscreeps/engine/db/index.js';
 
 export interface NotifyPrefs {
 	disabled: boolean;
@@ -13,7 +13,10 @@ const lastNotifyDateKey = (userId: string) => `user/${userId}/notifications/last
 
 export const DEFAULT_INTERVAL_MIN = 60;
 
-export async function getNotifyPrefs(shard: Shard, userId: string): Promise<NotifyPrefs> {
+// Prefs are a global, user-level setting (matching the original server's `db.users.notifyPrefs`),
+// so they live in the shared `db.data` store rather than per-shard. This lets `/api/auth/me`
+// surface them to the client via the `sendUserInfo` hook in ./backend.ts.
+export async function getNotifyPrefs(db: Database, userId: string): Promise<NotifyPrefs> {
 	interface PrefsFields {
 		disabled?: string;
 		disabledOnMessages?: string;
@@ -21,7 +24,7 @@ export async function getNotifyPrefs(shard: Shard, userId: string): Promise<Noti
 		interval?: string;
 		errorsInterval?: string;
 	}
-	const fields = await shard.data.hGetAll(prefsKey(userId)) as PrefsFields;
+	const fields = await db.data.hGetAll(prefsKey(userId)) as PrefsFields;
 	return {
 		disabled: fields.disabled === '1',
 		disabledOnMessages: fields.disabledOnMessages === '1',
@@ -31,7 +34,7 @@ export async function getNotifyPrefs(shard: Shard, userId: string): Promise<Noti
 	};
 }
 
-export async function setNotifyPrefs(shard: Shard, userId: string, prefs: Partial<NotifyPrefs>) {
+export async function setNotifyPrefs(db: Database, userId: string, prefs: Partial<NotifyPrefs>) {
 	const fields: Record<string, string> = {};
 	if (prefs.disabled !== undefined) fields.disabled = prefs.disabled ? '1' : '0';
 	if (prefs.disabledOnMessages !== undefined) fields.disabledOnMessages = prefs.disabledOnMessages ? '1' : '0';
@@ -39,7 +42,7 @@ export async function setNotifyPrefs(shard: Shard, userId: string, prefs: Partia
 	if (prefs.interval !== undefined) fields.interval = String(prefs.interval);
 	if (prefs.errorsInterval !== undefined) fields.errorsInterval = String(prefs.errorsInterval);
 	if (Object.keys(fields).length > 0) {
-		await shard.data.hmset(prefsKey(userId), fields);
+		await db.data.hmset(prefsKey(userId), fields);
 	}
 }
 

--- a/packages/xxscreeps/mods/notifications/test.ts
+++ b/packages/xxscreeps/mods/notifications/test.ts
@@ -223,7 +223,7 @@ describe('Notification delivery worker', () => {
 	test('respects notifyPrefs.disabled (drops without emit)', () => empty(async ({ shard, tick }) => {
 		using _clock = withFakeNow(baseTime);
 		using stdout = captureConsoleLog();
-		await setNotifyPrefs(shard, userA, { disabled: true });
+		await setNotifyPrefs(shard.db, userA, { disabled: true });
 		await seedRow(shard, userA, 'hi');
 		await tick(10);
 		assert.strictEqual(parseNotifyLines(stdout.lines).length, 0, 'disabled user → no emit');
@@ -268,7 +268,7 @@ describe('Notification delivery worker', () => {
 		using clock = withFakeNow(baseTime);
 		using stdout = captureConsoleLog();
 		// Disable the per-user throttle so delivery depends only on each row's group deadline.
-		await setNotifyPrefs(shard, userA, { interval: 0 });
+		await setNotifyPrefs(shard.db, userA, { interval: 0 });
 		// 60-minute group → due at the next 60-minute boundary.
 		await upsertNotification(shard, userA, 'msg', 'long', 60);
 		// 1-minute group (smallest non-zero `groupInterval`) → due at the next 1-minute boundary.


### PR DESCRIPTION
Add /api/user/notify-prefs endpoint and surface prefs on /api/auth/me

@misterwise  maybe you can also check since I think that code is from you .)

## Summary

The notifications mod already had the storage helpers and the runtime worker for notification preferences, but there was no API surface for them, so the official Angular client's account screen couldn't read or change notification settings. This PR wires that up to match the original screeps-server behavior.

### What's added

#### 1. POST /api/user/notify-prefs (new mods/notifications/backend.ts)

Mirrors the original server's handler:
- Auth-gated on the logged-in user.
- Validates the JSON body and maps disabled / disabledOnMessages / sendOnline (booleans) and interval / errorsInterval (numbers).
- interval / errorsInterval are checked against the original's allowed value sets (5,10,30,60,180,360,720,1440,4320 and 0,…,100000); out-of-range values are silently ignored, as in vanilla.
- Persists via setNotifyPrefs and returns { ok: 1 }.

▎ Note: the Angular client ignores the response body (it just re-fetches the user via /api/auth/me on success), so the return shape doesn't need to echo the original's raw DB-update result.

#### 2. Prefs surfaced on /api/auth/me (a sendUserInfo hook)

The account UI computes each toggle from Me.notifyPrefs.* (e.g. it posts { disabled: !Me.notifyPrefs.disabled }). Nothing populated notifyPrefs on the me payload, so the toggles read undefined → always-falsy and couldn't reflect or correctly flip saved state. The new hook adds userInfo.notifyPrefs for the caller's own profile.

#### 3. Prefs moved from per-shard storage to the global DB

getNotifyPrefs / setNotifyPrefs now take a Database and read/write db.data instead of shard.data. Notification prefs are a user-level setting (like the original db.users.notifyPrefs), so they belong in the shared global store — not least because the sendUserInfo hook only receives a Database, and the global store and a shard's store are physically separate. The notification queue and throttle state stay in shard.data, since those are genuinely per-world runtime state.

Callers updated accordingly:
- main.ts notification worker → getNotifyPrefs(shard.db, …)
- tests in mods/notifications/test.ts and mods/controller/test.ts → setNotifyPrefs(shard.db, …)

Behavioral differences from the original (intentional)

- Booleans are validated as real JSON booleans rather than coerced with !!, so the original's "false" → true quirk doesn't carry over. The official client always sends real booleans/numbers, so this is compatible.