### PR TITLE
map: avoid node:assert/strict in game runtime bundle

### DIFF
--- a/.changeset/game-map-assert-strict.md
+++ b/.changeset/game-map-assert-strict.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Drop the `node:assert/strict` import from `game/map.ts`, which the runtime bundler cannot resolve inside the isolated-vm sandbox.

--- a/packages/xxscreeps/game/map.ts
+++ b/packages/xxscreeps/game/map.ts
@@ -2,7 +2,6 @@ import type { ExitType } from './room/find.js';
 import type { Room } from './room/index.js';
 import type { TypeOf } from 'xxscreeps/schema/index.js';
 import type { Adapter } from 'xxscreeps/utility/astar.js';
-import assert from 'node:assert/strict';
 import { build, structForPath } from 'xxscreeps/engine/schema/index.js';
 import { primitiveComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -106,7 +105,9 @@ export class GameMap {
 	/** @internal */
 	'#getRoomTraits'(roomName: string) {
 		const traits = this.#traits.get(roomName);
-		assert.ok(traits);
+		if (!traits) {
+			throw new Error(`Could not access room ${roomName}`);
+		}
 		return traits;
 	}
 


### PR DESCRIPTION
game/map.ts is webpacked into the runtime that executes inside the isolated-vm sandbox. The bundler strips the node: scheme and cannot resolve assert/strict, so the worker crashes on startup. Replace assert.ok with a plain throw, matching the convention used elsewhere in game/.