### PR TITLE
creep: complete the Tombstone.creep deceased-creep surface

### DIFF
--- a/.changeset/tombstone-creep-body-shape.md
+++ b/.changeset/tombstone-creep-body-shape.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+`Tombstone.creep` exposes `{ type, hits }` body, `spawning`, an empty carry-sized `store`, and `saying`.

--- a/packages/xxscreeps/mods/creep/backend.ts
+++ b/packages/xxscreeps/mods/creep/backend.ts
@@ -1,6 +1,5 @@
 import { bindMapRenderer, bindRenderer } from 'xxscreeps/backend/index.js';
 import { renderActionLog } from 'xxscreeps/backend/sockets/render.js';
-import { me } from 'xxscreeps/game/index.js';
 import { renderStore } from 'xxscreeps/mods/resource/backend.js';
 import { Creep } from './creep.js';
 import { Tombstone } from './tombstone.js';
@@ -38,9 +37,6 @@ bindRenderer(Creep, (creep, next, previousTime) => {
 
 bindRenderer(Tombstone, (tombstone, next) => {
 	const creep = tombstone['#creep'];
-	const saying = creep.saying;
-	const creepSaying = saying && (saying.isPublic || creep.user === me)
-		? saying.message : undefined;
 	return {
 		...next(),
 		...renderStore(tombstone.store),
@@ -48,7 +44,7 @@ bindRenderer(Tombstone, (tombstone, next) => {
 		creepId: creep.id,
 		creepName: creep.name,
 		creepTicksToLive: creep.ticksToLive,
-		creepSaying,
+		creepSaying: creep.saying,
 		deathTime: tombstone.deathTime,
 		decayTime: tombstone['#decayTime'],
 		user: creep.user,

--- a/packages/xxscreeps/mods/creep/tombstone.ts
+++ b/packages/xxscreeps/mods/creep/tombstone.ts
@@ -1,5 +1,6 @@
 import type { ResourceType } from 'xxscreeps/mods/resource/resource.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomObject, create as createObject, format as objectFormat, requiredExpiryTime } from 'xxscreeps/game/object.js';
@@ -17,11 +18,7 @@ const shape = struct(objectFormat, {
 		body: vector(enumerated(...C.BODYPARTS_ALL)),
 		id: Id.format,
 		name: 'string',
-		saying: optional(struct({
-			isPublic: 'bool',
-			message: 'string',
-			time: 'int32',
-		})),
+		saying: optional('string'),
 		ticksToLive: 'int32',
 		user: Id.format,
 	}),
@@ -50,14 +47,17 @@ export class Tombstone extends withOverlay(RoomObject, shape) {
 	get creep() {
 		const creep = new Creep();
 		const creepInfo = this['#creep'];
+		const carryCapacity = Fn.accumulate(creepInfo.body, type => type === C.CARRY ? C.CARRY_CAPACITY : 0);
 		creep['#posId'] = this['#posId'];
 		creep['#user'] = creepInfo.user;
 		Object.defineProperties(creep, {
-			body: { enumerable: true, get: () => creepInfo.body },
+			body: { enumerable: true, value: creepInfo.body.map(type => ({ type, hits: 0 })) },
 			id: { enumerable: true, get: () => creepInfo.id },
 			name: { enumerable: true, get: () => creepInfo.name },
 			pos: { enumerable: true, get: () => this.pos },
-			store: { enumerable: true, get: () => this.store },
+			saying: { enumerable: true, value: creepInfo.saying },
+			spawning: { enumerable: true, value: false },
+			store: { enumerable: true, value: OpenStore['#create'](carryCapacity) },
 			ticksToLive: { enumerable: true, get: () => creepInfo.ticksToLive },
 		});
 		Object.defineProperty(this, 'creep', { value: creep });
@@ -105,11 +105,12 @@ export function buryCreep(creep: Creep, rate = C.CREEP_CORPSE_RATE) {
 		for (const [ type, amount ] of creep.store['#entries']()) deposit(type, amount);
 	}
 
+	const saying = creep['#saying'];
 	tombstone['#creep'] = {
 		body: creep.body.map(bodyPart => bodyPart.type),
 		id: creep.id,
 		name: creep.name,
-		saying: creep['#saying'],
+		saying: saying?.isPublic && saying.time === Game.time ? saying.message : undefined,
 		ticksToLive: creep.ticksToLive!,
 		user: creep['#user'],
 	};


### PR DESCRIPTION
## Summary
`Tombstone.creep` exposed only a partial creep — `body` as raw part-type strings and a `store` that aliased the tombstone's own store — and inherited getters misfire on the bufferless fake creep (`spawning` reads `#ageTime === 0` → true; `saying` is gated on `time === Game.time`). Widen the getter to `{ type, hits }` body parts, `spawning: false`, and an empty `store` sized to the body's carry capacity. `saying` is gated at bury time to the public death-tick message — a private or stale saying isn't memorialized — shrinking the stored `#creep` saying from a struct to a string; the getter and backend renderer forward it raw.

## Validation
screeps-ok tombstone parity (`18.1-tombstone.test.ts`, 18/18): closed TOMBSTONE-006/-010/-016/-017/-018; -012 (±1-tolerant ticksToLive) stays green.
