### PR TITLE
room-gen: add offline room terrain generation

### DIFF
--- a/.changeset/room-terrain-generation.md
+++ b/.changeset/room-terrain-generation.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add an offline `generate-room` command that procedurally generates a room's terrain.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,30 @@ an optional `--json` envelope mode for tooling. See
 [packages/xxscreeps/cli/README.md](packages/xxscreeps/cli/README.md) for flags
 and the JSON envelope schema.
 
+## Scripting
+
+The CLI is for quick tinkering; for anything heavier, import the engine
+modules directly from a Node script. This avoids the CLI's eval surface
+and gives full TypeScript types on the operations you call.
+
+```ts
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { generateRoom } from 'xxscreeps/scripts/room-gen.js';
+
+await using db = await Database.connect();
+await using shard = await Shard.connect(db, 'shard0');
+
+await generateRoom(shard, 'W12N5');
+await generateRoom(shard, 'W11N5', { terrainType: 3, swampType: 2 });
+await Promise.all([ db.save(), shard.save() ]);
+```
+
+`generateRoom` adds a room with procedurally generated terrain to the shard's
+terrain blob and `rooms` set. Like `npx xxscreeps import`, it is an offline
+operation — stop the server before running it so cached world state in the
+backend, processor, and runner workers doesn't go stale. Exits are read from
+any already-generated neighbor, so adjacent generated rooms connect.
+
 ## Docker
 
 If you want to run xxscreeps in Docker, you can do this:

--- a/packages/xxscreeps/scripts/generate-room.ts
+++ b/packages/xxscreeps/scripts/generate-room.ts
@@ -1,0 +1,46 @@
+import type { GenerateRoomOptions } from 'xxscreeps/scripts/room-gen.js';
+import { checkArguments } from 'xxscreeps/config/arguments.js';
+import { config } from 'xxscreeps/config/index.js';
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { generateRoom } from 'xxscreeps/scripts/room-gen.js';
+
+function parseOptionalInteger(value: string | undefined, name: string, min: number, max: number) {
+	if (value === undefined) {
+		return undefined;
+	}
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+		throw new Error(`${name} must be an integer from ${min} to ${max}`);
+	}
+	return parsed;
+}
+
+async function main() {
+	const argv = checkArguments({
+		argv: true,
+		string: [ 'shard', 'terrain-type', 'swamp-type' ] as const,
+	});
+	const roomName = argv.argv[0];
+	if (roomName === undefined) {
+		console.log('Usage: xxscreeps generate-room <room> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14]');
+		process.exitCode = 1;
+		return;
+	}
+
+	const terrainType = parseOptionalInteger(argv['terrain-type'], 'terrain-type', 1, 28);
+	const swampType = parseOptionalInteger(argv['swamp-type'], 'swamp-type', 0, 14);
+	const options: GenerateRoomOptions = {
+		...terrainType !== undefined && { terrainType },
+		...swampType !== undefined && { swampType },
+	};
+
+	await using db = await Database.connect();
+	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
+	const room = await generateRoom(shard, roomName, options);
+	await Promise.all([ db.save(), shard.save() ]);
+	console.log(`Generated room ${room.name}`);
+}
+
+if (process.argv[1] === 'generate-room') {
+	await main();
+}

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,9 +1,10 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
 import { Room } from 'xxscreeps/game/room/index.js';
