### PR TITLE
power creep: validate account ops with shared intent checks

### DIFF
--- a/.changeset/power-creep-account-checks.md
+++ b/.changeset/power-creep-account-checks.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Move power creep account validation into shared result-code checks.

--- a/packages/xxscreeps/mods/powercreep/backend.ts
+++ b/packages/xxscreeps/mods/powercreep/backend.ts
@@ -2,26 +2,23 @@ import type { PowerCreep } from './powercreep.js';
 import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
 import * as Model from './model.js';
 
 // The official client drives the power-creep screen through these routes (`/api/game/power-creeps/*`).
-// Each mutates account keyspace directly — there is no global-intent stage and no room presence yet.
-// The model is the sole validator; a thrown rejection maps to `{ error }`, success to `{ ok: 1 }`.
+// The body schema validates shape; the model runs the shared `check*` and commits under compare-and-swap.
+// A non-OK result code maps to `{ error }`, success to `{ ok: 1 }`.
 function mutationRoute<Body>(
 	schema: JSONSchemaType<Body>,
-	run: (db: Database, userId: string, body: Body) => Promise<unknown>,
+	run: (db: Database, userId: string, body: Body) => Promise<C.ErrorCode>,
 ) {
 	return makeValidatedPayloadRoute(schema, async context => {
 		const { userId } = context.state;
 		if (userId == null) {
 			return { error: 'not logged in' };
 		}
-		try {
-			await run(context.db, userId, context.request.body);
-			return { ok: 1 };
-		} catch (err) {
-			return { error: err instanceof Error ? err.message : 'error' };
-		}
+		const code = await run(context.db, userId, context.request.body);
+		return code === C.OK ? { ok: 1 } : { error: 'invalid' };
 	});
 }
 

--- a/packages/xxscreeps/mods/powercreep/model.ts
+++ b/packages/xxscreeps/mods/powercreep/model.ts
@@ -3,24 +3,13 @@ import type { Database } from 'xxscreeps/engine/db/index.js';
 import { Channel } from 'xxscreeps/engine/db/channel.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
-import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { createPowerCreep, read, write } from './powercreep.js';
+import {
+	checkCreatePowerCreep, checkRenamePowerCreep, checkUpgradePowerCreep, createPowerCreep, read, write,
+} from './powercreep.js';
 
 // Account-scoped power creep roster.
 const powerCreepsKey = (userId: string) => `user/${userId}/powerCreeps`;
