### PR TITLE
driver: resolve xxscreeps:mods/schema in the isolated sandbox bundle

### DIFF
--- a/.changeset/isolated-sandbox-schema.md
+++ b/.changeset/isolated-sandbox-schema.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Resolve `xxscreeps:mods/schema` in the isolated sandbox bundle.

--- a/packages/xxscreeps/driver/sandbox/isolated/index.ts
+++ b/packages/xxscreeps/driver/sandbox/isolated/index.ts
@@ -46,6 +46,7 @@ const getRuntimeSource = runOnce(() => {
 			new VirtualModulesPlugin({
 				'/xxscreeps:mods/constants': makeModSourceText(mods, 'constants'),
 				'/xxscreeps:mods/game': makeModSourceText(mods, 'game'),
+				'/xxscreeps:mods/schema': makeModSourceText(mods, 'schema'),
 				'/xxscreeps:packages': makePackagesModule(),
 			}),
 		],


### PR DESCRIPTION
The mods refactor (2ff79b3d) prefixes every side-effect aggregate module with `import "xxscreeps:mods/schema"` and registered the new virtual module in the experimental and nodejs sandboxes, but the isolated sandbox's webpack bundle was left without it — a live server on the default `runner.sandbox: 'isolated'` crashes the runner worker with `Module not found: Can't resolve '/xxscreeps:mods/schema'`. This registers the module in the bundle's `VirtualModulesPlugin` map alongside its siblings.

## Validation
- Reproduced the runner crash on a fresh imported world at current main; with the entry added the server boots and ticks cleanly under the isolated sandbox.
- Checked the remaining `xxscreeps:mods/*` consumers (host loader, pathfinder profile, experimental/nodejs sandboxes) — all handle the schema slot generically or don't load the aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)