### PR TITLE
schema: store layout archives in the database

### DIFF
--- a/.changeset/schema-archives-in-database.md
+++ b/.changeset/schema-archives-in-database.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Store schema archives in the database instead of the filesystem. Every persistent store is now self-describing: previous schema versions needed to upgrade old blobs are preloaded from `schema/{name}` hash keys on connect, and archives found in the legacy `schemaArchive` directory are imported automatically. The generated `.ksy` Kaitai documentation files are no longer written.

--- a/.changeset/schema-archives-in-database.md
+++ b/.changeset/schema-archives-in-database.md
@@ -2,4 +2,4 @@
 "xxscreeps": patch
 ---
 
-Store schema archives in the database instead of the filesystem. Every persistent store is now self-describing: previous schema versions needed to upgrade old blobs are preloaded from `schema/{name}` hash keys on connect, and archives found in the legacy `schemaArchive` directory are imported automatically. The generated `.ksy` Kaitai documentation files are no longer written.
+Store schema archives in the database instead of the filesystem.

--- a/packages/xxscreeps/config/config.schema.json
+++ b/packages/xxscreeps/config/config.schema.json
@@ -166,7 +166,7 @@
         },
         "schemaArchive": {
             "default": "./screeps/archive",
-            "description": "Where to save descriptions of the binary format used to write game data.",
+            "description": "Directory of schema archives written by previous versions of the server. These are imported into the database when connecting, after which the directory is no longer needed.",
             "type": "string"
         },
         "shards": {

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -231,7 +231,8 @@ export interface Config {
 	runner?: RunnerConfig;
 
 	/**
-	 * Where to save descriptions of the binary format used to write game data.
+	 * Directory of schema archives written by previous versions of the server. These are imported
+	 * into the database when connecting, after which the directory is no longer needed.
 	 * @default ./screeps/archive
 	 */
 	schemaArchive?: string | undefined;

--- a/packages/xxscreeps/engine/db/database.ts
+++ b/packages/xxscreeps/engine/db/database.ts
@@ -1,6 +1,7 @@
 import type { KeyValProvider, PubSubProvider } from 'xxscreeps/engine/db/storage/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import { connectToProvider } from 'xxscreeps/engine/db/storage/index.js';
+import { initializeSchemaArchive } from 'xxscreeps/engine/schema/build/index.js';
 import { acquireWith } from 'xxscreeps/utility/async.js';
 import { AsyncDisposableResource } from 'xxscreeps/utility/utility.js';
 
@@ -26,6 +27,7 @@ export class Database extends AsyncDisposableResource {
 			connectToProvider(info.data, 'keyval'),
 			connectToProvider(info.pubsub, 'pubsub'),
 		);
+		await initializeSchemaArchive(data);
 		return new Database(disposable.move(), data, pubsub);
 	}
 

--- a/packages/xxscreeps/engine/db/shard.ts
+++ b/packages/xxscreeps/engine/db/shard.ts
@@ -5,6 +5,7 @@ import type { Room } from 'xxscreeps/game/room/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as RoomSchema from 'xxscreeps/engine/db/room.js';
 import { connectToProvider } from 'xxscreeps/engine/db/storage/index.js';
+import { initializeSchemaArchive } from 'xxscreeps/engine/schema/build/index.js';
 import { World, upgradeTerrain } from 'xxscreeps/game/map.js';
 import { acquireWith } from 'xxscreeps/utility/async.js';
 import { AsyncDisposableResource } from 'xxscreeps/utility/utility.js';
@@ -68,6 +69,7 @@ export class Shard extends AsyncDisposableResource {
 			connectToProvider(info.pubsub, 'pubsub'),
 			connectToProvider(info.scratch, 'keyval'),
 		);
+		await initializeSchemaArchive(data);
 		const channel = disposable.adopt(
 			await new Channel<Message>(pubsub, 'channel/game').subscribe(),
 			subscription => subscription.disconnect(),

--- a/packages/xxscreeps/engine/db/storage/local/responder.ts
+++ b/packages/xxscreeps/engine/db/storage/local/responder.ts
@@ -1,6 +1,7 @@
 import type { LocalPayloadPort, UnknownMessage, WorkerConnectMessage } from './port.js';
 import type { Worker } from 'node:worker_threads';
 import type { MaybePromise } from 'xxscreeps/utility/types.js';
+import * as fs from 'node:fs/promises';
 import { parentPort } from 'node:worker_threads';
 import { config, configPath } from 'xxscreeps/config/index.js';
 import { isTopThread } from 'xxscreeps/engine/service/index.js';
@@ -24,6 +25,7 @@ export const isSiblingProcess = runOnce(async () => {
 		} else {
 			try {
 				const path = new URL(lock, configPath);
+				await fs.mkdir(new URL('.', path), { recursive: true });
 				process.on('exit', disposableToEffect(await FileSystemLock.acquire(path)));
 				return false;
 			} catch {

--- a/packages/xxscreeps/engine/schema/build/index.ts
+++ b/packages/xxscreeps/engine/schema/build/index.ts
@@ -37,6 +37,7 @@ const loadLegacySchemas = runOnce(() => {
 			try {
 				return fs.readdirSync(archivePath);
 			} catch {
+				// Legacy archive directory does not exist on fresh or already-migrated deployments
 				return [];
 			}
 		}();
@@ -77,19 +78,21 @@ export async function initializeSchemaArchive(keyval: KeyValProvider) {
 		for (const [ version, archive ] of Object.entries(archived)) {
 			archivedSchemas.set(archiveId(info.name, version), archive);
 		}
-		// Seed archives from the legacy `schemaArchive` directory
+		// Seed the current version plus any archives found in the legacy `schemaArchive` directory
+		const writes: Promise<boolean>[] = [];
 		const legacy = loadLegacySchemas().get(info.name.toLowerCase());
 		if (legacy) {
-			await Promise.all(Fn.map(legacy, async ([ version, archive ]) => {
+			for (const [ version, archive ] of legacy) {
 				if (!(version in archived)) {
 					archivedSchemas.set(archiveId(info.name, version), archive);
-					await keyval.hSet(key, version, archive, { if: 'NX' });
+					writes.push(keyval.hSet(key, version, archive, { if: 'NX' }));
 				}
-			}));
+			}
 		}
 		if (info.archive !== '?' && !(info.version in archived)) {
-			await keyval.hSet(key, `${info.version}`, info.archive, { if: 'NX' });
+			writes.push(keyval.hSet(key, `${info.version}`, info.archive, { if: 'NX' }));
 		}
+		await Promise.all(writes);
 	}));
 }
 

--- a/packages/xxscreeps/engine/schema/build/index.ts
+++ b/packages/xxscreeps/engine/schema/build/index.ts
@@ -1,24 +1,23 @@
+import type { KeyValProvider } from 'xxscreeps/engine/db/storage/provider.js';
 import type { Package } from 'xxscreeps/schema/build.js';
 import type { BufferView, Format } from 'xxscreeps/schema/index.js';
-import * as fsSync from 'node:fs';
-import * as fs from 'node:fs/promises';
-import { config, configPath } from 'xxscreeps/config/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { restoreLayout } from 'xxscreeps/schema/archive.js';
 import { build as buildSchema } from 'xxscreeps/schema/build.js';
 import { Builder } from 'xxscreeps/schema/index.js';
-import { archiveStruct } from 'xxscreeps/schema/kaitai.js';
 import { initializeView, makeViewReader } from 'xxscreeps/schema/read.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
 
-const archivePath = new URL(`${config.schemaArchive}/`, configPath);
-const archivedReaders = new Map<number, Promise<(view: BufferView) => unknown>>();
+const archivedSchemas = new Map<string, string>();
+const archivedReaders = new Map<string, (view: BufferView) => any>();
 const packages = new Map<string, Package>();
 
-function makeArchivePath(name: string, version: number, ext = 'js') {
-	const versionId = version.toString(16).padStart(8, '0').split(/(?<hex>[0-9a-f]{2})/).reverse().join('');
-	const pathFragment = `${name.toLowerCase()}-${versionId}`;
-	return new URL(`./${pathFragment}.${ext}`, archivePath);
+function archiveId(name: string, version: number | string) {
+	return `${name}#${version}`;
+}
+
+function schemaKey(name: string) {
+	return `schema/${name.toLowerCase()}`;
 }
 
 /**
@@ -27,19 +26,28 @@ function makeArchivePath(name: string, version: number, ext = 'js') {
  */
 export function build<Type extends Format>(format: Type, cache = new Map()) {
 	const result = buildSchema(format, cache);
-	const file = makeArchivePath(result.name, result.version);
-	fsSync.mkdirSync(archivePath, { recursive: true });
-	try {
-		fsSync.statSync(file);
-	} catch {
-		fsSync.writeFileSync(file, result.archive);
-		fsSync.writeFileSync(makeArchivePath(result.name, result.version, 'ksy'), archiveStruct(result.layout, result.version));
-	}
-	packages.set(result.name, {
-		...result,
-		archive: '?',
-	});
+	packages.set(result.name, result);
+	archivedSchemas.set(archiveId(result.name, result.version), result.archive);
 	return result;
+}
+
+/**
+ * Synchronizes schema archives with the given keyval provider. Archives of previous schema
+ * versions are loaded into memory for use by `makeUpgrader`, and the current version of each
+ * package is stored if it's not already known. This runs when connecting to a database or shard so
+ * that every persistent store carries the schemas needed to read its own blobs.
+ */
+export async function initializeSchemaArchive(keyval: KeyValProvider) {
+	await Promise.all(Fn.map(packages.values(), async info => {
+		const key = schemaKey(info.name);
+		const archived = await keyval.hGetAll(key);
+		for (const [ version, archive ] of Object.entries(archived)) {
+			archivedSchemas.set(archiveId(info.name, version), archive);
+		}
+		if (info.archive !== '?' && !(info.version in archived)) {
+			await keyval.hSet(key, `${info.version}`, info.archive, { if: 'NX' });
+		}
+	}));
 }
 
 /**
@@ -53,14 +61,11 @@ export function makeUpgrader(info: Package, write: (value: any) => Readonly<Uint
 		if (expectedVersion === version) {
 			return buffer;
 		} else {
-			const reader = await getOrSet(archivedReaders, version, async () => {
-				const archive = await async function() {
-					try {
-						return await fs.readFile(makeArchivePath(name, version), 'utf8');
-					} catch {
-						throw new Error(`No archived schema found for ${name} ${version}`);
-					}
-				}();
+			const reader = getOrSet(archivedReaders, archiveId(name, version), () => {
+				const archive = archivedSchemas.get(archiveId(name, version));
+				if (archive === undefined) {
+					throw new Error(`No archived schema found for ${name} ${version}`);
+				}
 				const layout = restoreLayout(archive, info.layout);
 				return makeViewReader({ layout, version }, new Builder({ materialize: true }));
 			});

--- a/packages/xxscreeps/engine/schema/build/index.ts
+++ b/packages/xxscreeps/engine/schema/build/index.ts
@@ -1,11 +1,14 @@
 import type { KeyValProvider } from 'xxscreeps/engine/db/storage/provider.js';
 import type { Package } from 'xxscreeps/schema/build.js';
 import type { BufferView, Format } from 'xxscreeps/schema/index.js';
+import * as fs from 'node:fs';
+import { config, configPath } from 'xxscreeps/config/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { restoreLayout } from 'xxscreeps/schema/archive.js';
 import { build as buildSchema } from 'xxscreeps/schema/build.js';
 import { Builder } from 'xxscreeps/schema/index.js';
 import { initializeView, makeViewReader } from 'xxscreeps/schema/read.js';
+import { runOnce } from 'xxscreeps/utility/memoize.js';
 import { getOrSet } from 'xxscreeps/utility/utility.js';
 
 const archivedSchemas = new Map<string, string>();
@@ -19,6 +22,36 @@ function archiveId(name: string, version: number | string) {
 function schemaKey(name: string) {
 	return `schema/${name.toLowerCase()}`;
 }
+
+/**
+ * Reads schema archives written to `config.schemaArchive` by previous versions of the server,
+ * keyed by lower-cased package name and version. These are seeded into the database by
+ * `initializeSchemaArchive` so existing deployments keep their upgrade history without carrying
+ * the archive directory around.
+ */
+const loadLegacySchemas = runOnce(() => {
+	const legacySchemas = new Map<string, Map<string, string>>();
+	if (config.schemaArchive) {
+		const archivePath = new URL(`${config.schemaArchive}/`, configPath);
+		const files = function() {
+			try {
+				return fs.readdirSync(archivePath);
+			} catch {
+				return [];
+			}
+		}();
+		for (const file of files) {
+			const match = /^(?<name>.+)-(?<version>[0-9a-f]{8})\.js$/.exec(file);
+			if (match) {
+				// File names encode the version as little-endian hex
+				const version = parseInt(match.groups!.version!.match(/[0-9a-f]{2}/g)!.reverse().join(''), 16);
+				const versions = getOrSet(legacySchemas, match.groups!.name!, () => new Map<string, string>());
+				versions.set(`${version}`, fs.readFileSync(new URL(file, archivePath), 'utf8'));
+			}
+		}
+	}
+	return legacySchemas;
+});
 
 /**
  * Builds a schema package from a format and retains the result which can be used later within the
@@ -43,6 +76,16 @@ export async function initializeSchemaArchive(keyval: KeyValProvider) {
 		const archived = await keyval.hGetAll(key);
 		for (const [ version, archive ] of Object.entries(archived)) {
 			archivedSchemas.set(archiveId(info.name, version), archive);
+		}
+		// Seed archives from the legacy `schemaArchive` directory
+		const legacy = loadLegacySchemas().get(info.name.toLowerCase());
+		if (legacy) {
+			await Promise.all(Fn.map(legacy, async ([ version, archive ]) => {
+				if (!(version in archived)) {
+					archivedSchemas.set(archiveId(info.name, version), archive);
+					await keyval.hSet(key, version, archive, { if: 'NX' });
+				}
+			}));
 		}
 		if (info.archive !== '?' && !(info.version in archived)) {
 			await keyval.hSet(key, `${info.version}`, info.archive, { if: 'NX' });


### PR DESCRIPTION
## What

Schema archives — the layout descriptions `makeUpgrader` needs to read blobs written by older schema versions — were written as files into `schemaArchive` at build time and read back lazily from disk. Deployments had to carry that directory around (e.g. bake it into images and seed it onto volumes).

They now live in the keyval provider itself, under `schema/{name}` hash keys (field = version, value = archive source). `Database.connect` / `Shard.connectWith` call `initializeSchemaArchive`, which preloads all archived versions into memory — keeping the upgrader synchronous — and stores the current version of each package with `hSet(..., { if: 'NX' })`, so concurrently starting services can race safely.

With this, every persistent store is self-describing: a database (redis or local) always carries the schemas needed to read its own blobs, which also makes backups and moving worlds between storage backends straightforward.

The generated `.ksy` Kaitai documentation files are no longer written.

## Migration (second commit — optional)

The second commit imports archives found in the legacy `schemaArchive` directory into the database on connect (idempotent), so existing worlds keep their upgrade history. Since the magic-number change in 05be3b2e already invalidated existing blobs and effectively required a world reset anyway, this commit can be dropped if you'd rather just expect fresh worlds.

## Testing

- `tsc -b` clean; eslint shows only the two warnings that already exist on main in this file.
- Two-process end-to-end test: process A declares a schema (v1), connects a fresh local store, and writes the archive plus a blob; process B declares a changed schema with the same name, connects, and verifies that upgrading fails before `initializeSchemaArchive`, succeeds after (existing field preserved, new field defaulted), that an upgraded blob is stable, and that both versions end up archived in the database. The same test was repeated with the old version's archive provided only as a file in the legacy directory (old filename encoding) to cover the seeding path.