-
-interface PowerInfo {
-	className: string;
-	level: number[];
-}
-
-interface PowerEntry {
-	power: number;
-	level: number;
-}
-
-const powerInfoTable: Record<number, PowerInfo> = C.POWER_INFO;
 
 /** Channel the backend publishes to on every roster mutation; the runner refreshes when it fires. */
 export function getPowerCreepChannel(db: Database, userId: string) {
@@ -47,32 +36,29 @@ export function loadPowerCreepsBlob(db: Database, userId: string) {
 }
 
 // Apply `fn` to the live roster and commit it with a compare-and-swap, retrying if a concurrent
-// mutation slipped in between the read and the write. `fn` validates and throws on rejection, in
-// which case nothing is written.
-async function mutate<Type>(db: Database, userId: string, fn: (roster: PowerCreep[]) => Type | Promise<Type>) {
+// mutation slipped in between the read and the write. `fn` runs the shared check and returns its result
+// code; the roster is written only when the check passes.
+async function mutate(
+	db: Database, userId: string,
+	fn: (roster: PowerCreep[]) => C.ErrorCode | Promise<C.ErrorCode>,
+): Promise<C.ErrorCode> {
 	const key = powerCreepsKey(userId);
 	for (let attempt = 0; attempt <= 4; ++attempt) {
 		const prior = await db.data.get(key, { blob: true });
 		const roster = parseRoster(prior).filter(isLive);
-		const result = await fn(roster);
+		const code = await fn(roster);
+		if (code !== C.OK) {
+			return code;
+		}
 		const stored = await db.data.set(key, write(roster), {
 			if: prior == null ? { if: 'NX' } : { if: 'EQ', value: prior },
 		});
 		if (stored !== false) {
 			await getPowerCreepChannel(db, userId).publish({ type: 'updated' });
-			return result;
+			return C.OK;
 		}
 	}
 	throw new Error('Roster busy');
-}
-
-function gplLevel(power: number) {
-	return Math.floor((power / C.POWER_LEVEL_MULTIPLY) ** (1 / C.POWER_LEVEL_POW));
-}
-
-function freeLevels(power: number, roster: PowerCreep[]) {
-	const used = roster.length + Fn.accumulate(roster, creep => creep.level);
-	return gplLevel(power) - used;
 }
 
 async function userPower(db: Database, userId: string) {
@@ -81,133 +67,62 @@ async function userPower(db: Database, userId: string) {
 
 export function create(db: Database, userId: string, name: string, className: string) {
 	return mutate(db, userId, async roster => {
-		if (freeLevels(await userPower(db, userId), roster) <= 0) {
-			throw new Error('Not enough power level');
+		const code = checkCreatePowerCreep(await userPower(db, userId), roster, name, className);
+		if (code === C.OK) {
+			roster.push(createPowerCreep(Id.generateId(), name.slice(0, 50), className));
 		}
-		if (!Object.values(C.POWER_CLASS).includes(className)) {
-			throw new Error('Invalid class');
-		}
-		const truncated = String(name).slice(0, 50);
-		if (roster.some(creep => creep.name === truncated)) {
-			throw new Error('Name already exists');
-		}
-		const creep = createPowerCreep(Id.generateId(), truncated, className);
-		roster.push(creep);
-		return creep;
+		return code;
 	});
-}
-
-// Every requested level must be reachable by allocating one point at a time without ever exceeding a
-// power's per-rank level prerequisite.
-function powersAreReachable(powers: PowerEntry[]) {
-	const target = Fn.accumulate(powers, entry => entry.level);
-	const built = new Map(Fn.map(powers, entry => [ entry.power, 0 ]));
-	let level = 0;
-	while (level < target) {
-		const next = powers.find(({ power, level: want }) => {
-			const have = built.get(power) ?? 0;
-			const info = powerInfoTable[power];
-			return info && have < 5 && have < want && powerInfoTable[power]!.level[have]! <= level;
-		});
-		if (next === undefined) {
-			return false;
-		}
-		built.set(next.power, (built.get(next.power) ?? 0) + 1);
-		level = Fn.accumulate(built.values());
-	}
-	return true;
 }
 
 export function upgrade(db: Database, userId: string, id: string, powers: Record<string, number>) {
 	return mutate(db, userId, async roster => {
 		const creep = roster.find(entry => entry.id === id);
 		if (!creep) {
-			throw new Error('Invalid id');
+			return C.ERR_NOT_OWNER;
 		}
-		const levelOf = (power: number) => creep['#powers'].find(entry => entry.power === power)?.level ?? 0;
-		const desired: PowerEntry[] = [];
-		for (const [ key, value ] of Object.entries(powers)) {
-			const power = Number(key);
-			const info = powerInfoTable[power];
-			if (!info) {
-				throw new Error(`Invalid power ${key}`);
-			}
-			if (info.className !== creep.className) {
-				throw new Error(`Invalid class for power ${key}`);
-			}
-			if (value < levelOf(power)) {
-				throw new Error(`Cannot downgrade power ${key}`);
-			}
-			if (value > 5) {
-				throw new Error(`Invalid max value for power ${key}`);
-			}
-			if (value > 0) {
-				desired.push({ power, level: value });
-			}
+		const code = checkUpgradePowerCreep(await userPower(db, userId), roster, creep, powers);
+		if (code === C.OK) {
+			creep['#powers'] = Object.entries(powers)
+				.filter(([ , level ]) => level !== 0)
+				.map(([ power, level ]) => ({ power: Number(power), level }));
 		}
-		// A power already learned may not be dropped by omitting it from the request.
-		for (const { power, level } of creep['#powers']) {
-			if ((desired.find(entry => entry.power === power)?.level ?? 0) < level) {
-				throw new Error(`Cannot downgrade power ${power}`);
-			}
-		}
-		const newLevel = Fn.accumulate(desired, entry => entry.level);
-		if (newLevel > C.POWER_CREEP_MAX_LEVEL) {
-			throw new Error('Max level');
-		}
-		for (const { power, level } of desired) {
-			if (newLevel < powerInfoTable[power]!.level[level - 1]!) {
-				throw new Error(`Not enough level for power ${power}`);
-			}
-		}
-		if (!powersAreReachable(desired)) {
-			throw new Error('Powers set is not valid');
-		}
-		if (freeLevels(await userPower(db, userId), roster) < newLevel - creep.level) {
-			throw new Error('Not enough power level');
-		}
-		creep['#powers'] = desired;
-		return creep;
+		return code;
 	});
 }
 
-export function rename(db: Database, userId: string, id: unknown, name: unknown) {
+export function rename(db: Database, userId: string, id: string, name: string) {
 	return mutate(db, userId, roster => {
 		const creep = roster.find(entry => entry.id === id);
 		if (!creep) {
-			throw new Error('Invalid id');
+			return C.ERR_NOT_OWNER;
 		}
-		const truncated = String(name).slice(0, 50);
-		if (roster.some(entry => entry.name === truncated)) {
-			throw new Error('Name already exists');
+		const code = checkRenamePowerCreep(roster, name);
+		if (code === C.OK) {
+			creep.name = name.slice(0, 50);
 		}
-		creep.name = truncated;
-		return creep;
+		return code;
 	});
 }
 
-export function scheduleDelete(db: Database, userId: string, id: unknown) {
+// delete / cancel-delete are idempotent and never fail: a repeated delete keeps the original timer, a
+// cancel clears it, and an unknown id is a no-op.
+export function scheduleDelete(db: Database, userId: string, id: string) {
 	return mutate(db, userId, roster => {
 		const creep = roster.find(entry => entry.id === id);
-		if (!creep) {
-			throw new Error('Invalid id');
+		if (creep?.deleteTime === 0) {
+			creep.deleteTime = Date.now() + C.POWER_CREEP_DELETE_COOLDOWN;
 		}
-		if (creep.deleteTime !== 0) {
-			throw new Error('Already being deleted');
-		}
-		creep.deleteTime = Date.now() + C.POWER_CREEP_DELETE_COOLDOWN;
+		return C.OK;
 	});
 }
 
-export function cancelDelete(db: Database, userId: string, id: unknown) {
+export function cancelDelete(db: Database, userId: string, id: string) {
 	return mutate(db, userId, roster => {
 		const creep = roster.find(entry => entry.id === id);
-		if (!creep) {
-			throw new Error('Invalid id');
+		if (creep) {
+			creep.deleteTime = 0;
 		}
-		if (creep.deleteTime === 0) {
-			throw new Error('Not being deleted');
-		}
-		creep.deleteTime = 0;
+		return C.OK;
 	});
 }

--- a/packages/xxscreeps/mods/powercreep/model.ts
+++ b/packages/xxscreeps/mods/powercreep/model.ts
@@ -3,10 +3,9 @@ import type { Database } from 'xxscreeps/engine/db/index.js';
 import { Channel } from 'xxscreeps/engine/db/channel.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import {
-	checkCreatePowerCreep, checkRenamePowerCreep, checkUpgradePowerCreep, createPowerCreep, read, write,
-} from './powercreep.js';
+import {	checkCreatePowerCreep, checkRenamePowerCreep, checkUpgradePowerCreep, createPowerCreep, read, write } from './powercreep.js';
 
 // Account-scoped power creep roster.
 const powerCreepsKey = (userId: string) => `user/${userId}/powerCreeps`;
@@ -83,9 +82,11 @@ export function upgrade(db: Database, userId: string, id: string, powers: Record
 		}
 		const code = checkUpgradePowerCreep(await userPower(db, userId), roster, creep, powers);
 		if (code === C.OK) {
-			creep['#powers'] = Object.entries(powers)
-				.filter(([ , level ]) => level !== 0)
-				.map(([ power, level ]) => ({ power: Number(power), level }));
+			creep['#powers'] = Fn.pipe(
+				Object.entries(powers),
+				$$ => Fn.filter($$, ([ , level ]) => level !== 0),
+				$$ => Fn.map($$, ([ power, level ]) => ({ power: Number(power), level })),
+				$$ => [ ...$$ ]);
 		}
 		return code;
 	});

--- a/packages/xxscreeps/mods/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/powercreep/powercreep.ts
@@ -49,6 +49,115 @@ export function createPowerCreep(id: string, name: string, className: string) {
 	return creep;
 }
 
+// --- Account roster checks: pure functions of account power + roster + args, each returning a result
+// code. ---
+
+interface PowerInfo { className: string; level: number[] }
+interface PowerEntry { power: number; level: number }
+const powerInfoTable: Record<number, PowerInfo> = C.POWER_INFO;
+
+/** Global power level earned from accumulated power experience. */
+function gplLevel(power: number) {
+	return Math.floor((power / C.POWER_LEVEL_MULTIPLY) ** (1 / C.POWER_LEVEL_POW));
+}
+
+/** Unallocated GPL levels: earned levels minus one per creep and each creep's own level. */
+function freeLevels(power: number, roster: PowerCreep[]) {
+	const used = roster.length + Fn.accumulate(roster, creep => creep.level);
+	return gplLevel(power) - used;
+}
+
+// Every requested level must be reachable by allocating one point at a time without ever exceeding a
+// power's per-rank level prerequisite.
+function powersAreReachable(powers: PowerEntry[]) {
+	const target = Fn.accumulate(powers, entry => entry.level);
+	const built = new Map(Fn.map(powers, entry => [ entry.power, 0 ]));
+	let level = 0;
+	while (level < target) {
+		const next = powers.find(({ power, level: want }) => {
+			const have = built.get(power) ?? 0;
+			const info = powerInfoTable[power];
+			return info && have < 5 && have < want && info.level[have]! <= level;
+		});
+		if (next === undefined) {
+			return false;
+		}
+		built.set(next.power, (built.get(next.power) ?? 0) + 1);
+		level = Fn.accumulate(built.values());
+	}
+	return true;
+}
+
+export function checkCreatePowerCreep(accountPower: number, roster: PowerCreep[], name: string, className: string) {
+	if (name === '' || name.length > 100) {
+		return C.ERR_INVALID_ARGS;
+	}
+	if (freeLevels(accountPower, roster) <= 0) {
+		return C.ERR_NOT_ENOUGH_RESOURCES;
+	}
+	if (roster.some(creep => creep.name === name)) {
+		return C.ERR_NAME_EXISTS;
+	}
+	if (!Object.values(C.POWER_CLASS).includes(className)) {
+		return C.ERR_INVALID_ARGS;
+	}
+	return C.OK;
+}
+
+export function checkUpgradePowerCreep(
+	accountPower: number, roster: PowerCreep[], creep: PowerCreep, powers: Record<string, number>,
+) {
+	const levelOf = (power: number) => creep['#powers'].find(entry => entry.power === power)?.level ?? 0;
+	const desired: PowerEntry[] = [];
+	for (const [ key, value ] of Object.entries(powers)) {
+		const power = Number(key);
+		if (powerInfoTable[power]?.className !== creep.className) {
+			return C.ERR_INVALID_ARGS;
+		}
+		if (value < levelOf(power)) {
+			return C.ERR_INVALID_ARGS;
+		}
+		if (value > 5) {
+			return C.ERR_FULL;
+		}
+		if (value > 0) {
+			desired.push({ power, level: value });
+		}
+	}
+	// A power already learned may not be dropped by omitting it from the request.
+	for (const { power, level } of creep['#powers']) {
+		if ((desired.find(entry => entry.power === power)?.level ?? 0) < level) {
+			return C.ERR_INVALID_ARGS;
+		}
+	}
+	const newLevel = Fn.accumulate(desired, entry => entry.level);
+	if (newLevel > C.POWER_CREEP_MAX_LEVEL) {
+		return C.ERR_FULL;
+	}
+	for (const { power, level } of desired) {
+		if (newLevel < powerInfoTable[power]!.level[level - 1]!) {
+			return C.ERR_FULL;
+		}
+	}
+	if (!powersAreReachable(desired)) {
+		return C.ERR_FULL;
+	}
+	if (freeLevels(accountPower, roster) < newLevel - creep.level) {
+		return C.ERR_NOT_ENOUGH_RESOURCES;
+	}
+	return C.OK;
+}
+
+export function checkRenamePowerCreep(roster: PowerCreep[], name: string) {
+	if (name === '' || name.length > 100) {
+		return C.ERR_INVALID_ARGS;
+	}
+	if (roster.some(creep => creep.name === name)) {
+		return C.ERR_NAME_EXISTS;
+	}
+	return C.OK;
+}
+
 // The roster is stored as a single per-user blob: a vector of power creeps.
 const rosterFormat = declare('PowerCreeps', vector(format));
 export const { read, write } = makeReaderAndWriter(rosterFormat);

--- a/packages/xxscreeps/mods/powercreep/test.ts
+++ b/packages/xxscreeps/mods/powercreep/test.ts
@@ -15,27 +15,28 @@ describe('PowerCreep account', () => {
 
 	test('create is gated by free GPL levels', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 1000);
-		await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
 		assert.strictEqual((await Model.loadRoster(shard.db, owner)).length, 1);
-		await assert.rejects(Model.create(shard.db, owner, 'Bob', C.POWER_CLASS.OPERATOR), /power level/);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Bob', C.POWER_CLASS.OPERATOR), C.ERR_NOT_ENOUGH_RESOURCES);
 	}));
 
 	test('create with no GPL is rejected', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 0);
-		await assert.rejects(Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), /power level/);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.ERR_NOT_ENOUGH_RESOURCES);
 	}));
 
 	test('create rejects an invalid class and a duplicate name', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 4000);
-		await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await assert.rejects(Model.create(shard.db, owner, 'X', 'wizard'), /class/);
-		await assert.rejects(Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), /exists/);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		assert.strictEqual(await Model.create(shard.db, owner, 'X', 'wizard'), C.ERR_INVALID_ARGS);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.ERR_NAME_EXISTS);
 	}));
 
 	test('upgrade learns a power and raises the level', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 4000);
