### PR TITLE
room socket: replay update missed during first-spawn skip window

### DIFF
--- a/.changeset/room-socket-missed-spawn-update.md
+++ b/.changeset/room-socket-missed-spawn-update.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Replay the room-socket update that was suppressed by the first-spawn race-condition workaround once its skip window closes.

--- a/packages/xxscreeps/backend/sockets/room.ts
+++ b/packages/xxscreeps/backend/sockets/room.ts
@@ -127,6 +127,7 @@ export const roomSubscription: SubscriptionEndpoint = {
 		let previous: any;
 		let previousTime = -1;
 		let skipUntil = 0;
+		let missedUpdateDuringSkip = false;
 		const { shard } = this.context;
 		const seenUsers = new Set<string>();
 		const roomName = parameters.room!;
@@ -143,7 +144,14 @@ export const roomSubscription: SubscriptionEndpoint = {
 			fn => disposable.defer(fn),
 			subscribeToRoom(shard, roomName, (room, time, didUpdate) => mustNotReject(async () => {
 				if (Date.now() < skipUntil) {
+					if (didUpdate) {
+						missedUpdateDuringSkip = true;
+					}
 					return;
+				}
+				if (missedUpdateDuringSkip) {
+					didUpdate = true;
+					missedUpdateDuringSkip = false;
 				}
 
 				// Render current room state


### PR DESCRIPTION
## Summary
- The `willSpawn` skip in the room-socket subscription broadcasts to every subscriber of the room and unconditionally drops the next `didUpdate` for one second, to work around a client-side race where the official client unsubscribes/resubscribes when placing its first spawn.
- Clients that don't do that unsubscribe/resubscribe dance never receive the new spawn/creep/controller state, because the shared `didUpdate` flag is consumed and reset before their listener runs again — the update is dropped, not deferred.
- This tracks whether an update was missed while skipped and forces one render once the skip window closes, fixing the miss for any client regardless of whether it resubscribes.