### PR TITLE
user: seed a no-op script on account creation

### DIFF
--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -1,6 +1,6 @@
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { branchManifestKey, buffersKey, stringsKey } from './code.js';
+import { branchManifestKey, buffersKey, saveContent, stringsKey } from './code.js';
 
 const providerMembersKey = (provider: string) => `usersByProvider/${provider}`;
 const userProvidersKey = (userId: string) => `user/${userId}/provider`;
@@ -52,6 +52,11 @@ export async function create(db: Database, userId: string, username: string, pro
 		...Fn.map(allProviders, ({ provider, id }) =>
 			db.data.hSet(providerMembersKey(provider), id, userId)),
 	]);
+
+	// A user with no committed code makes the runner throw "Cannot find module 'main'" every
+	// tick once it owns any room object. Seed an empty, valid script so ticking is a no-op until
+	// the player commits real code.
+	await saveContent(db, userId, 'main', new Map([ [ 'main', 'module.exports.loop = function () {};' ] ]));
 }
 
 /**

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -53,9 +53,6 @@ export async function create(db: Database, userId: string, username: string, pro
 			db.data.hSet(providerMembersKey(provider), id, userId)),
 	]);
 
-	// A user with no committed code makes the runner throw "Cannot find module 'main'" every
-	// tick once it owns any room object. Seed an empty, valid script so ticking is a no-op until
-	// the player commits real code.
 	await saveContent(db, userId, 'main', new Map([ [ 'main', 'module.exports.loop = function () {};' ] ]));
 }
 


### PR DESCRIPTION
## Summary
- New accounts never had any code committed, so once they own a room object the runner throws `Error: Cannot find module 'main'` on every single tick (logged to console each time).
- `User.create` now seeds an empty `module.exports.loop = function () {};` on branch `main`, matching the `main` branch convention already used elsewhere (`kDefaultBranch` in `backend/endpoints/user/code.ts`, and the test sandbox in `simulate.ts`). Ticking is now a silent no-op until the player commits real code.
- Callers that push real code right after `User.create` (the `manage.ts` bot CLI, `simulate.ts`) simply overwrite this branch's content, so no behavior change for them.