-		const creep = await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 1 });
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		const creep = (await Model.loadRoster(shard.db, owner))[0]!;
+		assert.strictEqual(await Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 1 }), C.OK);
 		const updated = (await Model.loadRoster(shard.db, owner))[0]!;
 		assert.strictEqual(updated.level, 1);
 		assert.strictEqual(updated.powers[C.PWR_GENERATE_OPS]!.level, 1);
@@ -45,43 +46,47 @@ describe('PowerCreep account', () => {
 		// gpl 3 leaves budget to spare, so the rejection is the reachability rule, not the GPL gate:
 		// reaching rank 2 of a power needs a total level >= 2 already allocated.
 		await setPower(shard.db, 9000);
-		const creep = await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await assert.rejects(Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 2 }), /not valid/);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		const creep = (await Model.loadRoster(shard.db, owner))[0]!;
+		assert.strictEqual(await Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 2 }), C.ERR_FULL);
 	}));
 
 	test('upgrade rejects when over the free-level budget', () => sim(async ({ shard }) => {
 		// gpl 1; the create consumed the only free level, so any upgrade is over budget.
 		await setPower(shard.db, 1000);
-		const creep = await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await assert.rejects(Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 1 }), /power level/);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		const creep = (await Model.loadRoster(shard.db, owner))[0]!;
+		assert.strictEqual(await Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 1 }), C.ERR_NOT_ENOUGH_RESOURCES);
 	}));
 
 	test('rename changes the name and rejects collisions', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 4000);
