### PR TITLE
construction: reject sites in rooms reserved by another player

### DIFF
--- a/.changeset/hungry-moons-shake.md
+++ b/.changeset/hungry-moons-shake.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+createConstructionSite returns ERR_NOT_OWNER in rooms reserved by another player

--- a/packages/xxscreeps/mods/construction/room.ts
+++ b/packages/xxscreeps/mods/construction/room.ts
@@ -2,7 +2,7 @@ import type { ConstructibleStructureType } from './construction-site.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import * as C from 'xxscreeps/game/constants/index.js';
-import { hooks, intents, userGame } from 'xxscreeps/game/index.js';
+import { Game, hooks, intents, me, userGame } from 'xxscreeps/game/index.js';
 import { RoomPosition, fetchArguments } from 'xxscreeps/game/position.js';
 import { Room, registerFindHandlers, registerLook } from 'xxscreeps/game/room/index.js';
 import { Structure } from 'xxscreeps/mods/structure/structure.js';
@@ -101,9 +101,12 @@ export function checkCreateConstructionSite(room: Room, pos: RoomPosition, struc
 		return C.ERR_INVALID_ARGS;
 	}
 
-	// Can't build in someone else's room
+	// Can't build in someone else's room, owned or reserved
 	const { controller } = room;
 	if (controller?.my === false) {
+		return C.ERR_NOT_OWNER;
+	}
+	if (controller && controller['#reservationEndTime'] > Game.time && room['#user'] !== me) {
 		return C.ERR_NOT_OWNER;
 	}
 

--- a/packages/xxscreeps/mods/construction/test.ts
+++ b/packages/xxscreeps/mods/construction/test.ts
@@ -137,6 +137,35 @@ describe('Construction', () => {
 			});
 		}));
 
+		const foreignReserved = simulate({
+			W1N1: room => {
+				room['#user'] = '101';
+				room.controller!['#reservationEndTime'] = 100;
+				room['#insertObject'](createCreep(new RoomPosition(20, 20, room.name), [ C.MOVE ], 'visitor', '100'));
+			},
+		});
+
+		test('CONSTRUCTION-SITE-014:reserved-not-owner-before-rcl-or-structure-cap', () => foreignReserved(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1!.createConstructionSite(25, 25, 'road'), C.ERR_NOT_OWNER);
+				assert.strictEqual(Game.rooms.W1N1!.createConstructionSite(25, 25, 'tower'), C.ERR_NOT_OWNER);
+			});
+		}));
+
+		const selfReserved = simulate({
+			W1N1: room => {
+				room['#user'] = '100';
+				room.controller!['#reservationEndTime'] = 100;
+				room['#insertObject'](createCreep(new RoomPosition(20, 20, room.name), [ C.MOVE ], 'visitor', '100'));
+			},
+		});
+
+		test('CONSTRUCTION-SITE-014:reserved-by-self-allowed', () => selfReserved(async ({ player }) => {
+			await player('100', Game => {
+				assert.strictEqual(Game.rooms.W1N1!.createConstructionSite(25, 25, 'road'), C.OK);
+			});
+		}));
+
 		const foreignOwnedAndFull = simulate({
 			W1N1: room => setupForeignRoom(room),
 			W2N1: room => {


### PR DESCRIPTION
`checkCreateConstructionSite` rejected hostile-owned rooms but not hostile-reserved ones: an unowned controller reads `my === undefined`, so a foreign reservation fell through to the RCL checks and roads/containers were placeable in reserved rooms.

## Validation

- New tests: a room reserved by another player returns `ERR_NOT_OWNER` for road and tower, ahead of the RCL/structure-cap checks; a self-reserved room still allows a road site.
- screeps-ok `CONSTRUCTION-SITE-014` (reserved controller returns `ERR_NOT_OWNER` for every structure type) passes with this branch; the rest of the construction/build catalog files are unchanged.
- Full xxscreeps test suite passing (462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)