-import { makeRoomName, parseRoomName } from 'xxscreeps/game/room/name.js';
+import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { computeRoomMeta } from 'xxscreeps/game/room/sector.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
@@ -96,24 +97,20 @@ const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
 const iterateRoomsInRange = makeLocalIterateInRangeTo(-Infinity, Infinity);
 
 function makeGrid(): Grid {
-	const grid: Grid = [];
-	for (let yy = 0; yy < 50; yy++) {
-		const row: Cell[] = [];
-		for (let xx = 0; xx < 50; xx++) {
-			row.push({ wall: false, swamp: false, forceOpen: false });
-		}
-		grid.push(row);
-	}
-	return grid;
+	return Fn.pipe(
+		Fn.range(50),
+		$$ => Fn.map($$, () => Fn.pipe(
+			Fn.range(50),
+			$$ => Fn.map($$, (): Cell => ({ wall: false, swamp: false, forceOpen: false })),
+			$$ => [ ...$$ ])),
+		$$ => [ ...$$ ]);
 }
 
 function smoothTerrain(grid: Grid, factor: number, key: 'wall' | 'swamp'): Grid {
 	const next = makeGrid();
-	for (let yy = 0; yy < 50; yy++) {
-		const row = grid[yy]!;
+	for (const [ yy, row ] of grid.entries()) {
 		const nextRow = next[yy]!;
-		for (let xx = 0; xx < 50; xx++) {
-			const cell = row[xx]!;
+		for (const [ xx, cell ] of row.entries()) {
 			const nextCell = nextRow[xx]!;
 			Object.assign(nextCell, cell);
 
@@ -149,10 +146,9 @@ function checkFlood(grid: Grid): boolean {
 	let startXx = -1;
 	let startYy = -1;
 
-	outer:
-	for (let xx = 0; xx < 50; xx++) {
-		for (let yy = 0; yy < 50; yy++) {
-			if (!grid[yy]![xx]!.wall) {
+	outer: for (const [ xx, row ] of grid.entries()) {
+		for (const [ yy, cell ] of row.entries()) {
+			if (!cell.wall) {
 				startXx = xx;
 				startYy = yy;
 				break outer;
@@ -162,12 +158,12 @@ function checkFlood(grid: Grid): boolean {
 
 	if (startXx === -1) return false;
 
-	const visited: boolean[][] = [];
-	for (let yy = 0; yy < 50; yy++) {
-		visited.push(new Array<boolean>(50).fill(false));
-	}
+	const visited = Fn.pipe(
+		Fn.range(50),
+		$$ => Fn.map($$, () => [ ...Fn.map(Fn.range(50), () => false) ]),
+		$$ => [ ...$$ ]);
 
-	const stack: [number, number][] = [ [ startXx, startYy ] ];
+	const stack = [ [ startXx, startYy ] as const ];
 	visited[startYy]![startXx] = true;
 
 	while (stack.length > 0) {
@@ -180,11 +176,10 @@ function checkFlood(grid: Grid): boolean {
 		}
 	}
 
-	for (let yy = 0; yy < 50; yy++) {
-		const row = grid[yy]!;
+	for (const [ yy, row ] of grid.entries()) {
 		const visitedRow = visited[yy]!;
-		for (let xx = 0; xx < 50; xx++) {
-			if (!row[xx]!.wall && !visitedRow[xx]) {
+		for (const [ xx, cell ] of row.entries()) {
+			if (!cell.wall && !visitedRow[xx]) {
 				return false;
 			}
 		}
@@ -197,25 +192,24 @@ interface ExitInterval {
 	length: number;
 }
 
-function genExit(): number[] {
+function *genExit(): Iterable<number> {
 	const exitLength = Math.floor(Math.random() * 43) + 1;
 	const intervalsCnt = [ 0, 0, 1, 1, 2 ][Math.floor(Math.random() * 5)]!;
 	const exitStart = Math.floor(Math.random() * (46 - exitLength)) + 2;
 
-	const intervals: ExitInterval[] = [];
-	let curStart = exitStart;
-
-	for (let jj = 0; jj < intervalsCnt; jj++) {
-		curStart += Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
-		let length = Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
-		if (length + curStart >= exitStart + exitLength - 5) {
-			length = exitStart + exitLength - curStart - 5;
+	const intervals = [ ...function*(): Iterable<ExitInterval> {
+		let curStart = exitStart;
+		for (let jj = 0; jj < intervalsCnt; jj++) {
+			curStart += Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
+			let length = Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
+			if (length + curStart >= exitStart + exitLength - 5) {
+				length = exitStart + exitLength - curStart - 5;
+			}
+			yield { start: curStart, length };
+			curStart += length + 1;
 		}
-		intervals.push({ start: curStart, length });
-		curStart += length + 1;
-	}
+	}() ];
 
-	const exit: number[] = [];
 	for (let pos = exitStart; pos <= exitStart + exitLength; pos++) {
 		if (intervalsCnt > 0) {
 			const first = intervals[0]!;
@@ -230,21 +224,18 @@ function genExit(): number[] {
 			}
 		}
 		if (pos < 2 || pos > 47) continue;
-		exit.push(pos);
+		yield pos;
 	}
-	return exit;
 }
 
-function exitsArray(terrain: Terrain, axis: 'x' | 'y', fixed: number): number[] {
-	const exits: number[] = [];
-	for (let ii = 0; ii < 50; ii++) {
+function *exitsArray(terrain: Terrain, axis: 'x' | 'y', fixed: number) {
+	for (let ii = 0; ii < 50; ++ii) {
 		const xx = axis === 'x' ? fixed : ii;
 		const yy = axis === 'x' ? ii : fixed;
 		if (terrain.get(xx, yy) !== C.TERRAIN_MASK_WALL) {
-			exits.push(ii);
+			yield ii;
 		}
 	}
-	return exits;
 }
 
 // Fills the room with cellular-automaton wall (and swamp) noise, rerolling the wall type until the
@@ -261,10 +252,8 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 			tries = 0;
 		}
 
-		for (let yy = 0; yy < 50; yy++) {
-			const row = grid[yy]!;
-			for (let xx = 0; xx < 50; xx++) {
-				const cell = row[xx]!;
+		for (const [ yy, row ] of grid.entries()) {
+			for (const [ xx, cell ] of row.entries()) {
 				if (yy === 0 && exits.top.includes(xx)) {
 					cell.forceOpen = true;
 					grid[yy + 1]![xx]!.forceOpen = true;
@@ -291,14 +280,14 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 		}
 
 		const wallParams = wallTypes[activeWallType]!;
-		for (let ii = 0; ii < wallParams.smooth; ii++) {
+		for (let ii = 0; ii < wallParams.smooth; ++ii) {
 			grid = smoothTerrain(grid, wallParams.factor, 'wall');
 		}
 	} while (!checkFlood(grid));
 
 	if (swampType) {
 		const swampParams = swampTypes[swampType]!;
-		for (let ii = 0; ii < swampParams.smooth; ii++) {
+		for (let ii = 0; ii < swampParams.smooth; ++ii) {
 			grid = smoothTerrain(grid, swampParams.factor, 'swamp');
 		}
 	}
@@ -307,10 +296,8 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 
 function gridToTerrain(grid: Grid): TerrainWriter {
 	const terrain = new TerrainWriter();
-	for (let yy = 0; yy < 50; yy++) {
-		const row = grid[yy]!;
-		for (let xx = 0; xx < 50; xx++) {
-			const cell = row[xx]!;
+	for (const [ yy, row ] of grid.entries()) {
+		for (const [ xx, cell ] of row.entries()) {
 			if (cell.wall) {
 				terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
 			} else if (cell.swamp) {
@@ -360,7 +347,7 @@ function buildRoom(
 
 		if (userExits) {
 			if (neighborTerrain) {
-				const neighborExits = exitsArray(neighborTerrain.terrain, info.axis, info.fixed);
+				const neighborExits = [ ...exitsArray(neighborTerrain.terrain, info.axis, info.fixed) ];
 				const match = neighborExits.length === userExits.length &&
 					userExits.every(exit => neighborExits.includes(exit));
 				if (!match) {
@@ -369,9 +356,9 @@ function buildRoom(
 			}
 			exits[dir] = userExits;
 		} else if (neighborTerrain) {
-			exits[dir] = exitsArray(neighborTerrain.terrain, info.axis, info.fixed);
+			exits[dir] = [ ...exitsArray(neighborTerrain.terrain, info.axis, info.fixed) ];
 		} else {
-			exits[dir] = genExit();
+			exits[dir] = [ ...genExit() ];
 		}
 	}
 
@@ -417,7 +404,8 @@ export async function generateRoom(
 	roomName: string,
 	options?: GenerateRoomOptions,
 ): Promise<Room> {
-	if (!/^[WE]\d+[NS]\d+$/.test(roomName)) {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (Number.isNaN(rx) || Number.isNaN(ry)) {
 		throw new Error(`Invalid room name: ${roomName}`);
 	}
 
@@ -433,9 +421,8 @@ export async function generateRoom(
 	terrainMap.set(roomName, { exits: packExits(terrain), terrain, ...computeRoomMeta(roomName, roomNames) });
 	// Sector relationships are stored bidirectionally, so a room landing can extend the records of
 	// rooms generated earlier -- an existing member gains this center, a center gains this member.
-	const { rx, ry } = parseRoomName(roomName);
 	for (const [ xx, yy ] of iterateRoomsInRange(rx, ry, 5)) {
-		const neighborName = makeRoomName(xx, yy);
+		const neighborName = makeSignedRoomName(xx, yy);
 		const record = terrainMap.get(neighborName);
 		if (record && neighborName !== roomName) {
 			terrainMap.set(neighborName, { ...record, ...computeRoomMeta(neighborName, roomNames) });

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,0 +1,447 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
+import * as MapSchema from 'xxscreeps/game/map.js';
+import { Room } from 'xxscreeps/game/room/index.js';
+import { makeRoomName, parseRoomName } from 'xxscreeps/game/room/name.js';
+import { flushUsers } from 'xxscreeps/game/room/room.js';
+import { computeRoomMeta } from 'xxscreeps/game/room/sector.js';
+import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
+import { makeWriter } from 'xxscreeps/schema/write.js';
+
+type ExitSide = 'top' | 'right' | 'bottom' | 'left';
+type ExitMap = Record<ExitSide, number[]>;
+
+// The world's per-room terrain map, as returned by `shard.loadWorld()`. The generation entry points
+// accumulate freshly built rooms into one of these and serialize it once, rather than once per room.
+type WorldTerrain = Awaited<ReturnType<Shard['loadWorld']>>['terrain'];
+
+export interface GenerateRoomOptions {
+	exits?: Partial<ExitMap>;
+	terrainType?: number;
+	swampType?: number;
+}
+
+interface TerrainTypeParams {
+	fill: number;
+	smooth: number;
+	factor: number;
+}
+
+const wallTypes: Record<number, TerrainTypeParams> = {
+	1: { fill: 0.4, smooth: 10, factor: 5 },
+	2: { fill: 0.2, smooth: 20, factor: 4 },
+	3: { fill: 0.2, smooth: 20, factor: 4 },
+	4: { fill: 0.3, smooth: 18, factor: 4 },
+	5: { fill: 0.3, smooth: 10, factor: 4 },
+	6: { fill: 0.3, smooth: 10, factor: 4 },
+	7: { fill: 0.3, smooth: 10, factor: 4 },
+	8: { fill: 0.35, smooth: 15, factor: 4 },
+	9: { fill: 0.3, smooth: 2, factor: 4 },
+	10: { fill: 0.35, smooth: 2, factor: 4 },
+	11: { fill: 0.35, smooth: 5, factor: 4 },
+	12: { fill: 0.35, smooth: 5, factor: 4 },
+	13: { fill: 0.25, smooth: 5, factor: 4 },
+	14: { fill: 0.4, smooth: 3, factor: 5 },
+	15: { fill: 0.5, smooth: 3, factor: 5 },
+	16: { fill: 0.45, smooth: 4, factor: 5 },
+	17: { fill: 0.45, smooth: 6, factor: 5 },
+	18: { fill: 0.45, smooth: 10, factor: 5 },
+	19: { fill: 0.5, smooth: 10, factor: 5 },
+	20: { fill: 0.4, smooth: 3, factor: 5 },
+	21: { fill: 0.5, smooth: 2, factor: 5 },
+	22: { fill: 0.45, smooth: 4, factor: 5 },
+	23: { fill: 0.45, smooth: 6, factor: 5 },
+	24: { fill: 0.45, smooth: 10, factor: 5 },
+	25: { fill: 0.5, smooth: 10, factor: 5 },
+	26: { fill: 0.45, smooth: 10, factor: 5 },
+	27: { fill: 0.45, smooth: 6, factor: 5 },
+	28: { fill: 0.2, smooth: 20, factor: 4 },
+};
+
+const swampTypes: Record<number, TerrainTypeParams> = {
+	1: { fill: 0.3, smooth: 3, factor: 5 },
+	2: { fill: 0.35, smooth: 3, factor: 5 },
+	3: { fill: 0.45, smooth: 3, factor: 5 },
+	4: { fill: 0.25, smooth: 1, factor: 5 },
+	5: { fill: 0.25, smooth: 30, factor: 4 },
+	6: { fill: 0.52, smooth: 30, factor: 5 },
+	7: { fill: 0.45, smooth: 3, factor: 5 },
+	8: { fill: 0.3, smooth: 1, factor: 5 },
+	9: { fill: 0.3, smooth: 1, factor: 4 },
+	10: { fill: 0.3, smooth: 3, factor: 5 },
+	11: { fill: 0.3, smooth: 3, factor: 5 },
+	12: { fill: 0.3, smooth: 1, factor: 5 },
+	13: { fill: 0.25, smooth: 1, factor: 5 },
+	14: { fill: 0.35, smooth: 3, factor: 5 },
+};
+
+// Random generation rolls wall types 1-27; type 28 duplicates 2/3 and is reachable only by passing
+// terrainType explicitly, never at random.
+function randomWallType(): number {
+	return Math.floor(Math.random() * 27) + 1;
+}
+
+interface Cell {
+	wall: boolean;
+	swamp: boolean;
+	forceOpen: boolean;
+}
+
+type Grid = Cell[][];
+
+// Yields the in-bounds tiles within Chebyshev `range` of (xx, yy) (the tile itself included), clamped
+// to the 50x50 grid, so neighbour walks don't need their own bounds guards.
+const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
+const iterateRoomsInRange = makeLocalIterateInRangeTo(-Infinity, Infinity);
+
+function makeGrid(): Grid {
+	const grid: Grid = [];
+	for (let yy = 0; yy < 50; yy++) {
+		const row: Cell[] = [];
+		for (let xx = 0; xx < 50; xx++) {
+			row.push({ wall: false, swamp: false, forceOpen: false });
+		}
+		grid.push(row);
+	}
+	return grid;
+}
+
+function smoothTerrain(grid: Grid, factor: number, key: 'wall' | 'swamp'): Grid {
+	const next = makeGrid();
+	for (let yy = 0; yy < 50; yy++) {
+		const row = grid[yy]!;
+		const nextRow = next[yy]!;
+		for (let xx = 0; xx < 50; xx++) {
+			const cell = row[xx]!;
+			const nextCell = nextRow[xx]!;
+			Object.assign(nextCell, cell);
+
+			let count = 0;
+			for (let dyy = -1; dyy <= 1; dyy++) {
+				for (let dxx = -1; dxx <= 1; dxx++) {
+					const nxx = xx + dxx;
+					const nyy = yy + dyy;
+					const outOfBounds = nxx < 0 || nyy < 0 || nxx > 49 || nyy > 49;
+					if (outOfBounds) {
+						if (key === 'wall') count++;
+					} else if (grid[nyy]![nxx]![key]) {
+						count++;
+					}
+				}
+			}
+			nextCell[key] = count >= factor;
+
+			if (key === 'wall') {
+				if (isBorder(xx, yy)) {
+					nextCell.wall = true;
+				}
+				if (cell.forceOpen) {
+					nextCell.wall = false;
+				}
+			}
+		}
+	}
+	return next;
+}
+
+function checkFlood(grid: Grid): boolean {
+	let startXx = -1;
+	let startYy = -1;
+
+	outer:
+	for (let xx = 0; xx < 50; xx++) {
+		for (let yy = 0; yy < 50; yy++) {
+			if (!grid[yy]![xx]!.wall) {
+				startXx = xx;
+				startYy = yy;
+				break outer;
+			}
+		}
+	}
+
+	if (startXx === -1) return false;
+
+	const visited: boolean[][] = [];
+	for (let yy = 0; yy < 50; yy++) {
+		visited.push(new Array<boolean>(50).fill(false));
+	}
+
+	const stack: [number, number][] = [ [ startXx, startYy ] ];
+	visited[startYy]![startXx] = true;
+
+	while (stack.length > 0) {
+		const [ cxx, cyy ] = stack.pop()!;
+		for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
+			if (!grid[nyy]![nxx]!.wall && !visited[nyy]![nxx]) {
+				visited[nyy]![nxx] = true;
+				stack.push([ nxx, nyy ]);
+			}
+		}
+	}
+
+	for (let yy = 0; yy < 50; yy++) {
+		const row = grid[yy]!;
+		const visitedRow = visited[yy]!;
+		for (let xx = 0; xx < 50; xx++) {
+			if (!row[xx]!.wall && !visitedRow[xx]) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+interface ExitInterval {
+	start: number;
+	length: number;
+}
+
+function genExit(): number[] {
+	const exitLength = Math.floor(Math.random() * 43) + 1;
+	const intervalsCnt = [ 0, 0, 1, 1, 2 ][Math.floor(Math.random() * 5)]!;
+	const exitStart = Math.floor(Math.random() * (46 - exitLength)) + 2;
+
+	const intervals: ExitInterval[] = [];
+	let curStart = exitStart;
+
+	for (let jj = 0; jj < intervalsCnt; jj++) {
+		curStart += Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
+		let length = Math.floor(Math.random() * (exitLength / (intervalsCnt * 2))) + 5;
+		if (length + curStart >= exitStart + exitLength - 5) {
+			length = exitStart + exitLength - curStart - 5;
+		}
+		intervals.push({ start: curStart, length });
+		curStart += length + 1;
+	}
+
+	const exit: number[] = [];
+	for (let pos = exitStart; pos <= exitStart + exitLength; pos++) {
+		if (intervalsCnt > 0) {
+			const first = intervals[0]!;
+			if (first.length > 0 && pos >= first.start && pos <= first.start + first.length) {
+				continue;
+			}
+			if (intervalsCnt > 1) {
+				const second = intervals[1]!;
+				if (second.length > 0 && pos >= second.start && pos <= second.start + second.length) {
+					continue;
+				}
+			}
+		}
+		if (pos < 2 || pos > 47) continue;
+		exit.push(pos);
+	}
+	return exit;
+}
+
+function exitsArray(terrain: Terrain, axis: 'x' | 'y', fixed: number): number[] {
+	const exits: number[] = [];
+	for (let ii = 0; ii < 50; ii++) {
+		const xx = axis === 'x' ? fixed : ii;
+		const yy = axis === 'x' ? ii : fixed;
+		if (terrain.get(xx, yy) !== C.TERRAIN_MASK_WALL) {
+			exits.push(ii);
+		}
+	}
+	return exits;
+}
+
+// Fills the room with cellular-automaton wall (and swamp) noise, rerolling the wall type until the
+// open terrain is fully connected, then smooths swamp the same way.
+function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): Grid {
+	let grid: Grid;
+	let activeWallType = wallType;
+	let tries = 0;
+	do {
+		grid = makeGrid();
+		tries++;
+		if (tries > 100) {
+			activeWallType = randomWallType();
+			tries = 0;
+		}
+
+		for (let yy = 0; yy < 50; yy++) {
+			const row = grid[yy]!;
+			for (let xx = 0; xx < 50; xx++) {
+				const cell = row[xx]!;
+				if (yy === 0 && exits.top.includes(xx)) {
+					cell.forceOpen = true;
+					grid[yy + 1]![xx]!.forceOpen = true;
+					continue;
+				}
+				if (yy === 49 && exits.bottom.includes(xx)) {
+					cell.forceOpen = true;
+					grid[yy - 1]![xx]!.forceOpen = true;
+					continue;
+				}
+				if (xx === 0 && exits.left.includes(yy)) {
+					cell.forceOpen = true;
+					row[xx + 1]!.forceOpen = true;
+					continue;
+				}
+				if (xx === 49 && exits.right.includes(yy)) {
+					cell.forceOpen = true;
+					row[xx - 1]!.forceOpen = true;
+					continue;
+				}
+				cell.wall = Math.random() < wallTypes[activeWallType]!.fill;
+				cell.swamp = swampType ? Math.random() < swampTypes[swampType]!.fill : false;
+			}
+		}
+
+		const wallParams = wallTypes[activeWallType]!;
+		for (let ii = 0; ii < wallParams.smooth; ii++) {
+			grid = smoothTerrain(grid, wallParams.factor, 'wall');
+		}
+	} while (!checkFlood(grid));
+
+	if (swampType) {
+		const swampParams = swampTypes[swampType]!;
+		for (let ii = 0; ii < swampParams.smooth; ii++) {
+			grid = smoothTerrain(grid, swampParams.factor, 'swamp');
+		}
+	}
+	return grid;
+}
+
+function gridToTerrain(grid: Grid): TerrainWriter {
+	const terrain = new TerrainWriter();
+	for (let yy = 0; yy < 50; yy++) {
+		const row = grid[yy]!;
+		for (let xx = 0; xx < 50; xx++) {
+			const cell = row[xx]!;
+			if (cell.wall) {
+				terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
+			} else if (cell.swamp) {
+				let hasNonWall = false;
+				for (let dyy = -1; dyy <= 1; dyy++) {
+					for (let dxx = -1; dxx <= 1; dxx++) {
+						const nxx = xx + dxx;
+						const nyy = yy + dyy;
+						if (nxx >= 0 && nxx <= 49 && nyy >= 0 && nyy <= 49 && !grid[nyy]![nxx]!.wall) {
+							hasNonWall = true;
+							break;
+						}
+					}
+					if (hasNonWall) break;
+				}
+				if (hasNonWall) {
+					terrain.set(xx, yy, C.TERRAIN_MASK_SWAMP);
+				}
+			}
+		}
+	}
+	return terrain;
+}
+
+// Builds a room's terrain entirely in memory; performs no storage I/O. `lookupTerrain` resolves an
+// already-built neighbor's terrain so shared exits line up.
+function buildRoom(
+	roomName: string,
+	options: GenerateRoomOptions | undefined,
+	lookupTerrain: (neighborName: string) => { terrain: Terrain } | undefined,
+) {
+	const { rx, ry } = parseRoomName(roomName);
+
+	const dirs = {
+		top: { neighborName: makeRoomName(rx, ry - 1), axis: 'y' as const, fixed: 49 },
+		right: { neighborName: makeRoomName(rx + 1, ry), axis: 'x' as const, fixed: 0 },
+		bottom: { neighborName: makeRoomName(rx, ry + 1), axis: 'y' as const, fixed: 0 },
+		left: { neighborName: makeRoomName(rx - 1, ry), axis: 'x' as const, fixed: 49 },
+	};
+
+	const exits: ExitMap = { top: [], right: [], bottom: [], left: [] };
+
+	for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
+		const info = dirs[dir];
+		const userExits = options?.exits?.[dir];
+		const neighborTerrain = lookupTerrain(info.neighborName);
+
+		if (userExits) {
+			if (neighborTerrain) {
+				const neighborExits = exitsArray(neighborTerrain.terrain, info.axis, info.fixed);
+				const match = neighborExits.length === userExits.length &&
+					userExits.every(exit => neighborExits.includes(exit));
+				if (!match) {
+					throw new Error(`Exits in room ${info.neighborName} don't match`);
+				}
+			}
+			exits[dir] = userExits;
+		} else if (neighborTerrain) {
+			exits[dir] = exitsArray(neighborTerrain.terrain, info.axis, info.fixed);
+		} else {
+			exits[dir] = genExit();
+		}
+	}
+
+	const wallType = options?.terrainType ?? randomWallType();
+	const swampType = options?.swampType ?? Math.floor(Math.random() * 14);
+
+	const grid = buildBaseTerrain(exits, wallType, swampType);
+	const terrain = gridToTerrain(grid);
+
+	const room = new Room();
+	room.name = roomName;
+	room['#user'] = null;
+	room['#level'] = -1;
+	room['#flushObjects'](null);
+	flushUsers(room);
+
+	return { room, terrain };
+}
+
+// A freshly-created shard has no world terrain blob; the strict (redis) provider then throws
+// "terrain does not exist" out of loadWorld. Seed an empty terrain map so the first generated room
+// can bootstrap the world. (The local provider tolerates the missing key, masking this.)
+async function ensureWorldTerrain(shard: Shard) {
+	if (await shard.data.get('terrain', { blob: true }) === null) {
+		await shard.data.set('terrain', makeWriter(MapSchema.schema)(new Map()));
+	}
+}
+
+// Serializes the terrain map and registers the freshly built rooms in a single batch write.
+async function flushRooms(shard: Shard, terrainMap: WorldTerrain, rooms: Room[]) {
+	if (rooms.length === 0) {
+		return;
+	}
+	await Promise.all([
+		shard.data.set('terrain', makeWriter(MapSchema.schema)(terrainMap)),
+		shard.data.sAdd('rooms', rooms.map(room => room.name)),
+		...rooms.map(room => shard.saveRoom(room.name, shard.time, room)),
+	]);
+}
+
+export async function generateRoom(
+	shard: Shard,
+	roomName: string,
+	options?: GenerateRoomOptions,
+): Promise<Room> {
+	if (!/^[WE]\d+[NS]\d+$/.test(roomName)) {
+		throw new Error(`Invalid room name: ${roomName}`);
+	}
+
+	await ensureWorldTerrain(shard);
+	const [ world, existingRooms ] = await Promise.all([ shard.loadWorld(), shard.data.sMembers('rooms') ]);
+	if (existingRooms.includes(roomName)) {
+		throw new Error(`Room already exists: ${roomName}`);
+	}
+
+	const terrainMap = new Map(world.terrain);
+	const { room, terrain } = buildRoom(roomName, options, neighborName => terrainMap.get(neighborName));
+	const roomNames = new Set([ ...terrainMap.keys(), roomName ]);
+	terrainMap.set(roomName, { exits: packExits(terrain), terrain, ...computeRoomMeta(roomName, roomNames) });
+	// Sector relationships are stored bidirectionally, so a room landing can extend the records of
+	// rooms generated earlier -- an existing member gains this center, a center gains this member.
+	const { rx, ry } = parseRoomName(roomName);
+	for (const [ xx, yy ] of iterateRoomsInRange(rx, ry, 5)) {
+		const neighborName = makeRoomName(xx, yy);
+		const record = terrainMap.get(neighborName);
+		if (record && neighborName !== roomName) {
+			terrainMap.set(neighborName, { ...record, ...computeRoomMeta(neighborName, roomNames) });
+		}
+	}
+	await flushRooms(shard, terrainMap, [ room ]);
+
+	return room;
+}

--- a/packages/xxscreeps/xxscreeps.js
+++ b/packages/xxscreeps/xxscreeps.js
@@ -9,6 +9,7 @@ const specifier = process.argv[1];
 const commands = {
 	import: './dist/scripts/scrape-world.js',
 	manage: './dist/scripts/manage.js',
+	'generate-room': './dist/scripts/generate-room.js',
 	start: './dist/engine/service/launcher.js',
 	main: './dist/engine/service/main.js',
 	backend: './dist/backend/server.js',


### PR DESCRIPTION
The terrain split requested on #290: the vanilla cellular-automaton generator as an offline `generate-room` command — wall/swamp type tables, fill+smooth passes, a full-connectivity reroll, `genExit`, and border exits matched against already-generated neighbors. Rooms land object-free at `#level -1`; object placement and the highway noise generator stay with #290.

Sector records stay bidirectionally consistent under incremental generation: a landing room stamps its own `computeRoomMeta` record and re-stamps existing rooms within sector range, so a member generated before its center still picks up the center when the center lands.

## Validation
- Full suite in the worktree: 465/465 passing.
- Offline smoke on an isolated local shard: generated a center, a member, and an edge room in both landing orders; every room's stored `sectors`/`sectorControl` equaled `computeRoomMeta` over the final room set, and `loadWorld`/`loadRoom` read back clean.
- eslint on the new files: zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)