-		const alice = await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await Model.create(shard.db, owner, 'Bob', C.POWER_CLASS.OPERATOR);
-		await Model.rename(shard.db, owner, alice.id, 'Alice2');
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Bob', C.POWER_CLASS.OPERATOR), C.OK);
+		const alice = (await Model.loadRoster(shard.db, owner)).find(creep => creep.name === 'Alice')!;
+		assert.strictEqual(await Model.rename(shard.db, owner, alice.id, 'Alice2'), C.OK);
 		const names = (await Model.loadRoster(shard.db, owner)).map(creep => creep.name).sort();
 		assert.deepStrictEqual(names, [ 'Alice2', 'Bob' ]);
-		await assert.rejects(Model.rename(shard.db, owner, alice.id, 'Bob'), /exists/);
+		assert.strictEqual(await Model.rename(shard.db, owner, alice.id, 'Bob'), C.ERR_NAME_EXISTS);
 	}));
 
 	test('delete schedules a cooldown that cancel reverses', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 1000);
-		const creep = await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
-		await Model.scheduleDelete(shard.db, owner, creep.id);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
+		const creep = (await Model.loadRoster(shard.db, owner))[0]!;
+		assert.strictEqual(await Model.scheduleDelete(shard.db, owner, creep.id), C.OK);
 		const pending = (await Model.loadRoster(shard.db, owner))[0]!;
 		assert.ok(pending.deleteTime > Date.now());
