### PR TITLE
Fix sector radius predicate for rooms shared between sectors

### DIFF
--- a/.changeset/sector-radius-predicate-shared-rooms.md
+++ b/.changeset/sector-radius-predicate-shared-rooms.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix `makeSectorRadiusPredicate` throwing on rooms shared between sectors.

--- a/packages/xxscreeps/game/room/sector.ts
+++ b/packages/xxscreeps/game/room/sector.ts
@@ -53,25 +53,27 @@ export function makeSectorRadiusPredicate(centralRoom: string, roomName: string,
 			const here = parseSignedRoomName(roomName);
 			const center = parseSignedRoomName(centralRoom);
 			const linearDistance = roomLinearDistance(here, center);
-			const linearDistance05 = linearDistance >> 1;
+			// The sharing centers sit equidistant from the subject room, `2 * linearDistance` rooms
+			// apart, so a coordinate belongs to `centralRoom` within half that spacing.
+			const radius = linearDistance * 50;
 			for (const sector of sectorNames) {
 				const parsedSector = parseSignedRoomName(sector);
-				if (roomLinearDistance(parsedSector, center) !== linearDistance) {
+				if (roomLinearDistance(parsedSector, here) !== linearDistance) {
 					throw new Error(`Irregular sector geometry ${roomName} ${sectorNames.join(',')}`);
 				}
 			}
 			const xBase = (here.rx - center.rx) * 50 - 24;
 			const yBase = (here.ry - center.ry) * 50 - 24;
-			const xInside = Math.max(Math.abs(xBase), Math.abs(xBase + 49)) < linearDistance05;
-			const yInside = Math.max(Math.abs(yBase), Math.abs(yBase + 49)) < linearDistance05;
+			const xInside = Math.max(Math.abs(xBase), Math.abs(xBase + 49)) < radius;
+			const yInside = Math.max(Math.abs(yBase), Math.abs(yBase + 49)) < radius;
 			if (xInside && yInside) {
 				return () => true;
 			} else if (xInside) {
-				return (xx, yy) => Math.abs(yBase + yy) < linearDistance05;
+				return (xx, yy) => Math.abs(yBase + yy) < radius;
 			} else if (yInside) {
-				return xx => Math.abs(xBase + xx) < linearDistance05;
+				return xx => Math.abs(xBase + xx) < radius;
 			} else {
-				return (xx, yy) => Math.abs(xBase + xx) < linearDistance05 && Math.abs(yBase + yy) < linearDistance05;
+				return (xx, yy) => Math.abs(xBase + xx) < radius && Math.abs(yBase + yy) < radius;
 			}
 		}
 	}

--- a/packages/xxscreeps/game/test.ts
+++ b/packages/xxscreeps/game/test.ts
@@ -5,7 +5,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import { testWorld } from 'xxscreeps/test/import.js';
 import { describe, test } from 'xxscreeps/test/index.js';
 import { RoomPosition } from './position.js';
-import { computeRoomMeta } from './room/sector.js';
+import { computeRoomMeta, makeSectorRadiusPredicate } from './room/sector.js';
 
 interface PositionAssertion {
 	xx: number;
@@ -105,6 +105,36 @@ describe('computeRoomMeta', () => {
 		assert.strictEqual(sectorControl.edges.length, 11, 'ring clipped to the present W0/N0 arms');
 		assert.strictEqual(sectorControl.members.length, 25, 'interior clipped to the present 5x5 corner');
 		assert.ok(!sectorControl.edges.includes('W10N5'), 'absent ring rooms are clipped');
+	});
+});
+
+describe('makeSectorRadiusPredicate', () => {
+	test('a single-sector room belongs wholly to its sector', () => {
+		const inSector = makeSectorRadiusPredicate('W5N5', 'W10N10', [ 'W5N5' ]);
+		assert.ok(inSector(0, 0), 'even the far corner is claimed');
+	});
+
+	test('a shared edge room splits between its two sectors', () => {
+		// W10N5 sits between W5N5 (east) and W15N5 (west).
+		const sectors = [ 'W5N5', 'W15N5' ];
+		const east = makeSectorRadiusPredicate('W5N5', 'W10N5', sectors);
+		const west = makeSectorRadiusPredicate('W15N5', 'W10N5', sectors);
+		assert.ok(east(49, 25), 'the east half belongs to W5N5');
+		assert.ok(!east(0, 25), 'the west half does not');
+		assert.ok(west(0, 25), 'the west half belongs to W15N5');
+		assert.ok(!west(49, 25), 'the east half does not');
+		for (let xx = 0; xx < 50; ++xx) {
+			assert.ok(!(east(xx, 25) && west(xx, 25)), `column ${xx} is claimed by at most one sector`);
+		}
+	});
+
+	test('a shared corner room splits between its four sectors', () => {
+		const sectors = [ 'W5N5', 'W15N5', 'W5N15', 'W15N15' ];
+		const inSector = makeSectorRadiusPredicate('W5N5', 'W10N10', sectors);
+		assert.ok(inSector(49, 49), 'the near quadrant belongs to W5N5');
+		assert.ok(!inSector(0, 49), 'the far quadrants do not');
+		assert.ok(!inSector(49, 0), 'the far quadrants do not');
+		assert.ok(!inSector(0, 0), 'the far quadrants do not');
 	});
 });
 


### PR DESCRIPTION
The multi-sector branch of `makeSectorRadiusPredicate` throws `Irregular sector geometry` for every shared edge and corner room: the regularity guard measures each owning sector's distance to the queried center rather than to the subject room, and the queried center is itself one of the owners, at distance 0. The cutoff also mixes units — `linearDistance >> 1` is in rooms but is compared against tile offsets. The boundary between sharing sectors is half their spacing in tiles, `linearDistance * 50` (250 on the standard template). The test shard holds a single sector, so every existing call hits the length-1 shortcut and neither defect was reachable; on a multi-sector world the deposit evaluator and decay hook throw on their first pass over a highway room.

## Validation

- Added `makeSectorRadiusPredicate` tests for the single-sector whole-room case, the two-sector edge split, and the four-sector corner split; the two multi-sector cases reproduced the throw before the fix.
- Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)