### PR TITLE
Fix double-unsubscribe crash in Subscription.disconnect

### DIFF
--- a/.changeset/pubsub-double-unsubscribe.md
+++ b/.changeset/pubsub-double-unsubscribe.md
@@ -2,4 +2,4 @@
 "xxscreeps": patch
 ---
 
-Fix a crash (`Cannot read properties of undefined (reading 'subscribers')`) in `RedisPubSubProvider.unsubscribe` that could take down the backend's socket handling. When several subscribers share one channel key (e.g. a room's shared and per-socket listeners), the previous size-based teardown could delete the whole delegate entry while a live subscriber remained — or race with an in-flight subscribe — leaving a later unsubscribe to dereference a missing entry. Unsubscribe now removes only its own subscriber, is a no-op if the entry or subscriber is already gone, and drops the shared Redis subscription only once the last subscriber leaves.
+Fix a backend socket crash

--- a/.changeset/pubsub-double-unsubscribe.md
+++ b/.changeset/pubsub-double-unsubscribe.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix a crash (`Cannot read properties of undefined (reading 'subscribers')`) in `RedisPubSubProvider.unsubscribe` that could take down the backend's socket handling. When several subscribers share one channel key (e.g. a room's shared and per-socket listeners), the previous size-based teardown could delete the whole delegate entry while a live subscriber remained — or race with an in-flight subscribe — leaving a later unsubscribe to dereference a missing entry. Unsubscribe now removes only its own subscriber, is a no-op if the entry or subscriber is already gone, and drops the shared Redis subscription only once the last subscriber leaves.

--- a/packages/redis/pubsub.ts
+++ b/packages/redis/pubsub.ts
@@ -85,12 +85,17 @@ export class RedisPubSubProvider implements PubSubProvider {
 
 	async unsubscribe(key: string, subscriber: RedisSubscription) {
 		const prefixKey = `${this.prefix}${key}`;
-		const subscribersInfo = this.subscribersByKey.get(prefixKey)!;
-		if (subscribersInfo.subscribers.size === 1) {
+		const subscribersInfo = this.subscribersByKey.get(prefixKey);
+		// The delegate entry may already be gone (another subscriber to the same key tore it down, or a
+		// subscribe raced with this unsubscribe), and `subscriber` may no longer be a member. Removing an
+		// unknown subscriber is a no-op — this keeps unsubscribe idempotent instead of crashing.
+		if (!subscribersInfo?.subscribers.delete(subscriber)) {
+			return;
+		}
+		// Only drop the shared Redis subscription once the last local subscriber for this key is gone.
+		if (subscribersInfo.subscribers.size === 0) {
 			this.subscribersByKey.delete(prefixKey);
 			await this.client.sUnsubscribe(prefixKey);
-		} else {
-			subscribersInfo.subscribers.delete(subscriber);
 		}
 	}
 }

--- a/packages/xxscreeps/engine/db/storage/local/pubsub.ts
+++ b/packages/xxscreeps/engine/db/storage/local/pubsub.ts
@@ -164,10 +164,13 @@ class LocalPubSubProviderParent extends SharedResponder implements PubSubProvide
 		const sources = getOrSet(this.subscriptionsByKey, key, () => new Set());
 		sources.add(subscription);
 		return [ () => {
-			if (sources.size === 1) {
+			// Remove only our own subscription; no-op if it (or the entry) is already gone. Drop the key
+			// entry only once its last subscriber leaves, and only if it is still the live entry.
+			if (!sources.delete(subscription)) {
+				return;
+			}
+			if (sources.size === 0 && this.subscriptionsByKey.get(key) === sources) {
 				this.subscriptionsByKey.delete(key);
-			} else {
-				sources.delete(subscription);
 			}
 		}, subscription ] as const;
 	}
@@ -199,13 +202,12 @@ class LocalPubSubProviderParent extends SharedResponder implements PubSubProvide
 					}
 
 					case 'unsubscribe': {
-						const source = subscriptionsByKey.get(message.key)!;
-						const sources = this.subscriptionsByKey.get(source.key)!;
-						if (sources.size === 1) {
+						const source = subscriptionsByKey.get(message.key);
+						const sources = source && this.subscriptionsByKey.get(source.key);
+						if (source && sources?.delete(source) && sources.size === 0) {
 							this.subscriptionsByKey.delete(source.key);
-						} else {
-							sources.delete(source);
 						}
+						break;
 					}
 				}
 			}
@@ -301,11 +303,14 @@ export class LocalPubSubProviderClient implements PubSubProvider {
 		const subscription = new ClientSubscription(listener, key, this);
 		subscriptions.add(subscription);
 		const effect: Effect = () => {
-			if (subscriptions.size === 1) {
+			// Remove only our own subscription; no-op if already gone. Tear down the upstream subscription
+			// only when this key's last local subscriber leaves and it is still the live entry.
+			if (!subscriptions.delete(subscription)) {
+				return;
+			}
+			if (subscriptions.size === 0 && this.subscriptionsByKey.get(key) === subscriptions) {
 				this.subscriptionsByKey.delete(key);
 				this.port.send({ type: 'unsubscribe', key });
-			} else {
-				subscriptions.delete(subscription);
 			}
 		};
 		return [ effect, subscription ] as const;


### PR DESCRIPTION
A subscription's disconnect could fire twice (explicit unsubscribe message plus socket-close cleanup), and the second call crashed RedisPubSubProvider.unsubscribe with an uncaught TypeError, killing the backend's socket handling while the engine kept ticking.