-		await assert.rejects(Model.scheduleDelete(shard.db, owner, creep.id), /being deleted/);
-		await Model.cancelDelete(shard.db, owner, creep.id);
-		const restored = (await Model.loadRoster(shard.db, owner))[0]!;
-		assert.strictEqual(restored.deleteTime, 0);
-		await assert.rejects(Model.cancelDelete(shard.db, owner, creep.id), /Not being deleted/);
+		// A repeated delete keeps the original timer rather than resetting it.
+		assert.strictEqual(await Model.scheduleDelete(shard.db, owner, creep.id), C.OK);
+		assert.strictEqual((await Model.loadRoster(shard.db, owner))[0]!.deleteTime, pending.deleteTime);
+		assert.strictEqual(await Model.cancelDelete(shard.db, owner, creep.id), C.OK);
+		assert.strictEqual((await Model.loadRoster(shard.db, owner))[0]!.deleteTime, 0);
 	}));
 
 	test('the driver blob materializes an unspawned roster member', () => sim(async ({ shard }) => {
 		await setPower(shard.db, 4000);
-		await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
+		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
 		const blob = await Model.loadPowerCreepsBlob(shard.db, owner);
 		assert.ok(blob);
 		const [ view ] = read(blob);


### PR DESCRIPTION
I hadn't realized initially how much it was diverging. Trying to get the
"global intent" shape of vanilla right I think put things too far off. I think
this is a lot closer to the existing precedent.

Validation now lives in shared `check*` functions returning result codes (like
`checkCreateConstructionSite`); the backend maps a non-OK code to `{ error }`,
ajv owns request shape, and the `typeof`/`String()`/`Number()` coercion is gone.
`delete`/`cancel-delete` are idempotent with no conflict errors. The checks run
inside the roster's compare-and-swap writer, since there's no room or processor
to be the authoritative writer here.

Runtime `PowerCreep` methods stay unwired (needs a commit channel this build
lacks); the checks are shaped for it to reuse.

## Validation
- `mods/powercreep` unit tests: 455/455 (`PowerCreep account`: 11).
- `tsc -b` and `eslint --max-warnings 0` clean.
