### PR TITLE
Add spawned power creep room entity

### DIFF
--- a/.changeset/power-creep-entity.md
+++ b/.changeset/power-creep-entity.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Spawn power creeps into rooms with the shared creep carry verbs, aging, renew, and death.

--- a/packages/xxscreeps/mods/classic/creep/creep.ts
+++ b/packages/xxscreeps/mods/classic/creep/creep.ts
@@ -609,6 +609,31 @@ registerObstacleChecker(params => {
 
 //
 // Intent checks
+
+/**
+ * The shared carry/store verb surface. `Creep` and `PowerCreep` both satisfy it, so the
+ * transfer/withdraw/pickup/drop checks (and their processor arms) operate on this type rather than
+ * `Creep` — power creeps carry resources the same way but have no body or fatigue.
+ */
+export interface Carrier extends RoomObject {
+	my: boolean;
+	spawning?: boolean;
+	store: OpenStore;
+	'#user': string;
+}
+
+/** Room-presence preconditions every carry verb shares, with no body part involved. */
+export function checkCarrier(creep: Carrier) {
+	if (!creep.my) {
+		return C.ERR_NOT_OWNER;
+	} else if (creep.spawning) {
+		return C.ERR_BUSY;
+	} else if (!(creep.room as unknown)) {
+		return C.ERR_INVALID_ARGS;
+	}
+	return C.OK;
+}
+
 export function checkCommon(creep: Creep, part?: PartType) {
 	if (!creep.my) {
 		return C.ERR_NOT_OWNER;
@@ -626,9 +651,9 @@ function checkFatigue(creep: Creep) {
 	return creep.fatigue > 0 ? C.ERR_TIRED : C.OK;
 }
 
-export function checkDrop(creep: Creep, resourceType: ResourceType, amount: number) {
+export function checkDrop(creep: Carrier, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
-		() => checkCommon(creep),
+		() => checkCarrier(creep),
 		() => checkHasResource(creep, resourceType, amount));
 }
 
@@ -654,9 +679,9 @@ export function checkPull(creep: Creep, target: Creep | null | undefined) {
 		() => target!.spawning ? C.ERR_INVALID_TARGET : C.OK);
 }
 
-export function checkPickup(creep: Creep, target: Resource) {
+export function checkPickup(creep: Carrier, target: Resource) {
 	return chainIntentChecks(
-		() => checkCommon(creep),
+		() => checkCarrier(creep),
 		() => checkTarget(target, Resource),
 		() => creep.store.getFreeCapacity(target.resourceType) > 0
 			? C.OK : C.ERR_FULL,
@@ -671,9 +696,9 @@ function checkTransferTarget(target: RoomObject & WithStore, resourceType: Resou
 		() => checkStoreAccepts(target, resourceType));
 }
 
-export function checkTransfer(creep: Creep, target: RoomObject & WithStore, resourceType: ResourceType, amount: number) {
+export function checkTransfer(creep: Carrier, target: RoomObject & WithStore, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
-		() => checkCommon(creep),
+		() => checkCarrier(creep),
 		() => checkResourceArgs(resourceType, amount),
 		() => checkTransferTarget(target, resourceType),
 		() => checkRange(creep, target, 1),
@@ -687,9 +712,9 @@ export function checkTransfer(creep: Creep, target: RoomObject & WithStore, reso
 		});
 }
 
-export function checkWithdraw(creep: Creep, target: Structure & WithStore, resourceType: ResourceType, amount: number) {
+export function checkWithdraw(creep: Carrier, target: Structure & WithStore, resourceType: ResourceType, amount: number) {
 	return chainIntentChecks(
-		() => checkCommon(creep),
+		() => checkCarrier(creep),
 		() => checkResourceArgs(resourceType, amount),
 		() => checkTarget(target, Ruin, Structure, Tombstone),
 		() => checkInteractionBlocked(creep, target),
@@ -701,7 +726,7 @@ export function checkWithdraw(creep: Creep, target: Structure & WithStore, resou
 		() => checkHasResourceAmount(target, resourceType, amount));
 }
 
-function checkInteractionBlocked(creep: Creep, target: Structure & WithStore) {
+function checkInteractionBlocked(creep: Carrier, target: Structure & WithStore) {
 	const user = creep['#user'];
 	const blocked = target.room.lookForAt(C.LOOK_STRUCTURES, target.pos)
 		.some(structure => structure['#doesPreventInteraction'](user));

--- a/packages/xxscreeps/mods/classic/creep/creep.ts
+++ b/packages/xxscreeps/mods/classic/creep/creep.ts
@@ -611,9 +611,8 @@ registerObstacleChecker(params => {
 // Intent checks
 
 /**
- * The verb surface shared by `Creep` and `PowerCreep`: the carry/store verbs plus `say`. The shared
- * intent checks and processor arms operate on this type rather than `Creep` — power creeps act the
- * same way but have no body or fatigue.
+ * The verb surface shared by `Creep` and `PowerCreep`: the carry/store verbs plus `say`. Power
+ * creeps act the same way but have no body or fatigue.
  */
 export interface Carrier extends RoomObject {
 	my: boolean;
@@ -623,7 +622,6 @@ export interface Carrier extends RoomObject {
 	'#user': string;
 }
 
-/** Ownership and busy preconditions every carry verb shares, with no body part involved. */
 export function checkCarrier(creep: Carrier) {
 	if (!creep.my) {
 		return C.ERR_NOT_OWNER;

--- a/packages/xxscreeps/mods/classic/creep/creep.ts
+++ b/packages/xxscreeps/mods/classic/creep/creep.ts
@@ -632,16 +632,16 @@ export function checkCarrier(creep: Carrier) {
 }
 
 export function checkCommon(creep: Creep, part?: PartType) {
-	if (!creep.my) {
-		return C.ERR_NOT_OWNER;
-	} else if (creep.spawning) {
-		return C.ERR_BUSY;
-	} else if (part && creep.getActiveBodyparts(part) === 0) {
-		return C.ERR_NO_BODYPART;
-	} else if (!(creep.room as unknown)) {
-		return C.ERR_INVALID_ARGS;
-	}
-	return C.OK;
+	return chainIntentChecks(
+		() => checkCarrier(creep),
+		() => {
+			if (part && creep.getActiveBodyparts(part) === 0) {
+				return C.ERR_NO_BODYPART;
+			} else if (!(creep.room as unknown)) {
+				return C.ERR_INVALID_ARGS;
+			}
+		},
+	);
 }
 
 function checkFatigue(creep: Creep) {

--- a/packages/xxscreeps/mods/classic/creep/creep.ts
+++ b/packages/xxscreeps/mods/classic/creep/creep.ts
@@ -611,25 +611,24 @@ registerObstacleChecker(params => {
 // Intent checks
 
 /**
- * The shared carry/store verb surface. `Creep` and `PowerCreep` both satisfy it, so the
- * transfer/withdraw/pickup/drop checks (and their processor arms) operate on this type rather than
- * `Creep` — power creeps carry resources the same way but have no body or fatigue.
+ * The verb surface shared by `Creep` and `PowerCreep`: the carry/store verbs plus `say`. The shared
+ * intent checks and processor arms operate on this type rather than `Creep` — power creeps act the
+ * same way but have no body or fatigue.
  */
 export interface Carrier extends RoomObject {
 	my: boolean;
 	spawning?: boolean;
 	store: OpenStore;
+	'#saying': Creep['#saying'];
 	'#user': string;
 }
 
-/** Room-presence preconditions every carry verb shares, with no body part involved. */
+/** Ownership and busy preconditions every carry verb shares, with no body part involved. */
 export function checkCarrier(creep: Carrier) {
 	if (!creep.my) {
 		return C.ERR_NOT_OWNER;
 	} else if (creep.spawning) {
 		return C.ERR_BUSY;
-	} else if (!(creep.room as unknown)) {
-		return C.ERR_INVALID_ARGS;
 	}
 	return C.OK;
 }

--- a/packages/xxscreeps/mods/classic/creep/processor.ts
+++ b/packages/xxscreeps/mods/classic/creep/processor.ts
@@ -223,11 +223,7 @@ export function isHostileInSafeMode(mover: CreepLib.Carrier) {
 	return controller?.safeMode !== undefined && controller['#user'] !== mover['#user'];
 }
 
-/**
- * Complete a resolved move: relocate the mover, wear out any road at the destination, and stomp
- * hostile construction sites unless safe mode protects them. Returns the destination tile's base
- * fatigue.
- */
+/** Complete a resolved move; returns the destination tile's base fatigue. */
 export function commitMove(mover: CreepLib.Carrier, pos: RoomPosition, roadWearout: number) {
 	mover.room['#moveObject'](mover, pos);
 	const baseFatigue = (() => {
@@ -464,7 +460,7 @@ export function teleportCreep(creep: Teleportable & Parameters<typeof writeRoomO
 	const oldPos = creep.pos;
 	creep.pos = next;
 	creep.room = undefined as never;
-	// Creeps are revitalized when moving to a new room; power creeps have no fatigue
+	// Creeps are revitalized when moving to a new room
 	if (creep.fatigue !== undefined) {
 		creep.fatigue = 0;
 	}

--- a/packages/xxscreeps/mods/classic/creep/processor.ts
+++ b/packages/xxscreeps/mods/classic/creep/processor.ts
@@ -154,18 +154,118 @@ function recalculateBody(creep: Creep) {
 	dropOverflowResources(creep);
 }
 
+//
+// Intent processor arms shared with `PowerCreep`
+export function processDrop(creep: CreepLib.Carrier, context: ProcessorContext, resourceType: ResourceType, amount: number) {
+	if (CreepLib.checkDrop(creep, resourceType, amount) === C.OK) {
+		creep.store['#subtract'](resourceType, amount);
+		ResourceIntent.drop(creep.pos, resourceType, amount);
+		context.didUpdate();
+	}
+}
+
+export function processPickup(creep: CreepLib.Carrier, context: ProcessorContext, id: string) {
+	const resource = Game.getObjectById<Resource>(id)!;
+	if (CreepLib.checkPickup(creep, resource) === C.OK) {
+		const amount = Math.min(creep.store.getFreeCapacity(resource.resourceType), resource.amount);
+		creep.store['#add'](resource.resourceType, amount);
+		resource.amount -= amount;
+		context.didUpdate();
+	}
+}
+
+export function processSay(creep: CreepLib.Carrier, context: ProcessorContext, message: string, isPublic: boolean) {
+	if (CreepLib.checkCarrier(creep) === C.OK) {
+		creep['#saying'] = {
+			isPublic,
+			message: String(message).substring(0, 10),
+			time: Game.time,
+		};
+		context.didUpdate();
+	}
+}
+
+export function processTransfer(creep: CreepLib.Carrier, context: ProcessorContext, id: string, resourceType: ResourceType, amount: number) {
+	const target = Game.getObjectById<RoomObject & WithStore>(id)!;
+	if (CreepLib.checkTransfer(creep, target, resourceType, amount) === C.OK) {
+		creep.store['#subtract'](resourceType, amount);
+		target.store['#add'](resourceType, amount);
+		appendEventLog(creep.room, {
+			event: C.EVENT_TRANSFER,
+			objectId: creep.id,
+			targetId: target.id,
+			resourceType,
+			amount,
+		});
+		context.didUpdate();
+	}
+}
+
+export function processWithdraw(creep: CreepLib.Carrier, context: ProcessorContext, id: string, resourceType: ResourceType, amount: number) {
+	const target = Game.getObjectById<Structure & WithStore>(id)!;
+	if (CreepLib.checkWithdraw(creep, target, resourceType, amount) === C.OK) {
+		target.store['#subtract'](resourceType, amount);
+		creep.store['#add'](resourceType, amount);
+		appendEventLog(creep.room, {
+			event: C.EVENT_TRANSFER,
+			objectId: target.id,
+			targetId: creep.id,
+			resourceType,
+			amount,
+		});
+		context.didUpdate();
+	}
+}
+
+/** Safe mode suppresses hostile movement priority and construction-site stomping. */
+export function isHostileInSafeMode(mover: CreepLib.Carrier) {
+	const { controller } = mover.room;
+	return controller?.safeMode !== undefined && controller['#user'] !== mover['#user'];
+}
+
+/**
+ * Complete a resolved move: relocate the mover, wear out any road at the destination, and stomp
+ * hostile construction sites unless safe mode protects them. Returns the destination tile's base
+ * fatigue.
+ */
+export function commitMove(mover: CreepLib.Carrier, pos: RoomPosition, roadWearout: number) {
+	mover.room['#moveObject'](mover, pos);
+	const baseFatigue = (() => {
+		const road = lookForStructureAt(mover.room, pos, C.STRUCTURE_ROAD);
+		if (road) {
+			// Wear-out advances decay but must not slip past `Game.time` — the road's Tick handler
+			// throws on overdue `ticksToDecay`.
+			road['#nextDecayTime'] = Math.max(Game.time, road['#nextDecayTime'] - roadWearout);
+			return 1;
+		}
+		const terrain = mover.room.getTerrain().get(pos.x, pos.y);
+		if (terrain === C.TERRAIN_MASK_SWAMP) {
+			return 10;
+		} else {
+			return 2;
+		}
+	})();
+	if (!isHostileInSafeMode(mover)) {
+		for (const object of mover.room['#lookAt'](pos)) {
+			if (object['#lookType'] === 'constructionSite' && object['#user'] !== mover['#user']) {
+				const { progress } = object;
+				if (progress > 1) {
+					ResourceIntent.drop(pos, C.RESOURCE_ENERGY, Math.floor(progress / 2));
+				}
+				mover.room['#removeObject'](object);
+				break;
+			}
+		}
+	}
+	return baseFatigue;
+}
+
 declare module 'xxscreeps/engine/processor/index.js' {
 	interface Intent { creep: typeof intents }
 }
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
-	registerIntentProcessor(Creep, 'drop', { before: 'transfer' }, (creep, context, resourceType: ResourceType, amount: number) => {
-		if (CreepLib.checkDrop(creep, resourceType, amount) === C.OK) {
-			creep.store['#subtract'](resourceType, amount);
-			ResourceIntent.drop(creep.pos, resourceType, amount);
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(Creep, 'drop', { before: 'transfer' }, processDrop),
 
 	registerIntentProcessor(Creep, 'move', {}, (creep, context, param: Direction | string) => {
 		const target = typeof param === 'string' ? Game.getObjectById<Creep>(param) : param;
@@ -219,56 +319,11 @@ const intents = [
 
 				// Deduct priority from hostile creeps in safe mode
 				const basePriority = weight ? -weight / power : power;
-				const priority = basePriority + function() {
-					if (
-						creep.room.controller?.safeMode === undefined ||
-						creep.room.controller['#user'] === creep['#user']
-					) {
-						return 0;
-					} else {
-						return -500;
-					}
-				}();
+				const priority = basePriority + (isHostileInSafeMode(creep) ? -500 : 0);
 
 				// Dispatch movement request
 				return commit(priority, pos => {
-					// Move resolved successfully
-					creep.room['#moveObject'](creep, pos);
-
-					// Calculate base fatigue from plain/road/swamp
-					const baseFatigue = (() => {
-						const road = lookForStructureAt(creep.room, pos, C.STRUCTURE_ROAD);
-						if (road) {
-							// Wear-out advances decay but must not slip past `Game.time` — the road's
-							// Tick handler throws on overdue `ticksToDecay`.
-							road['#nextDecayTime'] =
-								Math.max(Game.time, road['#nextDecayTime'] - C.ROAD_WEAROUT * creep.body.length);
-							return 1;
-						}
-						const terrain = creep.room.getTerrain().get(pos.x, pos.y);
-						if (terrain === C.TERRAIN_MASK_SWAMP) {
-							return 10;
-						} else {
-							return 2;
-						}
-					})();
-
-					// Stomp hostile construction sites
-					if (
-						creep.room.controller?.safeMode === undefined ||
-						creep.room.controller['#user'] === creep['#user']
-					) {
-						for (const object of creep.room['#lookAt'](pos)) {
-							if (object['#lookType'] === 'constructionSite' && object['#user'] !== creep['#user']) {
-								const { progress } = object;
-								if (progress > 1) {
-									ResourceIntent.drop(pos, C.RESOURCE_ENERGY, Math.floor(progress / 2));
-								}
-								creep.room['#removeObject'](object);
-								break;
-							}
-						}
-					}
+					const baseFatigue = commitMove(creep, pos, C.ROAD_WEAROUT * creep.body.length);
 
 					// Add adjusted fatigue to first creep in chain
 					let receiver = creep;
@@ -282,15 +337,7 @@ const intents = [
 		}
 	}),
 
-	registerIntentProcessor(Creep, 'pickup', {}, (creep, context, id: string) => {
-		const resource = Game.getObjectById<Resource>(id)!;
-		if (CreepLib.checkPickup(creep, resource) === C.OK) {
-			const amount = Math.min(creep.store.getFreeCapacity(resource.resourceType), resource.amount);
-			creep.store['#add'](resource.resourceType, amount);
-			resource.amount -= amount;
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(Creep, 'pickup', {}, processPickup),
 
 	registerIntentProcessor(Creep, 'pull', { before: 'move' }, (creep, context, id: string) => {
 		const target = Game.getObjectById<Creep>(id);
@@ -300,16 +347,7 @@ const intents = [
 		}
 	}),
 
-	registerIntentProcessor(Creep, 'say', {}, (creep, context, message: string, isPublic: boolean) => {
-		if (CreepLib.checkCommon(creep) === C.OK) {
-			creep['#saying'] = {
-				isPublic,
-				message: String(message).substring(0, 10),
-				time: Game.time,
-			};
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(Creep, 'say', {}, processSay),
 
 	registerIntentProcessor(Creep, 'suicide', {}, (creep, context) => {
 		if (CreepLib.checkCommon(creep) === C.OK) {
@@ -318,37 +356,9 @@ const intents = [
 		}
 	}),
 
-	registerIntentProcessor(Creep, 'transfer', { before: 'withdraw' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
-		const target = Game.getObjectById<RoomObject & WithStore>(id)!;
-		if (CreepLib.checkTransfer(creep, target, resourceType, amount) === C.OK) {
-			creep.store['#subtract'](resourceType, amount);
-			target.store['#add'](resourceType, amount);
-			appendEventLog(creep.room, {
-				event: C.EVENT_TRANSFER,
-				objectId: creep.id,
-				targetId: target.id,
-				resourceType,
-				amount,
-			});
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(Creep, 'transfer', { before: 'withdraw' }, processTransfer),
 
-	registerIntentProcessor(Creep, 'withdraw', { before: 'pickup' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
-		const target = Game.getObjectById<Structure & WithStore>(id)!;
-		if (CreepLib.checkWithdraw(creep, target, resourceType, amount) === C.OK) {
-			target.store['#subtract'](resourceType, amount);
-			creep.store['#add'](resourceType, amount);
-			appendEventLog(creep.room, {
-				event: C.EVENT_TRANSFER,
-				objectId: target.id,
-				targetId: creep.id,
-				resourceType,
-				amount,
-			});
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(Creep, 'withdraw', { before: 'pickup' }, processWithdraw),
 ];
 
 registerObjectPreTickProcessor(Creep, (creep, context) => {
@@ -409,28 +419,35 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 
 	// Move creep to next room
 	if (isBorder(creep.pos.x, creep.pos.y) && creep['#user'].length > 2) {
-		const { rx, ry } = parseRoomName(creep.pos.roomName);
-		const next = function() {
-			if (creep.pos.x === 0) {
-				return new RoomPosition(49, creep.pos.y, makeRoomName(rx - 1, ry));
-			} else if (creep.pos.x === 49) {
-				return new RoomPosition(0, creep.pos.y, makeRoomName(rx + 1, ry));
-			} else if (creep.pos.y === 0) {
-				return new RoomPosition(creep.pos.x, 49, makeRoomName(rx, ry - 1));
-			} else {
-				return new RoomPosition(creep.pos.x, 0, makeRoomName(rx, ry + 1));
-			}
-		}();
-		teleportCreep(creep, next, context);
+		teleportCreep(creep, borderExitPosition(creep.pos), context);
 	} else {
 		context.wakeAt(creep['#ageTime']);
 	}
 });
 
+/** The mirrored position in the adjacent room for an object standing on a border tile. */
+export function borderExitPosition(pos: RoomPosition) {
+	const { rx, ry } = parseRoomName(pos.roomName);
+	if (pos.x === 0) {
+		return new RoomPosition(49, pos.y, makeRoomName(rx - 1, ry));
+	} else if (pos.x === 49) {
+		return new RoomPosition(0, pos.y, makeRoomName(rx + 1, ry));
+	} else if (pos.y === 0) {
+		return new RoomPosition(pos.x, 49, makeRoomName(rx, ry - 1));
+	} else {
+		return new RoomPosition(pos.x, 0, makeRoomName(rx, ry + 1));
+	}
+}
+
+interface Teleportable extends RoomObject {
+	fatigue?: number;
+	'#actionLog': ActionLog;
+}
+
 // Move a creep to another room. Used by border crossing and by structures that transport creeps
 // across rooms (e.g. portals). The creep is removed from its current room and an import-payload
 // intent is queued for the destination room.
-export function teleportCreep(creep: Creep, next: RoomPosition, context: ProcessorContext) {
+export function teleportCreep(creep: Teleportable & Parameters<typeof writeRoomObject>[0], next: RoomPosition, context: ProcessorContext) {
 	if (creep.room === undefined as never) {
 		return;
 	}
@@ -447,8 +464,10 @@ export function teleportCreep(creep: Creep, next: RoomPosition, context: Process
 	const oldPos = creep.pos;
 	creep.pos = next;
 	creep.room = undefined as never;
-	// Creeps are revitalized when moving to a new room
-	creep.fatigue = 0;
+	// Creeps are revitalized when moving to a new room; power creeps have no fatigue
+	if (creep.fatigue !== undefined) {
+		creep.fatigue = 0;
+	}
 	// Reset actionLog since the actions were in the previous room
 	creep['#actionLog'] = [];
 	const importPayload = writeRoomObject(creep);

--- a/packages/xxscreeps/mods/classic/creep/processor.ts
+++ b/packages/xxscreeps/mods/classic/creep/processor.ts
@@ -1,6 +1,7 @@
 import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { ActionLog, RoomObject } from 'xxscreeps/game/object.js';
 import type { Direction } from 'xxscreeps/game/position.js';
+import type { AnyRoomObject } from 'xxscreeps/game/room/room.js';
 import type { Resource, ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import type { WithStore } from 'xxscreeps/mods/classic/resource/store.js';
 import type { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
@@ -32,6 +33,7 @@ hooks.register('flushContext', () => {
 	pulledToPuller.clear();
 	pullerToPulled.clear();
 });
+export const kRetainActionsTime = 10;
 
 export function buryCreep(creep: Creep, rate = C.CREEP_CORPSE_RATE) {
 	const tombstone = createRoomObject(new Tombstone(), creep.pos);
@@ -87,7 +89,6 @@ export function buryCreep(creep: Creep, rate = C.CREEP_CORPSE_RATE) {
 }
 
 export function flushActionLog(actionLog: ActionLog, context: ProcessorContext) {
-	const kRetainActionsTime = 10;
 	const timeLimit = Game.time - kRetainActionsTime;
 
 	const length = actionLog.length;
@@ -226,11 +227,11 @@ export function isHostileInSafeMode(mover: CreepLib.Carrier) {
 /** Complete a resolved move; returns the destination tile's base fatigue. */
 export function commitMove(mover: CreepLib.Carrier, pos: RoomPosition, roadWearout: number) {
 	mover.room['#moveObject'](mover, pos);
-	const baseFatigue = (() => {
+	const baseFatigue = function() {
 		const road = lookForStructureAt(mover.room, pos, C.STRUCTURE_ROAD);
 		if (road) {
-			// Wear-out advances decay but must not slip past `Game.time` — the road's Tick handler
-			// throws on overdue `ticksToDecay`.
+			// Wear-out advances decay but must not slip past `Game.time` — the road's Tick handler throws
+			// on overdue `ticksToDecay`.
 			road['#nextDecayTime'] = Math.max(Game.time, road['#nextDecayTime'] - roadWearout);
 			return 1;
 		}
@@ -240,7 +241,7 @@ export function commitMove(mover: CreepLib.Carrier, pos: RoomPosition, roadWearo
 		} else {
 			return 2;
 		}
-	})();
+	}();
 	if (!isHostileInSafeMode(mover)) {
 		for (const object of mover.room['#lookAt'](pos)) {
 			if (object['#lookType'] === 'constructionSite' && object['#user'] !== mover['#user']) {
@@ -443,7 +444,7 @@ interface Teleportable extends RoomObject {
 // Move a creep to another room. Used by border crossing and by structures that transport creeps
 // across rooms (e.g. portals). The creep is removed from its current room and an import-payload
 // intent is queued for the destination room.
-export function teleportCreep(creep: Teleportable & Parameters<typeof writeRoomObject>[0], next: RoomPosition, context: ProcessorContext) {
+export function teleportCreep(creep: AnyRoomObject & Teleportable, next: RoomPosition, context: ProcessorContext) {
 	if (creep.room === undefined as never) {
 		return;
 	}

--- a/packages/xxscreeps/mods/meta/memory/memory.ts
+++ b/packages/xxscreeps/mods/meta/memory/memory.ts
@@ -12,6 +12,7 @@ interface MemoryRecord {
 	[key: string]: unknown;
 	creeps?: Record<string, Record<string, unknown>>;
 	flags?: Record<string, Record<string, unknown>>;
+	powerCreeps?: Record<string, Record<string, unknown>>;
 	rooms?: Record<string, Record<string, unknown>>;
 	spawns?: Record<string, Record<string, unknown>>;
 }

--- a/packages/xxscreeps/mods/modern/powerspawn/schema.ts
+++ b/packages/xxscreeps/mods/modern/powerspawn/schema.ts
@@ -19,4 +19,6 @@ export const powerSpawnShape = declare('PowerSpawn', struct(ownedStructureShape,
 	 * @see https://docs.screeps.com/api/#StructurePowerSpawn.store
 	 */
 	store: powerSpawnStoreFormat,
+
+	'#spawnTime': 'int32',
 }));

--- a/packages/xxscreeps/mods/powercreep/backend.ts
+++ b/packages/xxscreeps/mods/powercreep/backend.ts
@@ -26,13 +26,13 @@ bindRenderer(PowerCreep, (creep, next, previousTime) => {
 		...next(),
 		...renderStore(creep.store),
 		actionLog,
-		name: creep.name,
+		ageTime: creep['#ageTime'],
 		className: creep.className,
-		level: creep.level,
-		powers: creep.powers,
 		hits: creep.hits,
 		hitsMax: creep.hitsMax,
-		ageTime: creep['#ageTime'],
+		level: creep.level,
+		name: creep.name,
+		powers: creep.powers,
 		user: creep['#user'],
 	};
 });

--- a/packages/xxscreeps/mods/powercreep/backend.ts
+++ b/packages/xxscreeps/mods/powercreep/backend.ts
@@ -7,8 +7,6 @@ import { renderStore } from 'xxscreeps/mods/classic/resource/backend.js';
 import * as Model from './model.js';
 import { PowerCreep } from './powercreep.js';
 
-// A spawned power creep is a room object; render the fields the official client shows for it (owner,
-// vitals, store, level, and the action log carrying `say`), mirroring the creep renderer.
 bindMapRenderer(PowerCreep, creep => creep['#user']);
 
 bindRenderer(PowerCreep, (creep, next, previousTime) => {

--- a/packages/xxscreeps/mods/powercreep/backend.ts
+++ b/packages/xxscreeps/mods/powercreep/backend.ts
@@ -1,9 +1,43 @@
-import type { PowerCreep } from './powercreep.js';
 import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
-import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { bindMapRenderer, bindRenderer, hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { renderActionLog } from 'xxscreeps/backend/sockets/render.js';
 import * as C from 'xxscreeps/game/constants/index.js';
+import { renderStore } from 'xxscreeps/mods/classic/resource/backend.js';
 import * as Model from './model.js';
+import { PowerCreep } from './powercreep.js';
+
+// A spawned power creep is a room object; render the fields the official client shows for it (owner,
+// vitals, store, level, and the action log carrying `say`), mirroring the creep renderer.
+bindMapRenderer(PowerCreep, creep => creep['#user']);
+
+bindRenderer(PowerCreep, (creep, next, previousTime) => {
+	const actionLog: Record<string, unknown> = renderActionLog(creep['#actionLog'], previousTime);
+	const saying = creep['#saying'];
+	if (
+		saying &&
+		(previousTime === undefined || previousTime < saying.time) &&
+		(saying.isPublic || creep.my)
+	) {
+		actionLog.say = {
+			isPublic: saying.isPublic,
+			message: saying.message,
+		};
+	}
+	return {
+		...next(),
+		...renderStore(creep.store),
+		actionLog,
+		name: creep.name,
+		className: creep.className,
+		level: creep.level,
+		powers: creep.powers,
+		hits: creep.hits,
+		hitsMax: creep.hitsMax,
+		ageTime: creep['#ageTime'],
+		user: creep['#user'],
+	};
+});
 
 // The official client drives the power-creep screen through these routes (`/api/game/power-creeps/*`).
 // The body schema validates shape; the model runs the shared `check*` and commits under compare-and-swap.

--- a/packages/xxscreeps/mods/powercreep/game.ts
+++ b/packages/xxscreeps/mods/powercreep/game.ts
@@ -1,5 +1,10 @@
+import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
 import { hooks, registerGlobal } from 'xxscreeps/game/index.js';
+import { registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
+import { compose } from 'xxscreeps/schema/index.js';
 import { PowerCreep, read } from './powercreep.js';
+import { powerCreepShape } from './schema.js';
 
 let roster: PowerCreep[] = [];
 
@@ -20,7 +25,9 @@ hooks.register('runtimeConnector', {
 	},
 });
 
-// Add `powerCreeps` to the global `Game` object, keyed by name (including unspawned creeps).
+// Add `powerCreeps` to the global `Game` object, keyed by name (including unspawned creeps). A spawned
+// creep is a room object whose `#addToMyGame` overrides its roster entry here, so the spawned form wins
+// wherever the creep is visible.
 declare module 'xxscreeps/game/game.js' {
 	interface Game {
 		/**
@@ -38,6 +45,26 @@ hooks.register('gameInitializer', Game => {
 		Game.powerCreeps[creep.name] = creep;
 	}
 });
+
+// A power creep is a room object once spawned, so it joins the `Room.objects` union.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const powerCreepSchema = registerVariant('Room.objects', compose(powerCreepShape, PowerCreep));
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const find = registerFindHandlers({
+	[C.FIND_POWER_CREEPS]: room => room['#lookFor'](C.LOOK_POWER_CREEPS),
+	[C.FIND_MY_POWER_CREEPS]: room => room['#lookFor'](C.LOOK_POWER_CREEPS).filter(creep => creep.my),
+	[C.FIND_HOSTILE_POWER_CREEPS]: room => room['#lookFor'](C.LOOK_POWER_CREEPS).filter(creep => !creep.my),
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const look = [ registerLook<PowerCreep>()(C.LOOK_POWER_CREEPS) ];
+
+declare module 'xxscreeps/game/room/index.js' {
+	interface Find { powerCreep: typeof find }
+	interface Look { powerCreep: typeof look }
+	interface RoomSchema { powerCreep: [ typeof powerCreepSchema ] }
+}
 
 registerGlobal(PowerCreep);
 declare module 'xxscreeps/game/runtime.js' {

--- a/packages/xxscreeps/mods/powercreep/game.ts
+++ b/packages/xxscreeps/mods/powercreep/game.ts
@@ -46,7 +46,6 @@ hooks.register('gameInitializer', Game => {
 	}
 });
 
-// A power creep is a room object once spawned, so it joins the `Room.objects` union.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const powerCreepSchema = registerVariant('Room.objects', compose(powerCreepShape, PowerCreep));
 

--- a/packages/xxscreeps/mods/powercreep/index.ts
+++ b/packages/xxscreeps/mods/powercreep/index.ts
@@ -3,8 +3,10 @@ import * as types from 'xxscreeps/tsroot.js';
 
 export const manifest: Manifest = {
 	dependencies: [
+		'xxscreeps/mods/classic/creep',
+		'xxscreeps/mods/modern/powerbank',
 		'xxscreeps/mods/modern/powerspawn',
 	],
-	provides: [ 'backend', 'constants', 'driver', 'game', 'schema', 'test' ],
+	provides: [ 'backend', 'constants', 'driver', 'game', 'processor', 'schema', 'test' ],
 	types,
 };

--- a/packages/xxscreeps/mods/powercreep/model.ts
+++ b/packages/xxscreeps/mods/powercreep/model.ts
@@ -74,7 +74,7 @@ export function create(db: Database, userId: string, name: string, className: st
 	return mutate(db, userId, async roster => {
 		const code = checkCreatePowerCreep(await userPower(db, userId), roster, name, className);
 		if (code === C.OK) {
-			roster.push(createPowerCreep(Id.generateId(), name.slice(0, 50), className));
+			roster.push(createPowerCreep(Id.generateId(), name.slice(0, 50), className, userId));
 		}
 		return code;
 	});
@@ -112,11 +112,15 @@ export function rename(db: Database, userId: string, id: string, name: string) {
 	});
 }
 
-// delete / cancel-delete are idempotent and never fail: a repeated delete keeps the original timer, a
-// cancel clears it, and an unknown id is a no-op.
+// delete / cancel-delete are idempotent: a repeated delete keeps the original timer, a cancel clears
+// it, and an unknown id is a no-op. A spawned creep can't be scheduled — its roster entry would
+// silently vanish out from under the room object once the timer elapsed.
 export function scheduleDelete(db: Database, userId: string, id: string) {
 	return mutate(db, userId, roster => {
 		const creep = roster.find(entry => entry.id === id);
+		if (creep && creep['#ageTime'] > 0) {
+			return C.ERR_BUSY;
+		}
 		if (creep?.deleteTime === 0) {
 			creep.deleteTime = Date.now() + C.POWER_CREEP_DELETE_COOLDOWN;
 		}
@@ -129,6 +133,42 @@ export function cancelDelete(db: Database, userId: string, id: string) {
 		const creep = roster.find(entry => entry.id === id);
 		if (creep) {
 			creep.deleteTime = 0;
+		}
+		return C.OK;
+	});
+}
+
+// Claim a roster entry for spawning. The roster is the authority: the entry must exist, be
+// unspawned, and have an elapsed cooldown, so a forged, duplicate, or stale-runtime intent finds
+// nothing to claim. Stamping `#ageTime` marks the entry spawned until the death writeback clears
+// it; a pending deletion is cancelled by the spawn. Returns the claimed entry, whose stored
+// identity and powers seed the room object.
+export async function claimSpawn(db: Database, userId: string, id: string, ageTime: number) {
+	let claimed: PowerCreep | undefined;
+	const code = await mutate(db, userId, roster => {
+		const creep = roster.find(entry => entry.id === id);
+		if (!creep || creep['#ageTime'] > 0 || creep.spawnCooldownTime > Date.now()) {
+			return C.ERR_BUSY;
+		}
+		creep['#ageTime'] = ageTime;
+		creep.deleteTime = 0;
+		claimed = creep;
+		return C.OK;
+	});
+	if (code === C.OK) {
+		return claimed;
+	}
+}
+
+// Record a spawn cooldown on the roster entry when a spawned creep dies, releasing the spawned
+// marker. Called from the room processor through `context.task`, the same account-keyspace
+// writeback path the GPL/GCL credit uses.
+export function setSpawnCooldown(db: Database, userId: string, id: string, cooldownTime: number) {
+	return mutate(db, userId, roster => {
+		const creep = roster.find(entry => entry.id === id);
+		if (creep) {
+			creep.spawnCooldownTime = cooldownTime;
+			creep['#ageTime'] = 0;
 		}
 		return C.OK;
 	});

--- a/packages/xxscreeps/mods/powercreep/model.ts
+++ b/packages/xxscreeps/mods/powercreep/model.ts
@@ -138,11 +138,9 @@ export function cancelDelete(db: Database, userId: string, id: string) {
 	});
 }
 
-// Claim a roster entry for spawning. The roster is the authority: the entry must exist, be
-// unspawned, and have an elapsed cooldown, so a forged, duplicate, or stale-runtime intent finds
-// nothing to claim. Stamping `#ageTime` marks the entry spawned until the death writeback clears
-// it; a pending deletion is cancelled by the spawn. Returns the claimed entry, whose stored
-// identity and powers seed the room object.
+// Claim a roster entry for spawning. The roster is the authority, so a forged, duplicate, or
+// stale-runtime intent finds nothing to claim; a non-zero `#ageTime` marks the entry spawned until
+// the death writeback clears it.
 export async function claimSpawn(db: Database, userId: string, id: string, ageTime: number) {
 	let claimed: PowerCreep | undefined;
 	const code = await mutate(db, userId, roster => {
@@ -160,9 +158,7 @@ export async function claimSpawn(db: Database, userId: string, id: string, ageTi
 	}
 }
 
-// Record a spawn cooldown on the roster entry when a spawned creep dies, releasing the spawned
-// marker. Called from the room processor through `context.task`, the same account-keyspace
-// writeback path the GPL/GCL credit uses.
+// Death writeback: start the spawn cooldown and release the spawned marker.
 export function setSpawnCooldown(db: Database, userId: string, id: string, cooldownTime: number) {
 	return mutate(db, userId, roster => {
 		const creep = roster.find(entry => entry.id === id);

--- a/packages/xxscreeps/mods/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/powercreep/powercreep.ts
@@ -107,7 +107,7 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	}
 
 	// Defer incoming damage to the tick processor so death routes through the tombstone + respawn
-	// cooldown path, rather than the base immediate `#destroy`. Power creeps have no body to absorb it.
+	// cooldown path, rather than the base immediate `#destroy`.
 	override '#applyDamage'(power: number, _type: number, source?: RoomObject) {
 		this.tickRawDamage = (this.tickRawDamage ?? 0) + power;
 		if (source) {
@@ -127,11 +127,12 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 		return false;
 	}
 
-	// --- Room verbs. A power creep acts only once spawned into a room; the account-only roster form
-	// returns `ERR_BUSY`, mirroring vanilla's room guard before it delegates to the shared creep verb.
-	// Power creeps share the carry/store surface with creeps (`Carrier`) but have no body or fatigue. ---
-
-	/** Drop a resource on the ground. */
+	/**
+	 * Drop this resource on the ground.
+	 * @param resourceType One of the `RESOURCE_*` constants.
+	 * @param amount The amount of resource units to be dropped. If omitted, all the available
+	 * carried amount is used.
+	 */
 	drop(resourceType: ResourceType, amount?: number) {
 		const intentAmount = (amount ?? 0) || this.store[resourceType];
 		return chainIntentChecks(
@@ -140,7 +141,9 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'drop', resourceType, intentAmount));
 	}
 
-	/** Move one square in the given direction. Power creeps move without fatigue. */
+	/**
+	 * Move the creep one square in the specified direction.
+	 */
 	move(direction: Direction) {
 		return chainIntentChecks(
 			() => checkSpawned(this),
@@ -149,7 +152,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'move', direction));
 	}
 
-	/** Pick up a dropped resource. */
+	/**
+	 * Pick up an item (a dropped piece of energy). The target has to be at adjacent square to the
+	 * creep or at the same square.
+	 * @param resource The target object to be picked up
+	 */
 	pickup(resource: Resource) {
 		return chainIntentChecks(
 			() => checkSpawned(this),
@@ -157,7 +164,13 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'pickup', resource.id));
 	}
 
-	/** Display a speech bubble. */
+	/**
+	 * Display a visual speech balloon above the creep with the specified message. The message will be
+	 * available for one tick. You can read the last message using the `saying` property. Any valid
+	 * Unicode characters are allowed, including emoji.
+	 * @param message The message to be displayed. Maximum length is 10 characters.
+	 * @param public Set to true to allow other players to see this message. Default is false.
+	 */
 	say(message: string, isPublic = false) {
 		return chainIntentChecks(
 			() => checkSpawned(this),
@@ -165,7 +178,14 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'say', String(message).substring(0, 10), isPublic));
 	}
 
-	/** Transfer a resource to another object. */
+	/**
+	 * Transfer resource from the creep to another object. The target has to be at adjacent square to
+	 * the creep.
+	 * @param target The target object
+	 * @param resourceType One of the `RESOURCE_*` constants
+	 * @param amount The amount of resources to be transferred. If omitted, all the available carried
+	 * amount is used.
+	 */
 	transfer(target: RoomObject & WithStore, resourceType: ResourceType, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
 			(amount ?? 0) || Math.min(this.store[resourceType], target.store.getFreeCapacity(resourceType)!));
@@ -175,7 +195,12 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'transfer', target.id, resourceType, intentAmount));
 	}
 
-	/** Withdraw a resource from a structure or tombstone. */
+	/**
+	 * Withdraw resources from a structure or tombstone. The target has to be at adjacent square to
+	 * the creep. Multiple creeps can withdraw from the same object in the same tick. Your creeps can
+	 * withdraw resources from hostile structures/tombstones as well, in case if there is no hostile
+	 * rampart on top of it.
+	 */
 	withdraw(target: Structure & WithStore, resourceType: ResourceType, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
 			(amount ?? 0) || Math.min(this.store.getFreeCapacity(resourceType), target.store[resourceType]));
@@ -185,7 +210,10 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'withdraw', target.id, resourceType, intentAmount));
 	}
 
-	/** Spawn this roster member into a room at the given power spawn. */
+	/**
+	 * Spawn this power creep in the specified Power Spawn.
+	 * @param powerSpawn Your Power Spawn structure
+	 */
 	spawn(powerSpawn: StructurePowerSpawn) {
 		return chainIntentChecks(
 			() => isSpawned(this) ? C.ERR_BUSY : C.OK,
@@ -196,7 +224,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(powerSpawn, 'spawnPowerCreep', this.id));
 	}
 
-	/** Reset this creep's lifetime at an adjacent power spawn or power bank. */
+	/**
+	 * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby. It
+	 * has to be at adjacent tile.
+	 * @param target The target structure
+	 */
 	renew(target: StructurePowerSpawn | StructurePowerBank) {
 		return chainIntentChecks(
 			() => checkSpawned(this),
@@ -204,7 +236,10 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 			() => intents.save(this, 'renew', target.id));
 	}
 
-	/** Kill this power creep immediately. */
+	/**
+	 * Kill the power creep immediately. It will not be destroyed permanently, but will become
+	 * unspawned, so that you can spawn it again.
+	 */
 	suicide() {
 		return chainIntentChecks(
 			() => checkSpawned(this),
@@ -229,7 +264,6 @@ export function checkRenew(creep: PowerCreep, target: StructurePowerSpawn | Stru
 		() => checkRange(creep, target, 1));
 }
 
-// Power creeps block movement like creeps, deferring to the same safe-mode rules.
 registerObstacleChecker(params => {
 	const { room, user } = params;
 	if (params.ignoreCreeps) {
@@ -245,7 +279,6 @@ registerObstacleChecker(params => {
 	}
 });
 
-// Initialize the fields shared by spawned and unspawned creeps.
 function instantiatePowerCreep(
 	id: string, pos: RoomPosition, name: string, className: string, owner: string, storeCapacity: number,
 ) {
@@ -259,8 +292,6 @@ function instantiatePowerCreep(
 		hits: 0,
 		store: OpenStore['#create'](storeCapacity),
 	});
-	// Private-symbol fields are assigned by member access, not as object-literal keys: the private
-	// transform only rewrites `obj['#x']` accesses, so a literal `'#x'` key would miss the symbol slot.
 	creep['#posId'] = pos['#id'];
 	creep['#powers'] = [];
 	creep['#user'] = owner;

--- a/packages/xxscreeps/mods/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/powercreep/powercreep.ts
@@ -53,8 +53,25 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 		return Object.fromEntries(Fn.map(this['#powers'], ({ power, level }) => [ power, { level } ]));
 	}
 
+	/**
+	 * The maximum amount of hit points of the creep.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.hitsMax
+	 */
 	override get hitsMax() { return 1000 * (this.level + 1); }
+
+	/**
+	 * Whether it is your creep or foe.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.my
+	 */
 	override get my() { return this['#user'] === me; }
+
+	/**
+	 * An object with the creep's owner info.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.owner
+	 */
 	get owner() { return userInfo.get(this['#user']); }
 
 	// An unspawned creep has `#ageTime` of `0`: no remaining lifetime and no shard assignment.
@@ -73,6 +90,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	 */
 	get shard() { return this['#ageTime'] === 0 ? null : userGame?.shard.name ?? null; }
 
+	/**
+	 * The text message that the creep was saying at the last tick.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.saying
+	 */
 	get saying() {
 		const saying = this['#saying'];
 		if (saying?.time === Game.time && (saying.isPublic || this.my)) {
@@ -80,9 +102,29 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 		}
 	}
 
+	/**
+	 * Alias for `PowerCreep.store`.
+	 * @public
+	 * @deprecated
+	 * @see https://docs.screeps.com/api/#PowerCreep.store
+	 */
 	get carry() { return this.store; }
+
+	/**
+	 * Alias for `PowerCreep.store.getCapacity()`.
+	 * @public
+	 * @deprecated
+	 * @see https://docs.screeps.com/api/#Store.getCapacity
+	 */
 	get carryCapacity() { return this.store.getCapacity(); }
 
+	/**
+	 * A shorthand to `Memory.powerCreeps[creep.name]`. You can use it for quick access the creep's
+	 * specific memory data object.
+	 * [Learn more about memory](https://docs.screeps.com/global-objects.html#Memory-object)
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.memory
+	 */
 	get memory(): Record<string, unknown> | undefined {
 		if (!this.my) {
 			return;
@@ -132,6 +174,10 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	 * @param resourceType One of the `RESOURCE_*` constants.
 	 * @param amount The amount of resource units to be dropped. If omitted, all the available
 	 * carried amount is used.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`, `ERR_INVALID_ARGS`,
+	 * `ERR_NOT_ENOUGH_RESOURCES`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.drop
 	 */
 	drop(resourceType: ResourceType, amount?: number) {
 		const intentAmount = (amount ?? 0) || this.store[resourceType];
@@ -143,6 +189,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 
 	/**
 	 * Move the creep one square in the specified direction.
+	 * @param direction One of the following constants: `TOP`, `TOP_RIGHT`, `RIGHT`, `BOTTOM_RIGHT`,
+	 * `BOTTOM`, `BOTTOM_LEFT`, `LEFT`, `TOP_LEFT`
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`, `ERR_INVALID_ARGS`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.move
 	 */
 	move(direction: Direction) {
 		return chainIntentChecks(
@@ -155,7 +206,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	/**
 	 * Pick up an item (a dropped piece of energy). The target has to be at adjacent square to the
 	 * creep or at the same square.
-	 * @param resource The target object to be picked up
+	 * @param resource The target object to be picked up.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`, `ERR_INVALID_TARGET`,
+	 * `ERR_FULL`, `ERR_NOT_IN_RANGE`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.pickup
 	 */
 	pickup(resource: Resource) {
 		return chainIntentChecks(
@@ -169,7 +224,10 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	 * available for one tick. You can read the last message using the `saying` property. Any valid
 	 * Unicode characters are allowed, including emoji.
 	 * @param message The message to be displayed. Maximum length is 10 characters.
-	 * @param public Set to true to allow other players to see this message. Default is false.
+	 * @param isPublic Set to true to allow other players to see this message. Default is false.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.say
 	 */
 	say(message: string, isPublic = false) {
 		return chainIntentChecks(
@@ -181,10 +239,15 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	/**
 	 * Transfer resource from the creep to another object. The target has to be at adjacent square to
 	 * the creep.
-	 * @param target The target object
-	 * @param resourceType One of the `RESOURCE_*` constants
+	 * @param target The target object.
+	 * @param resourceType One of the `RESOURCE_*` constants.
 	 * @param amount The amount of resources to be transferred. If omitted, all the available carried
 	 * amount is used.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`,
+	 * `ERR_NOT_ENOUGH_RESOURCES`, `ERR_INVALID_TARGET`, `ERR_FULL`, `ERR_NOT_IN_RANGE`,
+	 * `ERR_INVALID_ARGS`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.transfer
 	 */
 	transfer(target: RoomObject & WithStore, resourceType: ResourceType, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
@@ -200,6 +263,15 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	 * the creep. Multiple creeps can withdraw from the same object in the same tick. Your creeps can
 	 * withdraw resources from hostile structures/tombstones as well, in case if there is no hostile
 	 * rampart on top of it.
+	 * @param target The target object.
+	 * @param resourceType One of the `RESOURCE_*` constants.
+	 * @param amount The amount of resources to be transferred. If omitted, all the available amount
+	 * is used.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`,
+	 * `ERR_NOT_ENOUGH_RESOURCES`, `ERR_INVALID_TARGET`, `ERR_FULL`, `ERR_NOT_IN_RANGE`,
+	 * `ERR_INVALID_ARGS`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.withdraw
 	 */
 	withdraw(target: Structure & WithStore, resourceType: ResourceType, amount?: number) {
 		const intentAmount = calculateChecked(this, target, () =>
@@ -212,7 +284,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 
 	/**
 	 * Spawn this power creep in the specified Power Spawn.
-	 * @param powerSpawn Your Power Spawn structure
+	 * @param powerSpawn Your Power Spawn structure.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`, `ERR_INVALID_TARGET`,
+	 * `ERR_TIRED`, `ERR_RCL_NOT_ENOUGH`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.spawn
 	 */
 	spawn(powerSpawn: StructurePowerSpawn) {
 		return chainIntentChecks(
@@ -227,7 +303,11 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	/**
 	 * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby. It
 	 * has to be at adjacent tile.
-	 * @param target The target structure
+	 * @param target The target structure.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`, `ERR_INVALID_TARGET`,
+	 * `ERR_NOT_IN_RANGE`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.renew
 	 */
 	renew(target: StructurePowerSpawn | StructurePowerBank) {
 		return chainIntentChecks(
@@ -239,6 +319,9 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	/**
 	 * Kill the power creep immediately. It will not be destroyed permanently, but will become
 	 * unspawned, so that you can spawn it again.
+	 * @returns One of the following codes: `OK`, `ERR_NOT_OWNER`, `ERR_BUSY`
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.suicide
 	 */
 	suicide() {
 		return chainIntentChecks(

--- a/packages/xxscreeps/mods/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/powercreep/powercreep.ts
@@ -1,11 +1,26 @@
+import type { GameConstructor } from 'xxscreeps/game/index.js';
+import type { Direction } from 'xxscreeps/game/position.js';
+import type { Resource, ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import type { WithStore } from 'xxscreeps/mods/classic/resource/store.js';
+import type { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
 import type { TypeOf } from 'xxscreeps/schema/index.js';
 import { makeReaderAndWriter } from 'xxscreeps/engine/schema/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { chainIntentChecks, checkRange, checkTarget } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { RoomObject } from 'xxscreeps/game/object.js';
+import { Game, intents, me, userGame, userInfo } from 'xxscreeps/game/index.js';
+import { RoomObject, optionalExpiryTime, saveAction } from 'xxscreeps/game/object.js';
+import { registerObstacleChecker } from 'xxscreeps/game/pathfinder/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
+import { checkCarrier, checkDrop, checkPickup, checkTransfer, checkWithdraw } from 'xxscreeps/mods/classic/creep/creep.js';
+import { OpenStore, calculateChecked } from 'xxscreeps/mods/classic/resource/store.js';
+import { checkIsActive } from 'xxscreeps/mods/classic/structure/structure.js';
+import * as Memory from 'xxscreeps/mods/meta/memory/memory.js';
+import { StructurePowerBank } from 'xxscreeps/mods/modern/powerbank/powerbank.js';
+import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
 import { compose, declare, vector, withOverlay } from 'xxscreeps/schema/index.js';
-import { instantiate } from 'xxscreeps/utility/utility.js';
+import { assign } from 'xxscreeps/utility/utility.js';
 import { powerCreepShape } from './schema.js';
 
 /**
@@ -16,23 +31,8 @@ import { powerCreepShape } from './schema.js';
  * @see https://docs.screeps.com/api/#PowerCreep
  */
 export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
-	/**
-	 * The name of the shard where the power creep is spawned, or `null`.
-	 * @public
-	 * @see https://docs.screeps.com/api/#PowerCreep.shard
-	 */
-	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
-	get shard(): string | null { return null; }
-
-	/**
-	 * The remaining amount of game ticks after which the creep will die and become unspawned.
-	 * Undefined if the creep is not spawned in the world.
-	 * @public
-	 * @see https://docs.screeps.com/api/#PowerCreep.ticksToLive
-	 */
-	get ticksToLive(): number | undefined { return undefined; }
-
-	override get '#lookType'() { return C.LOOK_POWER_CREEPS; }
+	/** @internal — raw incoming damage this tick; settled to `hits` in the tick processor. */
+	declare tickRawDamage: number | undefined;
 
 	/**
 	 * The power creep's level.
@@ -52,21 +52,235 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	get powers(): Record<number, { level: number }> {
 		return Object.fromEntries(Fn.map(this['#powers'], ({ power, level }) => [ power, { level } ]));
 	}
+
+	override get hitsMax() { return 1000 * (this.level + 1); }
+	override get my() { return this['#user'] === me; }
+	get owner() { return userInfo.get(this['#user']); }
+
+	// An unspawned creep has `#ageTime` of `0`: no remaining lifetime and no shard assignment.
+	/**
+	 * The remaining amount of game ticks after which the creep will die and become unspawned.
+	 * Undefined if the creep is not spawned in the world.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.ticksToLive
+	 */
+	get ticksToLive() { return optionalExpiryTime(this['#ageTime']); }
+
+	/**
+	 * The name of the shard where the power creep is spawned, or `null`.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.shard
+	 */
+	get shard() { return this['#ageTime'] === 0 ? null : userGame?.shard.name ?? null; }
+
+	get saying() {
+		const saying = this['#saying'];
+		if (saying?.time === Game.time && (saying.isPublic || this.my)) {
+			return saying.message;
+		}
+	}
+
+	get carry() { return this.store; }
+	get carryCapacity() { return this.store.getCapacity(); }
+
+	get memory(): Record<string, unknown> | undefined {
+		if (!this.my) {
+			return;
+		}
+		return (Memory.get().powerCreeps ??= {})[this.name] ??= {};
+	}
+
+	override get '#hasIntent'() { return true; }
+	override get '#layer'() { return 0; }
+	override get '#lookType'() { return C.LOOK_POWER_CREEPS; }
+	override get '#providesVision'() { return true; }
+
+	set memory(memory: Record<string, unknown>) {
+		if (!this.my) {
+			return;
+		}
+		(Memory.get().powerCreeps ??= {})[this.name] ??= memory;
+	}
+
+	override '#addToMyGame'(game: GameConstructor) {
+		game.powerCreeps[this.name] = this;
+	}
+
+	// Defer incoming damage to the tick processor so death routes through the tombstone + respawn
+	// cooldown path, rather than the base immediate `#destroy`. Power creeps have no body to absorb it.
+	override '#applyDamage'(power: number, _type: number, source?: RoomObject) {
+		this.tickRawDamage = (this.tickRawDamage ?? 0) + power;
+		if (source) {
+			saveAction(this, 'attacked', source.pos);
+		}
+	}
+
+	override '#destroy'(type?: number) {
+		if (super['#destroy'](type)) {
+			appendEventLog(this.room, {
+				event: C.EVENT_OBJECT_DESTROYED,
+				objectId: this.id,
+				type: 'powerCreep',
+			});
+			return true;
+		}
+		return false;
+	}
+
+	// --- Room verbs. A power creep acts only once spawned into a room; the account-only roster form
+	// returns `ERR_BUSY`, mirroring vanilla's room guard before it delegates to the shared creep verb.
+	// Power creeps share the carry/store surface with creeps (`Carrier`) but have no body or fatigue. ---
+
+	/** Drop a resource on the ground. */
+	drop(resourceType: ResourceType, amount?: number) {
+		const intentAmount = (amount ?? 0) || this.store[resourceType];
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkDrop(this, resourceType, intentAmount),
+			() => intents.save(this, 'drop', resourceType, intentAmount));
+	}
+
+	/** Move one square in the given direction. Power creeps move without fatigue. */
+	move(direction: Direction) {
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkCarrier(this),
+			() => Number.isInteger(direction) && direction >= 1 && direction <= 8 ? C.OK : C.ERR_INVALID_ARGS,
+			() => intents.save(this, 'move', direction));
+	}
+
+	/** Pick up a dropped resource. */
+	pickup(resource: Resource) {
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkPickup(this, resource),
+			() => intents.save(this, 'pickup', resource.id));
+	}
+
+	/** Display a speech bubble. */
+	say(message: string, isPublic = false) {
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkCarrier(this),
+			() => intents.save(this, 'say', String(message).substring(0, 10), isPublic));
+	}
+
+	/** Transfer a resource to another object. */
+	transfer(target: RoomObject & WithStore, resourceType: ResourceType, amount?: number) {
+		const intentAmount = calculateChecked(this, target, () =>
+			(amount ?? 0) || Math.min(this.store[resourceType], target.store.getFreeCapacity(resourceType)!));
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkTransfer(this, target, resourceType, intentAmount),
+			() => intents.save(this, 'transfer', target.id, resourceType, intentAmount));
+	}
+
+	/** Withdraw a resource from a structure or tombstone. */
+	withdraw(target: Structure & WithStore, resourceType: ResourceType, amount?: number) {
+		const intentAmount = calculateChecked(this, target, () =>
+			(amount ?? 0) || Math.min(this.store.getFreeCapacity(resourceType), target.store[resourceType]));
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkWithdraw(this, target, resourceType, intentAmount),
+			() => intents.save(this, 'withdraw', target.id, resourceType, intentAmount));
+	}
+
+	/** Spawn this roster member into a room at the given power spawn. */
+	spawn(powerSpawn: StructurePowerSpawn) {
+		return chainIntentChecks(
+			() => isSpawned(this) ? C.ERR_BUSY : C.OK,
+			() => checkTarget(powerSpawn, StructurePowerSpawn),
+			() => this.my && powerSpawn.my ? C.OK : C.ERR_NOT_OWNER,
+			() => checkIsActive(powerSpawn),
+			() => this.spawnCooldownTime > Date.now() ? C.ERR_TIRED : C.OK,
+			() => intents.save(powerSpawn, 'spawnPowerCreep', this.id));
+	}
+
+	/** Reset this creep's lifetime at an adjacent power spawn or power bank. */
+	renew(target: StructurePowerSpawn | StructurePowerBank) {
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkRenew(this, target),
+			() => intents.save(this, 'renew', target.id));
+	}
+
+	/** Kill this power creep immediately. */
+	suicide() {
+		return chainIntentChecks(
+			() => checkSpawned(this),
+			() => checkCarrier(this),
+			() => intents.save(this, 'suicide'));
+	}
 }
 
-/** Build a fresh, unspawned roster member. */
-export function createPowerCreep(id: string, name: string, className: string) {
-	const pos = new RoomPosition(0, 0, 'E0S0');
-	const creep = instantiate(PowerCreep, {
+// The overlay type of `room` lies for player ergonomics — an unspawned roster member has none.
+const isSpawned = (creep: PowerCreep) => (creep.room as unknown) !== undefined;
+
+/** Room verbs act only on a spawned creep; the account-only roster form is busy. */
+function checkSpawned(creep: PowerCreep) {
+	return isSpawned(creep) ? C.OK : C.ERR_BUSY;
+}
+
+export function checkRenew(creep: PowerCreep, target: StructurePowerSpawn | StructurePowerBank) {
+	return chainIntentChecks(
+		() => creep.my ? C.OK : C.ERR_NOT_OWNER,
+		() => checkTarget(target, StructurePowerSpawn, StructurePowerBank),
+		() => target instanceof StructurePowerSpawn ? checkIsActive(target) : C.OK,
+		() => checkRange(creep, target, 1));
+}
+
+// Power creeps block movement like creeps, deferring to the same safe-mode rules.
+registerObstacleChecker(params => {
+	const { room, user } = params;
+	if (params.ignoreCreeps) {
+		return null;
+	} else if (room.controller?.safeMode === undefined) {
+		return object => object instanceof PowerCreep;
+	} else {
+		const safeUser = room.controller['#user'];
+		if (safeUser !== user) {
+			return object => object instanceof PowerCreep;
+		}
+		return object => object instanceof PowerCreep && object['#user'] === user;
+	}
+});
+
+// Initialize the fields shared by spawned and unspawned creeps.
+function instantiatePowerCreep(
+	id: string, pos: RoomPosition, name: string, className: string, owner: string, storeCapacity: number,
+) {
+	const creep = assign(new PowerCreep(), {
 		id,
 		pos,
 		name,
 		className,
 		spawnCooldownTime: 0,
 		deleteTime: 0,
+		hits: 0,
+		store: OpenStore['#create'](storeCapacity),
 	});
+	// Private-symbol fields are assigned by member access, not as object-literal keys: the private
+	// transform only rewrites `obj['#x']` accesses, so a literal `'#x'` key would miss the symbol slot.
 	creep['#posId'] = pos['#id'];
 	creep['#powers'] = [];
+	creep['#user'] = owner;
+	creep['#actionLog'] = [];
+	creep['#ageTime'] = 0;
+	return creep;
+}
+
+/** Build a fresh, unspawned roster member. */
+export function createPowerCreep(id: string, name: string, className: string, owner: string) {
+	return instantiatePowerCreep(id, new RoomPosition(0, 0, 'E0S0'), name, className, owner, 0);
+}
+
+/** Copy a claimed roster entry into a room: same identity and powers, with fresh room presence. */
+export function createSpawnedPowerCreep(pos: RoomPosition, entry: PowerCreep) {
+	const creep = instantiatePowerCreep(
+		entry.id, pos, entry.name, entry.className, entry['#user'], 100 * (entry.level + 1));
+	creep['#powers'] = entry['#powers'].map(({ power, level }) => ({ power, level }));
+	creep.hits = creep.hitsMax;
+	creep['#ageTime'] = entry['#ageTime'];
 	return creep;
 }
 

--- a/packages/xxscreeps/mods/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/powercreep/powercreep.ts
@@ -15,7 +15,7 @@ import { RoomPosition } from 'xxscreeps/game/position.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { checkCarrier, checkDrop, checkPickup, checkTransfer, checkWithdraw } from 'xxscreeps/mods/classic/creep/creep.js';
 import { OpenStore, calculateChecked } from 'xxscreeps/mods/classic/resource/store.js';
-import { checkIsActive } from 'xxscreeps/mods/classic/structure/structure.js';
+import { checkIsActive, checkMyStructure } from 'xxscreeps/mods/classic/structure/structure.js';
 import * as Memory from 'xxscreeps/mods/meta/memory/memory.js';
 import { StructurePowerBank } from 'xxscreeps/mods/modern/powerbank/powerbank.js';
 import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
@@ -293,8 +293,8 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	spawn(powerSpawn: StructurePowerSpawn) {
 		return chainIntentChecks(
 			() => isSpawned(this) ? C.ERR_BUSY : C.OK,
-			() => checkTarget(powerSpawn, StructurePowerSpawn),
-			() => this.my && powerSpawn.my ? C.OK : C.ERR_NOT_OWNER,
+			() => checkMyStructure(powerSpawn, StructurePowerSpawn),
+			() => this.my ? C.OK : C.ERR_NOT_OWNER,
 			() => checkIsActive(powerSpawn),
 			() => this.spawnCooldownTime > Date.now() ? C.ERR_TIRED : C.OK,
 			() => intents.save(powerSpawn, 'spawnPowerCreep', this.id));
@@ -332,7 +332,8 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 }
 
 // The overlay type of `room` lies for player ergonomics — an unspawned roster member has none.
-const isSpawned = (creep: PowerCreep) => (creep.room as unknown) !== undefined;
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+const isSpawned = (creep: PowerCreep) => creep.room !== undefined;
 
 /** Room verbs act only on a spawned creep; the account-only roster form is busy. */
 function checkSpawned(creep: PowerCreep) {

--- a/packages/xxscreeps/mods/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/powercreep/processor.ts
@@ -1,0 +1,199 @@
+import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
+import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { Direction } from 'xxscreeps/game/position.js';
+import type { Resource, ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import type { WithStore } from 'xxscreeps/mods/classic/resource/store.js';
+import type { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
+import { registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
+import * as Movement from 'xxscreeps/engine/processor/movement.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { Game } from 'xxscreeps/game/index.js';
+import { createRoomObject, saveAction } from 'xxscreeps/game/object.js';
+import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
+import { checkCarrier, checkDrop, checkPickup, checkTransfer, checkWithdraw } from 'xxscreeps/mods/classic/creep/creep.js';
+import { flushActionLog } from 'xxscreeps/mods/classic/creep/processor.js';
+import { Tombstone } from 'xxscreeps/mods/classic/creep/tombstone.js';
+import * as ResourceIntent from 'xxscreeps/mods/classic/resource/processor/resource.js';
+import { OpenStore } from 'xxscreeps/mods/classic/resource/store.js';
+import { checkMyStructure } from 'xxscreeps/mods/classic/structure/structure.js';
+import { StructurePowerBank } from 'xxscreeps/mods/modern/powerbank/powerbank.js';
+import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
+import * as Model from './model.js';
+import { PowerCreep, checkRenew, createSpawnedPowerCreep } from './powercreep.js';
+
+// Leave a tombstone where a power creep died and drop whatever it was carrying. Power creeps have no
+// body, so the corpse only holds the store; the tombstone decays on the power-creep timer.
+function buryPowerCreep(creep: PowerCreep) {
+	const tombstone = createRoomObject(new Tombstone(), creep.pos);
+	tombstone.deathTime = Game.time;
+	tombstone.store = new OpenStore();
+	for (const [ resourceType, amount ] of creep.store['#entries']()) {
+		tombstone.store['#add'](resourceType, amount);
+	}
+	const saying = creep['#saying'];
+	tombstone['#creep'] = {
+		body: [],
+		id: creep.id,
+		name: creep.name,
+		saying: saying?.isPublic && saying.time === Game.time ? saying.message : undefined,
+		ticksToLive: creep.ticksToLive ?? 0,
+		user: creep['#user'],
+	};
+	tombstone['#decayTime'] = Game.time + C.TOMBSTONE_DECAY_POWER_CREEP;
+	creep.room['#insertObject'](tombstone);
+	creep['#destroy']();
+}
+
+// Death frees the roster slot and starts the wall-clock respawn cooldown. The roster lives in account
+// keyspace, so the writeback rides `context.task` — the same path the GPL/GCL credit uses.
+function killPowerCreep(creep: PowerCreep, context: ProcessorContext) {
+	const user = creep['#user'];
+	const id = creep.id;
+	buryPowerCreep(creep);
+	context.task(Model.setSpawnCooldown(context.shard.db, user, id, Date.now() + C.POWER_CREEP_SPAWN_COOLDOWN));
+	context.setActive();
+}
+
+declare module 'xxscreeps/engine/processor/index.js' {
+	interface Intent { powerCreep: typeof intents }
+}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const intents = [
+	// A power spawn materializes a roster member on its own tile. The intent carries only the roster
+	// id; the claim atomically validates it against the authoritative roster and returns the stored
+	// entry, so identity and powers can't be forged and a duplicate or cooldown-lagged spawn finds
+	// nothing to claim.
+	registerIntentProcessor(StructurePowerSpawn, 'spawnPowerCreep', {}, (spawn, context, id: string) => {
+		if (checkMyStructure(spawn, StructurePowerSpawn) !== C.OK) {
+			return;
+		}
+		if (Fn.some(spawn.room['#lookAt'](spawn.pos), instanceOfPredicate(PowerCreep))) {
+			return;
+		}
+		const ageTime = Game.time + C.POWER_CREEP_LIFE_TIME;
+		context.task(Model.claimSpawn(context.shard.db, spawn['#user']!, id, ageTime), entry => {
+			if (entry) {
+				spawn.room['#insertObject'](createSpawnedPowerCreep(spawn.pos, entry));
+				context.didUpdate();
+			}
+		});
+	}),
+
+	registerIntentProcessor(PowerCreep, 'drop', { before: 'transfer' }, (creep, context, resourceType: ResourceType, amount: number) => {
+		if (checkDrop(creep, resourceType, amount) === C.OK) {
+			creep.store['#subtract'](resourceType, amount);
+			ResourceIntent.drop(creep.pos, resourceType, amount);
+			context.didUpdate();
+		}
+	}),
+
+	// Fatigue-free movement: no body, no weight, no pull chains. A single move request resolves through
+	// the shared movement arbiter at a fixed priority.
+	registerIntentProcessor(PowerCreep, 'move', {}, (creep, context, direction: Direction) => {
+		if (checkCarrier(creep) === C.OK) {
+			Movement.announce(creep, direction, commit => commit(1, pos => {
+				creep.room['#moveObject'](creep, pos);
+				context.didUpdate();
+			}));
+		}
+	}),
+
+	registerIntentProcessor(PowerCreep, 'pickup', {}, (creep, context, id: string) => {
+		const resource = Game.getObjectById<Resource>(id)!;
+		if (checkPickup(creep, resource) === C.OK) {
+			const amount = Math.min(creep.store.getFreeCapacity(resource.resourceType), resource.amount);
+			creep.store['#add'](resource.resourceType, amount);
+			resource.amount -= amount;
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(PowerCreep, 'say', {}, (creep, context, message: string, isPublic: boolean) => {
+		if (checkCarrier(creep) === C.OK) {
+			creep['#saying'] = {
+				isPublic,
+				message: String(message).substring(0, 10),
+				time: Game.time,
+			};
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(PowerCreep, 'transfer', { before: 'withdraw' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
+		const target = Game.getObjectById<RoomObject & WithStore>(id)!;
+		if (checkTransfer(creep, target, resourceType, amount) === C.OK) {
+			creep.store['#subtract'](resourceType, amount);
+			target.store['#add'](resourceType, amount);
+			appendEventLog(creep.room, {
+				event: C.EVENT_TRANSFER,
+				objectId: creep.id,
+				targetId: target.id,
+				resourceType,
+				amount,
+			});
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(PowerCreep, 'withdraw', { before: 'pickup' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
+		const target = Game.getObjectById<Structure & WithStore>(id)!;
+		if (checkWithdraw(creep, target, resourceType, amount) === C.OK) {
+			target.store['#subtract'](resourceType, amount);
+			creep.store['#add'](resourceType, amount);
+			appendEventLog(creep.room, {
+				event: C.EVENT_TRANSFER,
+				objectId: target.id,
+				targetId: creep.id,
+				resourceType,
+				amount,
+			});
+			context.didUpdate();
+		}
+	}),
+
+	// Renew at an adjacent power spawn or power bank, resetting the creep to a full lifetime.
+	registerIntentProcessor(PowerCreep, 'renew', {}, (creep, context, id: string) => {
+		const target = Game.getObjectById<StructurePowerSpawn | StructurePowerBank>(id)!;
+		if (checkRenew(creep, target) === C.OK) {
+			creep['#ageTime'] = Game.time + C.POWER_CREEP_LIFE_TIME;
+			saveAction(creep, 'healed', target.pos);
+			context.didUpdate();
+		}
+	}),
+
+	registerIntentProcessor(PowerCreep, 'suicide', {}, (creep, context) => {
+		if (checkCarrier(creep) === C.OK) {
+			killPowerCreep(creep, context);
+		}
+	}),
+];
+
+registerObjectPreTickProcessor(PowerCreep, (creep, context) => {
+	flushActionLog(creep['#actionLog'], context);
+	const saying = creep['#saying'];
+	if (saying) {
+		if (saying.time <= Game.time - 10) {
+			creep['#saying'] = undefined;
+			context.didUpdate();
+		} else {
+			context.wakeAt(saying.time + 10);
+		}
+	}
+});
+
+registerObjectTickProcessor(PowerCreep, (creep, context) => {
+	// Settle damage accumulated this tick (power creeps have no body to absorb it).
+	const damage = creep.tickRawDamage ?? 0;
+	if (damage > 0) {
+		creep.hits = Math.max(0, creep.hits - damage);
+		creep.tickRawDamage = 0;
+		context.didUpdate();
+	}
+	if (creep.ticksToLive === 0 || creep.hits <= 0) {
+		killPowerCreep(creep, context);
+	} else {
+		context.wakeAt(creep['#ageTime']);
+	}
+});

--- a/packages/xxscreeps/mods/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/powercreep/processor.ts
@@ -1,9 +1,5 @@
 import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
-import type { RoomObject } from 'xxscreeps/game/object.js';
 import type { Direction } from 'xxscreeps/game/position.js';
-import type { Resource, ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
-import type { WithStore } from 'xxscreeps/mods/classic/resource/store.js';
-import type { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
 import { registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import * as Movement from 'xxscreeps/engine/processor/movement.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -11,11 +7,10 @@ import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { createRoomObject, saveAction } from 'xxscreeps/game/object.js';
-import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
-import { checkCarrier, checkDrop, checkPickup, checkTransfer, checkWithdraw } from 'xxscreeps/mods/classic/creep/creep.js';
-import { flushActionLog } from 'xxscreeps/mods/classic/creep/processor.js';
+import { isBorder } from 'xxscreeps/game/terrain.js';
+import { checkCarrier } from 'xxscreeps/mods/classic/creep/creep.js';
+import { borderExitPosition, commitMove, flushActionLog, isHostileInSafeMode, processDrop, processPickup, processSay, processTransfer, processWithdraw, teleportCreep } from 'xxscreeps/mods/classic/creep/processor.js';
 import { Tombstone } from 'xxscreeps/mods/classic/creep/tombstone.js';
-import * as ResourceIntent from 'xxscreeps/mods/classic/resource/processor/resource.js';
 import { OpenStore } from 'xxscreeps/mods/classic/resource/store.js';
 import { checkMyStructure } from 'xxscreeps/mods/classic/structure/structure.js';
 import { StructurePowerBank } from 'xxscreeps/mods/modern/powerbank/powerbank.js';
@@ -81,77 +76,27 @@ const intents = [
 		});
 	}),
 
-	registerIntentProcessor(PowerCreep, 'drop', { before: 'transfer' }, (creep, context, resourceType: ResourceType, amount: number) => {
-		if (checkDrop(creep, resourceType, amount) === C.OK) {
-			creep.store['#subtract'](resourceType, amount);
-			ResourceIntent.drop(creep.pos, resourceType, amount);
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(PowerCreep, 'drop', { before: 'transfer' }, processDrop),
 
 	// Fatigue-free movement: no body, no weight, no pull chains. A single move request resolves through
 	// the shared movement arbiter at a fixed priority.
 	registerIntentProcessor(PowerCreep, 'move', {}, (creep, context, direction: Direction) => {
 		if (checkCarrier(creep) === C.OK) {
-			Movement.announce(creep, direction, commit => commit(1, pos => {
-				creep.room['#moveObject'](creep, pos);
+			const priority = 1 + (isHostileInSafeMode(creep) ? -500 : 0);
+			Movement.announce(creep, direction, commit => commit(priority, pos => {
+				commitMove(creep, pos, C.ROAD_WEAROUT_POWER_CREEP);
 				context.didUpdate();
 			}));
 		}
 	}),
 
-	registerIntentProcessor(PowerCreep, 'pickup', {}, (creep, context, id: string) => {
-		const resource = Game.getObjectById<Resource>(id)!;
-		if (checkPickup(creep, resource) === C.OK) {
-			const amount = Math.min(creep.store.getFreeCapacity(resource.resourceType), resource.amount);
-			creep.store['#add'](resource.resourceType, amount);
-			resource.amount -= amount;
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(PowerCreep, 'pickup', {}, processPickup),
 
-	registerIntentProcessor(PowerCreep, 'say', {}, (creep, context, message: string, isPublic: boolean) => {
-		if (checkCarrier(creep) === C.OK) {
-			creep['#saying'] = {
-				isPublic,
-				message: String(message).substring(0, 10),
-				time: Game.time,
-			};
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(PowerCreep, 'say', {}, processSay),
 
-	registerIntentProcessor(PowerCreep, 'transfer', { before: 'withdraw' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
-		const target = Game.getObjectById<RoomObject & WithStore>(id)!;
-		if (checkTransfer(creep, target, resourceType, amount) === C.OK) {
-			creep.store['#subtract'](resourceType, amount);
-			target.store['#add'](resourceType, amount);
-			appendEventLog(creep.room, {
-				event: C.EVENT_TRANSFER,
-				objectId: creep.id,
-				targetId: target.id,
-				resourceType,
-				amount,
-			});
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(PowerCreep, 'transfer', { before: 'withdraw' }, processTransfer),
 
-	registerIntentProcessor(PowerCreep, 'withdraw', { before: 'pickup' }, (creep, context, id: string, resourceType: ResourceType, amount: number) => {
-		const target = Game.getObjectById<Structure & WithStore>(id)!;
-		if (checkWithdraw(creep, target, resourceType, amount) === C.OK) {
-			target.store['#subtract'](resourceType, amount);
-			creep.store['#add'](resourceType, amount);
-			appendEventLog(creep.room, {
-				event: C.EVENT_TRANSFER,
-				objectId: target.id,
-				targetId: creep.id,
-				resourceType,
-				amount,
-			});
-			context.didUpdate();
-		}
-	}),
+	registerIntentProcessor(PowerCreep, 'withdraw', { before: 'pickup' }, processWithdraw),
 
 	// Renew at an adjacent power spawn or power bank, resetting the creep to a full lifetime.
 	registerIntentProcessor(PowerCreep, 'renew', {}, (creep, context, id: string) => {
@@ -193,6 +138,8 @@ registerObjectTickProcessor(PowerCreep, (creep, context) => {
 	}
 	if (creep.ticksToLive === 0 || creep.hits <= 0) {
 		killPowerCreep(creep, context);
+	} else if (isBorder(creep.pos.x, creep.pos.y)) {
+		teleportCreep(creep, borderExitPosition(creep.pos), context);
 	} else {
 		context.wakeAt(creep['#ageTime']);
 	}

--- a/packages/xxscreeps/mods/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/powercreep/processor.ts
@@ -2,17 +2,15 @@ import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { Direction } from 'xxscreeps/game/position.js';
 import { registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import * as Movement from 'xxscreeps/engine/processor/movement.js';
-import { Fn } from 'xxscreeps/functional/fn.js';
-import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { createRoomObject, saveAction } from 'xxscreeps/game/object.js';
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { checkCarrier } from 'xxscreeps/mods/classic/creep/creep.js';
-import { borderExitPosition, commitMove, flushActionLog, isHostileInSafeMode, processDrop, processPickup, processSay, processTransfer, processWithdraw, teleportCreep } from 'xxscreeps/mods/classic/creep/processor.js';
+import { borderExitPosition, commitMove, flushActionLog, isHostileInSafeMode, kRetainActionsTime, processDrop, processPickup, processSay, processTransfer, processWithdraw, teleportCreep } from 'xxscreeps/mods/classic/creep/processor.js';
 import { Tombstone } from 'xxscreeps/mods/classic/creep/tombstone.js';
 import { OpenStore } from 'xxscreeps/mods/classic/resource/store.js';
-import { checkMyStructure } from 'xxscreeps/mods/classic/structure/structure.js';
+import { checkIsActive, checkMyStructure } from 'xxscreeps/mods/classic/structure/structure.js';
 import { StructurePowerBank } from 'xxscreeps/mods/modern/powerbank/powerbank.js';
 import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
 import * as Model from './model.js';
@@ -48,20 +46,18 @@ function killPowerCreep(creep: PowerCreep, context: ProcessorContext) {
 	context.setActive();
 }
 
-declare module 'xxscreeps/engine/processor/index.js' {
-	interface Intent { powerCreep: typeof intents }
-}
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
 	// The intent carries only the roster id; `claimSpawn` validates it against the authoritative
 	// roster and returns the stored entry that seeds the room object.
 	registerIntentProcessor(StructurePowerSpawn, 'spawnPowerCreep', {}, (spawn, context, id: string) => {
-		if (checkMyStructure(spawn, StructurePowerSpawn) !== C.OK) {
+		if (checkMyStructure(spawn, StructurePowerSpawn) !== C.OK || checkIsActive(spawn) !== C.OK) {
 			return;
 		}
-		if (Fn.some(spawn.room['#lookAt'](spawn.pos), instanceOfPredicate(PowerCreep))) {
+		if (spawn['#spawnTime'] === Game.time) {
 			return;
 		}
+		spawn['#spawnTime'] = Game.time;
 		const ageTime = Game.time + C.POWER_CREEP_LIFE_TIME;
 		context.task(Model.claimSpawn(context.shard.db, spawn['#user']!, id, ageTime), entry => {
 			if (entry) {
@@ -111,11 +107,11 @@ registerObjectPreTickProcessor(PowerCreep, (creep, context) => {
 	flushActionLog(creep['#actionLog'], context);
 	const saying = creep['#saying'];
 	if (saying) {
-		if (saying.time <= Game.time - 10) {
+		if (saying.time <= Game.time - kRetainActionsTime) {
 			creep['#saying'] = undefined;
 			context.didUpdate();
 		} else {
-			context.wakeAt(saying.time + 10);
+			context.wakeAt(saying.time + kRetainActionsTime);
 		}
 	}
 });
@@ -136,3 +132,9 @@ registerObjectTickProcessor(PowerCreep, (creep, context) => {
 		context.wakeAt(creep['#ageTime']);
 	}
 });
+
+// ---
+
+declare module 'xxscreeps/engine/processor/index.js' {
+	interface Intent { powerCreep: typeof intents }
+}

--- a/packages/xxscreeps/mods/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/powercreep/processor.ts
@@ -18,8 +18,6 @@ import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn
 import * as Model from './model.js';
 import { PowerCreep, checkRenew, createSpawnedPowerCreep } from './powercreep.js';
 
-// Leave a tombstone where a power creep died and drop whatever it was carrying. Power creeps have no
-// body, so the corpse only holds the store; the tombstone decays on the power-creep timer.
 function buryPowerCreep(creep: PowerCreep) {
 	const tombstone = createRoomObject(new Tombstone(), creep.pos);
 	tombstone.deathTime = Game.time;
@@ -41,8 +39,7 @@ function buryPowerCreep(creep: PowerCreep) {
 	creep['#destroy']();
 }
 
-// Death frees the roster slot and starts the wall-clock respawn cooldown. The roster lives in account
-// keyspace, so the writeback rides `context.task` — the same path the GPL/GCL credit uses.
+// The roster lives in account keyspace, so the death writeback rides `context.task`.
 function killPowerCreep(creep: PowerCreep, context: ProcessorContext) {
 	const user = creep['#user'];
 	const id = creep.id;
@@ -56,10 +53,8 @@ declare module 'xxscreeps/engine/processor/index.js' {
 }
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
-	// A power spawn materializes a roster member on its own tile. The intent carries only the roster
-	// id; the claim atomically validates it against the authoritative roster and returns the stored
-	// entry, so identity and powers can't be forged and a duplicate or cooldown-lagged spawn finds
-	// nothing to claim.
+	// The intent carries only the roster id; `claimSpawn` validates it against the authoritative
+	// roster and returns the stored entry that seeds the room object.
 	registerIntentProcessor(StructurePowerSpawn, 'spawnPowerCreep', {}, (spawn, context, id: string) => {
 		if (checkMyStructure(spawn, StructurePowerSpawn) !== C.OK) {
 			return;
@@ -78,8 +73,6 @@ const intents = [
 
 	registerIntentProcessor(PowerCreep, 'drop', { before: 'transfer' }, processDrop),
 
-	// Fatigue-free movement: no body, no weight, no pull chains. A single move request resolves through
-	// the shared movement arbiter at a fixed priority.
 	registerIntentProcessor(PowerCreep, 'move', {}, (creep, context, direction: Direction) => {
 		if (checkCarrier(creep) === C.OK) {
 			const priority = 1 + (isHostileInSafeMode(creep) ? -500 : 0);
@@ -98,7 +91,6 @@ const intents = [
 
 	registerIntentProcessor(PowerCreep, 'withdraw', { before: 'pickup' }, processWithdraw),
 
-	// Renew at an adjacent power spawn or power bank, resetting the creep to a full lifetime.
 	registerIntentProcessor(PowerCreep, 'renew', {}, (creep, context, id: string) => {
 		const target = Game.getObjectById<StructurePowerSpawn | StructurePowerBank>(id)!;
 		if (checkRenew(creep, target) === C.OK) {
@@ -129,7 +121,7 @@ registerObjectPreTickProcessor(PowerCreep, (creep, context) => {
 });
 
 registerObjectTickProcessor(PowerCreep, (creep, context) => {
-	// Settle damage accumulated this tick (power creeps have no body to absorb it).
+	// Settle damage deferred by `#applyDamage`
 	const damage = creep.tickRawDamage ?? 0;
 	if (damage > 0) {
 		creep.hits = Math.max(0, creep.hits - damage);

--- a/packages/xxscreeps/mods/powercreep/schema.ts
+++ b/packages/xxscreeps/mods/powercreep/schema.ts
@@ -4,11 +4,9 @@ import { actionLogFormat, roomObjectShape } from 'xxscreeps/game/schema.js';
 import { openStoreFormat } from 'xxscreeps/mods/classic/resource/schema.js';
 import { declare, enumerated, optional, struct, variant, vector } from 'xxscreeps/schema/index.js';
 
-// A power creep is a `RoomObject` whether it is sitting in the account roster or spawned into a room,
-// so it gets a single serialized format. Unspawned creeps live at `RoomPosition(0, 0, 'E0S0')` (the
-// all-zero signed position); spawning is then just a matter of copying the object into a room. The
-// room-presence fields (`hits`/`store`/`#ageTime`/...) carry default/empty values until a spawn fills
-// them in.
+// One serialized format whether the creep is sitting in the account roster or spawned into a room.
+// Unspawned creeps live at `RoomPosition(0, 0, 'E0S0')` (the all-zero signed position); spawning
+// copies the object into a room.
 /** @internal */
 export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	...variant('powerCreep'),
@@ -35,7 +33,7 @@ export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	 * @public
 	 * @see https://docs.screeps.com/api/#PowerCreep.spawnCooldownTime
 	 */
-	// Wall-clock ms; set when a spawned creep dies, `0` while idle.
+	// Wall-clock ms, not game ticks
 	spawnCooldownTime: 'double',
 
 	/**
@@ -45,8 +43,7 @@ export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	 * @see https://docs.screeps.com/api/#PowerCreep.deleteTime
 	 */
 	deleteTime: 'double',
-	// Room presence — empty/`0` while unspawned, populated by a spawn into a room. On a roster entry
-	// a non-zero `#ageTime` marks the creep as currently spawned; death clears it back to `0`.
+	// Room presence — empty until a spawn fills them in
 	hits: 'int32',
 	store: openStoreFormat,
 	'#actionLog': actionLogFormat,

--- a/packages/xxscreeps/mods/powercreep/schema.ts
+++ b/packages/xxscreeps/mods/powercreep/schema.ts
@@ -1,9 +1,18 @@
+import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { roomObjectShape } from 'xxscreeps/game/schema.js';
-import { declare, enumerated, struct, vector } from 'xxscreeps/schema/index.js';
+import { actionLogFormat, roomObjectShape } from 'xxscreeps/game/schema.js';
+import { openStoreFormat } from 'xxscreeps/mods/classic/resource/schema.js';
+import { declare, enumerated, optional, struct, variant, vector } from 'xxscreeps/schema/index.js';
 
+// A power creep is a `RoomObject` whether it is sitting in the account roster or spawned into a room,
+// so it gets a single serialized format. Unspawned creeps live at `RoomPosition(0, 0, 'E0S0')` (the
+// all-zero signed position); spawning is then just a matter of copying the object into a room. The
+// room-presence fields (`hits`/`store`/`#ageTime`/...) carry default/empty values until a spawn fills
+// them in.
 /** @internal */
 export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
+	...variant('powerCreep'),
+
 	/**
 	 * Power creep’s name. You can choose the name while creating a new power creep, and it cannot be
 	 * changed later. This name is a hash key to access the creep via the
@@ -26,6 +35,7 @@ export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	 * @public
 	 * @see https://docs.screeps.com/api/#PowerCreep.spawnCooldownTime
 	 */
+	// Wall-clock ms; set when a spawned creep dies, `0` while idle.
 	spawnCooldownTime: 'double',
 
 	/**
@@ -35,4 +45,16 @@ export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	 * @see https://docs.screeps.com/api/#PowerCreep.deleteTime
 	 */
 	deleteTime: 'double',
+	// Room presence — empty/`0` while unspawned, populated by a spawn into a room. On a roster entry
+	// a non-zero `#ageTime` marks the creep as currently spawned; death clears it back to `0`.
+	hits: 'int32',
+	store: openStoreFormat,
+	'#actionLog': actionLogFormat,
+	'#ageTime': 'int32',
+	'#saying': optional(struct({
+		isPublic: 'bool',
+		message: 'string',
+		time: 'int32',
+	})),
+	'#user': Id.format,
 }));

--- a/packages/xxscreeps/mods/powercreep/schema.ts
+++ b/packages/xxscreeps/mods/powercreep/schema.ts
@@ -43,8 +43,20 @@ export const powerCreepShape = declare('PowerCreep', struct(roomObjectShape, {
 	 * @see https://docs.screeps.com/api/#PowerCreep.deleteTime
 	 */
 	deleteTime: 'double',
+
 	// Room presence — empty until a spawn fills them in
+	/**
+	 * The current amount of hit points of the creep.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.hits
+	 */
 	hits: 'int32',
+
+	/**
+	 * A [`Store`](https://docs.screeps.com/api/#Store) object that contains cargo of this creep.
+	 * @public
+	 * @see https://docs.screeps.com/api/#PowerCreep.store
+	 */
 	store: openStoreFormat,
 	'#actionLog': actionLogFormat,
 	'#ageTime': 'int32',

--- a/packages/xxscreeps/mods/powercreep/test.ts
+++ b/packages/xxscreeps/mods/powercreep/test.ts
@@ -3,7 +3,9 @@ import * as User from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition, getPositionInDirection } from 'xxscreeps/game/position.js';
-import { lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
+import { create as createConstructionSite } from 'xxscreeps/mods/classic/construction/construction-site.js';
+import { create as createRoad } from 'xxscreeps/mods/classic/road/road.js';
+import { lookForStructureAt, lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
 import { create as createPowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as Model from './model.js';
@@ -131,6 +133,7 @@ describe('PowerCreep spawned', () => {
 			room['#level'] = 8;
 			room['#user'] = room.controller!['#user'] = owner;
 		},
+		W2N1: () => {},
 	});
 
 	// Seed the account roster with a creep named Alice and return her id. Spawning claims the
@@ -219,6 +222,77 @@ describe('PowerCreep spawned', () => {
 		await tick();
 		await player(owner, Game => {
 			assert.strictEqual(Game.powerCreeps.Alice!.pos.isEqualTo(target), true);
+		});
+	}));
+
+	test('a spawned power creep crosses a room border', () => sim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await poke('W1N1', owner, (Game, room) => {
+			const alice = room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!;
+			room['#moveObject'](alice, new RoomPosition(0, 25, 'W1N1'));
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+		});
+		await peekRoom('W2N1', room => {
+			const alice = room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!;
+			assert.strictEqual(alice.pos.isEqualTo(49, 25), true);
+		});
+	}));
+
+	test('a moving power creep wears out roads', () => sim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		const target = getPositionInDirection(spawnPos, C.TOP)!;
+		let decayTime: number;
+		await poke('W1N1', owner, (Game, room) => {
+			const road = createRoad(target);
+			decayTime = road['#nextDecayTime'];
+			room['#insertObject'](road);
+		});
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.move(C.TOP), C.OK);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			const road = lookForStructureAt(room, target, C.STRUCTURE_ROAD)!;
+			assert.strictEqual(road['#nextDecayTime'], decayTime - C.ROAD_WEAROUT_POWER_CREEP);
+		});
+	}));
+
+	test('a moving power creep stomps hostile construction sites', () => sim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		const target = getPositionInDirection(spawnPos, C.TOP)!;
+		await poke('W1N1', owner, (Game, room) => {
+			const site = createConstructionSite(target, C.STRUCTURE_ROAD, hostile, 300);
+			site.progress = 100;
+			room['#insertObject'](site);
+		});
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.move(C.TOP), C.OK);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_CONSTRUCTION_SITES).length, 0);
+			// Half the progress hits the ground, minus the decay step of the tick it dropped in.
+			const dropped = room['#lookFor'](C.LOOK_RESOURCES)[0]!;
+			assert.strictEqual(dropped.amount, 49);
+			assert.strictEqual(dropped.pos.isEqualTo(target), true);
 		});
 	}));
 

--- a/packages/xxscreeps/mods/powercreep/test.ts
+++ b/packages/xxscreeps/mods/powercreep/test.ts
@@ -44,9 +44,9 @@ describe('mod/powercreep', () => {
 		assert.strictEqual(await Model.create(shard.db, owner, 'Alice', C.POWER_CLASS.OPERATOR), C.OK);
 		const creep = (await Model.loadRoster(shard.db, owner))[0]!;
 		assert.strictEqual(await Model.upgrade(shard.db, owner, creep.id, { [C.PWR_GENERATE_OPS]: 1 }), C.OK);
-		const updated = (await Model.loadRoster(shard.db, owner))[0]!;
-		assert.strictEqual(updated.level, 1);
-		assert.strictEqual(updated.powers[C.PWR_GENERATE_OPS]!.level, 1);
+		const updated = (await Model.loadRoster(shard.db, owner))[0];
+		assert.strictEqual(updated?.level, 1);
+		assert.strictEqual(updated.powers[C.PWR_GENERATE_OPS]?.level, 1);
 	}));
 
 	test('upgrade rejects an unreachable rank jump', () => sim(async ({ shard }) => {
@@ -159,9 +159,9 @@ describe('PowerCreep spawned', () => {
 		});
 		await tick();
 		await player(owner, Game => {
-			const alice = Game.powerCreeps.Alice!;
+			const alice = Game.powerCreeps.Alice;
 			assert.strictEqual(Game.powerCreeps.Forged, undefined);
-			assert.strictEqual(alice.room.name, 'W1N1');
+			assert.strictEqual(alice?.room.name, 'W1N1');
 			assert.strictEqual(alice.pos.isEqualTo(spawnPos), true);
 			assert.strictEqual(alice.ticksToLive, C.POWER_CREEP_LIFE_TIME);
 			assert.strictEqual(alice.hits, 1000);
@@ -178,7 +178,7 @@ describe('PowerCreep spawned', () => {
 		await tick();
 		await player(owner, Game => {
 			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
-			assert.strictEqual(Game.powerCreeps.Alice!.spawn(powerSpawn), C.ERR_BUSY);
+			assert.strictEqual(Game.powerCreeps.Alice?.spawn(powerSpawn), C.ERR_BUSY);
 		});
 	}));
 
@@ -191,7 +191,7 @@ describe('PowerCreep spawned', () => {
 		await tick();
 		await player(owner, Game => {
 			// Step off the power spawn so the tile guard can't mask the roster claim.
-			assert.strictEqual(Game.powerCreeps.Alice!.move(C.TOP), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.move(C.TOP), C.OK);
 		});
 		await tick();
 		await player(owner, Game => {
@@ -221,7 +221,7 @@ describe('PowerCreep spawned', () => {
 		});
 		await tick();
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.pos.isEqualTo(target), true);
+			assert.strictEqual(Game.powerCreeps.Alice?.pos.isEqualTo(target), true);
 		});
 	}));
 
@@ -241,8 +241,8 @@ describe('PowerCreep spawned', () => {
 			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
 		});
 		await peekRoom('W2N1', room => {
-			const alice = room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!;
-			assert.strictEqual(alice.pos.isEqualTo(49, 25), true);
+			const alice = room['#lookFor'](C.LOOK_POWER_CREEPS)[0];
+			assert.strictEqual(alice?.pos.isEqualTo(49, 25), true);
 		});
 	}));
 
@@ -261,12 +261,12 @@ describe('PowerCreep spawned', () => {
 			room['#insertObject'](road);
 		});
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.move(C.TOP), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.move(C.TOP), C.OK);
 		});
 		await tick();
 		await peekRoom('W1N1', room => {
-			const road = lookForStructureAt(room, target, C.STRUCTURE_ROAD)!;
-			assert.strictEqual(road['#nextDecayTime'], decayTime - C.ROAD_WEAROUT_POWER_CREEP);
+			const road = lookForStructureAt(room, target, C.STRUCTURE_ROAD);
+			assert.strictEqual(road?.['#nextDecayTime'], decayTime - C.ROAD_WEAROUT_POWER_CREEP);
 		});
 	}));
 
@@ -290,8 +290,8 @@ describe('PowerCreep spawned', () => {
 		await peekRoom('W1N1', room => {
 			assert.strictEqual(room['#lookFor'](C.LOOK_CONSTRUCTION_SITES).length, 0);
 			// Half the progress hits the ground, minus the decay step of the tick it dropped in.
-			const dropped = room['#lookFor'](C.LOOK_RESOURCES)[0]!;
-			assert.strictEqual(dropped.amount, 49);
+			const dropped = room['#lookFor'](C.LOOK_RESOURCES)[0];
+			assert.strictEqual(dropped?.amount, 49);
 			assert.strictEqual(dropped.pos.isEqualTo(target), true);
 		});
 	}));
@@ -307,11 +307,11 @@ describe('PowerCreep spawned', () => {
 			room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!.store['#add'](C.RESOURCE_ENERGY, 50);
 		});
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.drop(C.RESOURCE_ENERGY), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.drop(C.RESOURCE_ENERGY), C.OK);
 		});
 		await tick();
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.store[C.RESOURCE_ENERGY], 0);
+			assert.strictEqual(Game.powerCreeps.Alice?.store[C.RESOURCE_ENERGY], 0);
 		});
 	}));
 
@@ -329,11 +329,11 @@ describe('PowerCreep spawned', () => {
 		await player(owner, Game => {
 			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
 			assert.ok(Game.powerCreeps.Alice!.ticksToLive! < C.POWER_CREEP_LIFE_TIME);
-			assert.strictEqual(Game.powerCreeps.Alice!.renew(powerSpawn), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.renew(powerSpawn), C.OK);
 		});
 		await tick();
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.ticksToLive, C.POWER_CREEP_LIFE_TIME);
+			assert.strictEqual(Game.powerCreeps.Alice?.ticksToLive, C.POWER_CREEP_LIFE_TIME);
 		});
 	}));
 
@@ -345,7 +345,7 @@ describe('PowerCreep spawned', () => {
 		});
 		await tick();
 		await player(owner, Game => {
-			assert.strictEqual(Game.powerCreeps.Alice!.suicide(), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.suicide(), C.OK);
 		});
 		await tick();
 		await peekRoom('W1N1', room => {

--- a/packages/xxscreeps/mods/powercreep/test.ts
+++ b/packages/xxscreeps/mods/powercreep/test.ts
@@ -1,11 +1,16 @@
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
+import * as Id from 'xxscreeps/engine/schema/id.js';
 import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition, getPositionInDirection } from 'xxscreeps/game/position.js';
+import { lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
+import { create as createPowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as Model from './model.js';
 import { createPowerCreep, read, write } from './powercreep.js';
 
 const owner = '100';
+const hostile = '101';
 
 // GPL level = floor(sqrt(power / 1000)): 1000 -> 1, 4000 -> 2, 9000 -> 3.
 const setPower = (db: Database, power: number) => db.data.hSet(User.infoKey(owner), 'power', `${power}`);
@@ -98,7 +103,7 @@ describe('mod/powercreep', () => {
 	}));
 
 	test('the stored object round-trips its powers through the blob', () => {
-		const creep = createPowerCreep('a', 'Alice', C.POWER_CLASS.OPERATOR);
+		const creep = createPowerCreep('a', 'Alice', C.POWER_CLASS.OPERATOR, owner);
 		creep['#powers'] = [ { power: C.PWR_GENERATE_OPS, level: 2 } ];
 		const [ view ] = read(write([ creep ]));
 		assert.strictEqual(view!.level, 2);
@@ -115,5 +120,229 @@ describe('mod/powercreep', () => {
 		]);
 		const names = (await Model.loadRoster(shard.db, owner)).map(creep => creep.name).sort();
 		assert.deepStrictEqual(names, [ 'Alice', 'Bob' ]);
+	}));
+});
+
+describe('PowerCreep spawned', () => {
+	const spawnPos = new RoomPosition(25, 25, 'W1N1');
+	const sim = simulate({
+		W1N1: room => {
+			room['#insertObject'](createPowerSpawn(spawnPos, owner));
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = owner;
+		},
+	});
+
+	// Seed the account roster with a creep named Alice and return her id. Spawning claims the
+	// authoritative roster entry, so every spawned creep starts from one.
+	const createAlice = async (db: Database) => {
+		await setPower(db, 1000);
+		await Model.create(db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
+		const [ created ] = await Model.loadRoster(db, owner);
+		return created!.id;
+	};
+
+	// The harness never materializes the account roster into the runtime, so the roster member is
+	// reconstructed inline and spawned through the real intent path; the intent carries only the
+	// roster id, and once processed the creep is a normal room object reachable through
+	// `Game.powerCreeps`.
+	test('spawn places the creep on the power spawn with a full lifetime', () => sim(async ({ player, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			const forged = createPowerCreep(id, 'Forged', C.POWER_CLASS.OPERATOR, owner);
+			forged['#powers'] = [ { power: C.PWR_GENERATE_OPS, level: 5 } ];
+			assert.strictEqual(forged.spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const alice = Game.powerCreeps.Alice!;
+			assert.strictEqual(Game.powerCreeps.Forged, undefined);
+			assert.strictEqual(alice.room.name, 'W1N1');
+			assert.strictEqual(alice.pos.isEqualTo(spawnPos), true);
+			assert.strictEqual(alice.ticksToLive, C.POWER_CREEP_LIFE_TIME);
+			assert.strictEqual(alice.hits, 1000);
+			assert.deepStrictEqual(alice.powers, {});
+		});
+	}));
+
+	test('spawn on an already-spawned creep returns ERR_BUSY', () => sim(async ({ player, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(Game.powerCreeps.Alice!.spawn(powerSpawn), C.ERR_BUSY);
+		});
+	}));
+
+	test('a second spawn cannot claim an already-spawned roster entry', () => sim(async ({ player, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			// Step off the power spawn so the tile guard can't mask the roster claim.
+			assert.strictEqual(Game.powerCreeps.Alice!.move(C.TOP), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			// A room-less inline handle passes the runtime checks; the roster entry is already claimed.
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 1);
+		});
+	}));
+
+	test('a spawned power creep moves without fatigue', () => sim(async ({ player, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		let target: RoomPosition;
+		await player(owner, Game => {
+			const alice = Game.powerCreeps.Alice!;
+			// Step off the power spawn, into open terrain.
+			target = getPositionInDirection(alice.pos, C.TOP)!;
+			assert.strictEqual(alice.move(C.TOP), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.pos.isEqualTo(target), true);
+		});
+	}));
+
+	test('a spawned power creep drops a carried resource', () => sim(async ({ player, poke, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await poke('W1N1', owner, (Game, room) => {
+			room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!.store['#add'](C.RESOURCE_ENERGY, 50);
+		});
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.drop(C.RESOURCE_ENERGY), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.store[C.RESOURCE_ENERGY], 0);
+		});
+	}));
+
+	test('renew at the power spawn resets the lifetime', () => sim(async ({ player, poke, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		// Age the creep partway down so the renew is observable.
+		await poke('W1N1', owner, (Game, room) => {
+			room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!['#ageTime'] = shard.time + 100;
+		});
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.ok(Game.powerCreeps.Alice!.ticksToLive! < C.POWER_CREEP_LIFE_TIME);
+			assert.strictEqual(Game.powerCreeps.Alice!.renew(powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.ticksToLive, C.POWER_CREEP_LIFE_TIME);
+		});
+	}));
+
+	test('suicide leaves a tombstone and starts the respawn cooldown', () => sim(async ({ player, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.powerCreeps.Alice!.suicide(), C.OK);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_TOMBSTONES).length, 1);
+		});
+		const [ entry ] = await Model.loadRoster(shard.db, owner);
+		assert.ok(entry!.spawnCooldownTime > Date.now());
+	}));
+
+	test('spawn is rejected while a roster spawn cooldown is still pending', () => sim(async ({ player, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		// A recent death's cooldown writeback the runtime has not seen yet.
+		await Model.setSpawnCooldown(shard.db, owner, id, Date.now() + C.POWER_CREEP_SPAWN_COOLDOWN);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			// The inline runtime creep carries a stale cooldown of 0, so the runtime check passes; the
+			// roster claim must reject it against the authoritative cooldown.
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+		});
+	}));
+
+	test('age-out leaves a tombstone and starts the respawn cooldown', () => sim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await poke('W1N1', owner, (Game, room) => {
+			room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!['#ageTime'] = shard.time + 1;
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_TOMBSTONES).length, 1);
+		});
+		const [ entry ] = await Model.loadRoster(shard.db, owner);
+		assert.ok(entry!.spawnCooldownTime > Date.now());
+	}));
+
+	test('lethal damage routes death through the tombstone + respawn cooldown', () => sim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		// Ranged mass attack reaches this through `#applyDamage` → tick settlement; drive hits to
+		// zero directly.
+		await poke('W1N1', owner, (Game, room) => {
+			room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!.hits = 0;
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_TOMBSTONES).length, 1);
+		});
+		const [ entry ] = await Model.loadRoster(shard.db, owner);
+		assert.ok(entry!.spawnCooldownTime > Date.now());
+	}));
+
+	test('spawning a creep you do not own is rejected', () => sim(async ({ player }) => {
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			// A creep owned by another player cannot be spawned, even at your own power spawn.
+			assert.strictEqual(createPowerCreep(Id.generateId(), 'Wrong', C.POWER_CLASS.OPERATOR, hostile).spawn(powerSpawn), C.ERR_NOT_OWNER);
+		});
 	}));
 });


### PR DESCRIPTION
Adds the spawned power creep room form on top of the account layer. The spawn intent carries only the roster id; the processor atomically claims the authoritative unspawned entry and seeds the on-tile room object from its stored identity and powers. Spawn, movement, carry/store verbs, say, renew, suicide, aging, tombstones, and account cooldown writeback are included; applying learned powers remains a follow-up.

Power creeps share the classic creep processor arms for movement and carry/store behavior, including border crossing, road wear-out, hostile construction-site removal, and safe-mode movement priority.

## Scope and design notes

- Combat targeting and healing are follow-up work. `AttackTarget` and the heal verbs still exclude power creeps, apart from ranged mass attack reaching `#applyDamage`; the post-heal `hitsMax` clamp belongs with that integration.
- `notifyWhenAttacked` was deferred instead of leaving a write-only surface. It should return with combat integration, wired through the notifications mod's attack-notify path.
- The `classic/creep/processor.ts` extraction is behavior-identical substrate used by the power creep verbs. It can be split into a preliminary PR if that makes the review easier.
- The `PowerCreep.memory` setter still mirrors Creep's `??=` behavior. Vanilla assigns unconditionally, but changing only one class would fork the two APIs; both should change together in a separate PR, if at all.
- Vanilla power creep tombstones expose `powerCreep*` fields. `extend()` in `utility/utility.ts` is the established mechanism for adding public API members to a foreign class, so the getter half is solved. The remaining issue is structural: the creep-owned tombstone occupant schema is fixed, and `bindRenderer` has a single owner. This PR therefore keeps the current creep-shaped occupant pending a design that also composes cleanly with #301.

## Validation

- `pnpm run build` passed.
- The default suite passed 498/498 tests, and `npm test -- --private-transform=isolated-vm` passed 499/499 tests.
- ESLint reported zero errors and zero new warnings across all 11 changed TypeScript files.
- The rebased worktree was live-smoked on a worktree-native imported world against Redis 8.4. The same roster id was submitted to two active power spawns; exactly one on-tile entity materialized with the roster-stored name, class, level, and powers and a claimed `#ageTime`. It crossed W7N7 to W8N7, then suicide left one tombstone and wrote back a future cooldown while clearing `#ageTime` and the pending deletion marker. The server shut down cleanly.
