### PR TITLE
Add user/overview endpoint for the client overview page

### DIFF
--- a/.changeset/user-overview-endpoint.md
+++ b/.changeset/user-overview-endpoint.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add the `user/overview` endpoint so the client overview page renders room previews.

--- a/packages/xxscreeps/mods/controller/backend.ts
+++ b/packages/xxscreeps/mods/controller/backend.ts
@@ -75,6 +75,25 @@ hooks.register('route', {
 });
 
 hooks.register('route', {
+	path: '/api/user/overview',
+
+	async execute(context) {
+		const { userId } = context.state;
+		const { shard } = context;
+		const rooms = userId == null ? [] : await shard.scratch.sMembers(controlledRoomsKey(userId));
+		return {
+			ok: 1,
+			shards: {
+				[shard.name]: { rooms },
+			},
+			stats: {},
+			statsMax: {},
+			totals: {},
+		};
+	},
+});
+
+hooks.register('route', {
 	path: '/api/user/world-status',
 
 	async execute(context) {


### PR DESCRIPTION
The client's overview page (`#!/overview`) renders its room-previews grid from `GET /api/user/overview`, which xxscreeps didn't implement — the request 404s, the client loader swallows it (`.catch(() => [])`), and the whole rooms section disappears. This adds the endpoint next to `user/rooms` in the controller mod (same controlled-rooms data), returning the user's controlled rooms per shard so the grid renders. Stats are left empty, matching the official backend's TODO stub.

## Validation

- `tsc -b` and eslint clean.
- Verified live against the Steam client: without the route the overview rooms section is empty; with it the section renders the owned room's preview thumbnail (terrain PNG served from `/assets/map/<shard>/<room>.png`). Unauthenticated requests return 401 consistently with the sibling session routes `user/world-status` / `user/world-start-room`.
