### PR TITLE
memory: clear pending foreign-segment request on setActiveForeignSegment(null)

### DIFF
--- a/.changeset/foreign-segment-clear.md
+++ b/.changeset/foreign-segment-clear.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Clear the pending foreign-segment request when `RawMemory.setActiveForeignSegment(null)` is called.

--- a/packages/xxscreeps/mods/memory/driver.ts
+++ b/packages/xxscreeps/mods/memory/driver.ts
@@ -126,7 +126,7 @@ hooks.register('runnerConnector', player => {
 
 				// Resolve + persist the foreign-segment request, then re-subscribe.
 				async function() {
-					if (payload.foreignSegmentRequest) {
+					if (payload.foreignSegmentRequest !== undefined) {
 						activeForeignSegment = await saveActiveForeignSegment(shard, userId, activeForeignSegment, payload.foreignSegmentRequest);
 						await syncForeignSubscription();
 					}


### PR DESCRIPTION
`RawMemory.setActiveForeignSegment(null)` flushes a `null` clear-request through
`foreignSegmentRequest`, but the driver consumed it with a truthy check
(`if (payload.foreignSegmentRequest)`), so `null` was dropped and treated the same as
"no call this tick". The stored `activeForeignSegment` was never cleared and
`RawMemory.foreignSegment` stayed populated on the following tick.

`!== undefined` lets the `null` reach `saveActiveForeignSegment`, which already clears
the stored request — matching the sibling `defaultPublicSegmentUpdate` /
`publicSegmentsUpdate` consumers in the same block.

## Validation

- RAWMEMORY-FOREIGN-006 (setActiveForeignSegment(null) clears the pending request) —
  now passes; fails at the next-tick assertion when the fix is reverted.