### PR TITLE
invader: deploy canonical bunker templates with reward containers

### DIFF
--- a/.changeset/stronghold-templates.md
+++ b/.changeset/stronghold-templates.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Deploy real bunker stronghold layouts with reward containers, crushing player objects on template tiles.

--- a/packages/xxscreeps/mods/invader/game.ts
+++ b/packages/xxscreeps/mods/invader/game.ts
@@ -1,10 +1,27 @@
 import { registerVariant } from 'xxscreeps/engine/schema/index.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { optionalExpiryTime } from 'xxscreeps/game/object.js';
+import { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
 import { compose } from 'xxscreeps/schema/index.js';
+import { extend } from 'xxscreeps/utility/utility.js';
 import { StructureInvaderCore } from './invader-core.js';
 import { invaderCoreShape } from './schema.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const invaderCoreSchema = registerVariant('Room.objects', compose(invaderCoreShape, StructureInvaderCore));
+
+// Deployed stronghold peers surface their shared collapse timer. This mod registers
+// `#collapseTime` on every structure, so it also owns the derived view; subclasses with their own
+// `effects` getters (the invader core, controllers) shadow it with their own state.
+extend(Structure, {
+	effects: {
+		enumerable: true,
+		get() {
+			const ticksRemaining = optionalExpiryTime(this['#collapseTime']);
+			return ticksRemaining === undefined ? undefined : [ { effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining } ];
+		},
+	},
+});
 
 // ---
 

--- a/packages/xxscreeps/mods/invader/index.ts
+++ b/packages/xxscreeps/mods/invader/index.ts
@@ -3,11 +3,15 @@ import type { Manifest } from 'xxscreeps/config/mods.js';
 export const manifest: Manifest = {
 	dependencies: [
 		'xxscreeps/mods/classic/combat',
+		'xxscreeps/mods/classic/construction',
 		'xxscreeps/mods/classic/controller',
 		'xxscreeps/mods/classic/creep',
 		'xxscreeps/mods/classic/defense',
+		'xxscreeps/mods/modern/factory',
 		'xxscreeps/mods/classic/logistics',
 		'xxscreeps/mods/npc',
+		'xxscreeps/mods/classic/resource',
+		'xxscreeps/mods/classic/road',
 		'xxscreeps/mods/classic/spawn',
 	],
 	provides: [ 'backend', 'constants', 'game', 'processor', 'schema', 'test' ],

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -1,3 +1,4 @@
+import type { StrongholdStructure, StrongholdTemplate } from './strongholds.js';
 import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { StructureTower } from 'xxscreeps/mods/classic/defense/tower.js';
 import { registerIntentProcessor, registerObjectPreTickProcessor, registerObjectTickProcessor, registerRoomTickProcessor } from 'xxscreeps/engine/processor/index.js';
@@ -9,21 +10,24 @@ import { optionalExpiryTime, saveAction } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Room } from 'xxscreeps/game/room/index.js';
+import { ConstructionSite } from 'xxscreeps/mods/classic/construction/construction-site.js';
 import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
 import { release, reserve } from 'xxscreeps/mods/classic/controller/processor.js';
 import * as Creep from 'xxscreeps/mods/classic/creep/creep.js';
-import { flushActionLog } from 'xxscreeps/mods/classic/creep/processor.js';
+import { buryCreep, flushActionLog } from 'xxscreeps/mods/classic/creep/processor.js';
 import { create as createRampart } from 'xxscreeps/mods/classic/defense/rampart.js';
 import { create as createTower } from 'xxscreeps/mods/classic/defense/tower.js';
-import { activateNPC, registerNPC } from 'xxscreeps/mods/npc/processor.js';
 import { create as createContainer } from 'xxscreeps/mods/classic/resource/container.js';
+import { drop as dropResource } from 'xxscreeps/mods/classic/resource/processor/resource.js';
 import { create as createRoad } from 'xxscreeps/mods/classic/road/road.js';
 import { birthSpawnCreep } from 'xxscreeps/mods/classic/spawn/processor.js';
 import { Spawning } from 'xxscreeps/mods/classic/spawn/spawn.js';
 import { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
+import { activateNPC, registerNPC } from 'xxscreeps/mods/npc/processor.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { StructureInvaderCore, checkAttackController, checkCreateCreep, checkReserveController, checkTransferEnergy, checkUpgradeController } from './invader-core.js';
 import { loop } from './loop/index.js';
+import { calcReward, containerAmounts, containerRewards, templates } from './strongholds.js';
 
 // Register invader NPC
 registerNPC('2', loop);
@@ -251,28 +255,93 @@ registerObjectTickProcessor(StructureInvaderCore, (core, context) => {
 	}
 });
 
-// The structures a deployed stronghold spawns around its core. A stub layout; the canonical bunker
-// templates and their reward containers land in a follow-up. Decaying peers are pinned to the
-// collapse time so they don't decay (and read a past expiry) while the room sleeps until collapse.
-function strongholdTemplate(pos: RoomPosition, collapseTime: number) {
-	const tower = createTower(new RoomPosition(pos.x, pos.y - 1, pos.roomName), '2');
-	const rampart = createRampart(new RoomPosition(pos.x + 1, pos.y, pos.roomName), '2');
-	const container = createContainer(new RoomPosition(pos.x - 1, pos.y, pos.roomName));
-	const road = createRoad(new RoomPosition(pos.x, pos.y + 1, pos.roomName));
-	rampart['#nextDecayTime'] = collapseTime;
-	container['#nextDecayTime'] = collapseTime;
-	road['#nextDecayTime'] = collapseTime;
-	return [ tower, rampart, container, road ];
+// One structure of a deployed stronghold, created at its template position with the per-type loot
+// and hit points. A decaying peer is pinned to the collapse time so it never reads a past expiry
+// while the room sleeps until collapse. The caller stamps the shared collapse timer and id.
+function createPeer(type: StrongholdStructure['type'], pos: RoomPosition, rewardLevel: number, collapseTime: number) {
+	switch (type) {
+		case C.STRUCTURE_RAMPART: {
+			const rampart = createRampart(pos, '2');
+			rampart.hits = C.STRONGHOLD_RAMPART_HITS[rewardLevel]!;
+			rampart['#nextDecayTime'] = collapseTime;
+			return rampart;
+		}
+		case C.STRUCTURE_TOWER: {
+			const tower = createTower(pos, '2');
+			tower.store['#add'](C.RESOURCE_ENERGY, C.TOWER_CAPACITY);
+			return tower;
+		}
+		case C.STRUCTURE_CONTAINER: {
+			const container = createContainer(pos);
+			for (const [ resource, amount ] of calcReward(containerRewards, containerAmounts[rewardLevel]!, 3)) {
+				container.store['#add'](resource, amount);
+			}
+			// Reward containers are withdraw-only
+			container.store['#capacity'] = 0;
+			container['#nextDecayTime'] = collapseTime;
+			return container;
+		}
+		case C.STRUCTURE_ROAD: {
+			const road = createRoad(pos);
+			road['#nextDecayTime'] = collapseTime;
+			return road;
+		}
+	}
+}
+
+// The structures a deployed stronghold spawns around its core, per its bunker template. Template
+// peers freely share a tile (a rampart over a tower, container, or road).
+function *strongholdTemplate(core: StructureInvaderCore, template: StrongholdTemplate, collapseTime: number) {
+	const { rewardLevel } = template;
+	for (const entry of template.structures) {
+		const pos = new RoomPosition(core.pos.x + entry.dx, core.pos.y + entry.dy, core.pos.roomName);
+		const peer = createPeer(entry.type, pos, rewardLevel, collapseTime);
+		peer['#collapseTime'] = collapseTime;
+		peer['#strongholdId'] = core.id;
+		yield peer;
+	}
+}
+
+// Crush whatever the template lands on: creeps on its tiles die, construction sites refund half
+// their progress as dropped energy, and player-buildable structures are destroyed. Runs before any
+// peer is inserted, so peers never crush each other on shared tiles.
+function crushStrongholdTiles(core: StructureInvaderCore, template: StrongholdTemplate) {
+	const { room } = core;
+	const positions = Fn.pipe(
+		template.structures,
+		$$ => Fn.map($$, entry => new RoomPosition(core.pos.x + entry.dx, core.pos.y + entry.dy, core.pos.roomName)),
+		$$ => new Map(Fn.map($$, pos => [ pos['#id'], pos ] as const)),
+	);
+	for (const pos of positions.values()) {
+		for (const object of room['#lookAt'](pos)) {
+			if (object instanceof Creep.Creep) {
+				buryCreep(object);
+			} else if (object instanceof ConstructionSite) {
+				if (object.progress > 1) {
+					dropResource(pos, C.RESOURCE_ENERGY, Math.floor(object.progress / 2));
+				}
+				room['#removeObject'](object);
+			} else if (object instanceof Structure && object.structureType in C.CONSTRUCTION_COST) {
+				object['#destroy']();
+			}
+		}
+	}
 }
 
 // Deploy the stronghold: drop the deploy timer, start the shared collapse timer, and spawn the
-// template peers carrying that same timer so the whole stronghold vanishes together.
+// template peers carrying that same timer and id so the whole stronghold vanishes together.
 function deployStronghold(core: StructureInvaderCore, context: ProcessorContext) {
+	const templateName = core['#templateName'];
+	if (templateName === undefined) {
+		throw new Error('Deploying invader core has no stronghold template');
+	}
+	const template = templates[templateName];
 	core['#deployTime'] = 0;
+	core['#strongholdId'] = core.id;
 	const duration = Math.round(C.STRONGHOLD_DECAY_TICKS * (0.9 + Math.random() * 0.2));
 	const collapseTime = core['#collapseTime'] = Game.time + duration;
-	for (const peer of strongholdTemplate(core.pos, collapseTime)) {
-		peer['#collapseTime'] = collapseTime;
+	crushStrongholdTiles(core, template);
+	for (const peer of strongholdTemplate(core, template, collapseTime)) {
 		core.room['#insertObject'](peer);
 	}
 	context.wakeAt(collapseTime);

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -307,23 +307,23 @@ function *strongholdTemplate(core: StructureInvaderCore, template: StrongholdTem
 // peer is inserted, so peers never crush each other on shared tiles.
 function crushStrongholdTiles(core: StructureInvaderCore, template: StrongholdTemplate) {
 	const { room } = core;
-	const positions = Fn.pipe(
+	const objects = Fn.pipe(
 		template.structures,
 		$$ => Fn.map($$, entry => new RoomPosition(core.pos.x + entry.dx, core.pos.y + entry.dy, core.pos.roomName)),
-		$$ => new Map(Fn.map($$, pos => [ pos['#id'], pos ] as const)),
-	);
-	for (const pos of positions.values()) {
-		for (const object of room['#lookAt'](pos)) {
-			if (object instanceof Creep.Creep) {
-				buryCreep(object);
-			} else if (object instanceof ConstructionSite) {
-				if (object.progress > 1) {
-					dropResource(pos, C.RESOURCE_ENERGY, Math.floor(object.progress / 2));
-				}
-				room['#removeObject'](object);
-			} else if (object instanceof Structure && object.structureType in C.CONSTRUCTION_COST) {
-				object['#destroy']();
+		$$ => Fn.map($$, pos => [ pos['#id'], pos ] as const),
+		$$ => new Map($$),
+		$$ => $$.values(),
+		$$ => Fn.transform($$, pos => room['#lookAt'](pos)));
+	for (const object of objects) {
+		if (object instanceof Creep.Creep) {
+			buryCreep(object);
+		} else if (object instanceof ConstructionSite) {
+			if (object.progress > 1) {
+				dropResource(object.pos, C.RESOURCE_ENERGY, Math.floor(object.progress / 2));
 			}
+			room['#removeObject'](object);
+		} else if (object instanceof Structure && object.structureType in C.CONSTRUCTION_COST) {
+			object['#destroy']();
 		}
 	}
 }

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -27,7 +27,7 @@ import { activateNPC, registerNPC } from 'xxscreeps/mods/npc/processor.js';
 import { assign } from 'xxscreeps/utility/utility.js';
 import { StructureInvaderCore, checkAttackController, checkCreateCreep, checkReserveController, checkTransferEnergy, checkUpgradeController } from './invader-core.js';
 import { loop } from './loop/index.js';
-import { calcReward, containerAmounts, containerRewards, templates } from './strongholds.js';
+import { calcReward, templates } from './strongholds.js';
 
 // Register invader NPC
 registerNPC('2', loop);
@@ -273,7 +273,7 @@ function createPeer(type: StrongholdStructure['type'], pos: RoomPosition, reward
 		}
 		case C.STRUCTURE_CONTAINER: {
 			const container = createContainer(pos);
-			for (const [ resource, amount ] of calcReward(containerRewards, containerAmounts[rewardLevel]!, 3)) {
+			for (const [ resource, amount ] of calcReward(rewardLevel)) {
 				container.store['#add'](resource, amount);
 			}
 			// Reward containers are withdraw-only

--- a/packages/xxscreeps/mods/invader/schema.ts
+++ b/packages/xxscreeps/mods/invader/schema.ts
@@ -1,8 +1,9 @@
+import * as Id from 'xxscreeps/engine/schema/id.js';
 import { registerStruct } from 'xxscreeps/engine/schema/index.js';
 import { actionLogFormat } from 'xxscreeps/game/schema.js';
 import { spawningFormat } from 'xxscreeps/mods/classic/spawn/schema.js';
 import { ownedStructureShape } from 'xxscreeps/mods/classic/structure/schema.js';
-import { declare, optional, struct, variant } from 'xxscreeps/schema/index.js';
+import { declare, enumerated, optional, struct, variant } from 'xxscreeps/schema/index.js';
 
 /** @internal */
 export const invaderCoreShape = declare('InvaderCore', struct(ownedStructureShape, {
@@ -12,6 +13,9 @@ export const invaderCoreShape = declare('InvaderCore', struct(ownedStructureShap
 	spawning: optional(spawningFormat, null),
 	'#actionLog': actionLogFormat,
 	'#deployTime': 'int32',
+	// Bunker layout this core deploys, e.g. 'bunker3'; its `rewardLevel` drives rampart hits and
+	// container loot. Set at placement.
+	'#templateName': enumerated(undefined, 'bunker1', 'bunker2', 'bunker3', 'bunker4', 'bunker5'),
 }));
 
 // Track energy mined on room
@@ -23,6 +27,9 @@ const roomSchema = registerStruct('Room', {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const structureSchema = registerStruct('Structure', {
 	'#collapseTime': 'int32',
+	// Groups a deployed stronghold's structures — the invader core and every peer it spawns share
+	// one id.
+	'#strongholdId': Id.optionalFormat,
 });
 
 // ---

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -8,9 +8,9 @@ import {
 	RESOURCE_PURIFIER, RESOURCE_REDUCTANT, RESOURCE_UTRIUM_BAR, RESOURCE_ZYNTHIUM_BAR,
 } from 'xxscreeps/mods/modern/factory/constants.js';
 
-// Stronghold layout templates and loot tables ported from @screeps/common (lib/strongholds.js),
-// which is ISC-licensed. Each template's `rewardLevel` matches its bunker number. The core's own
-// template entry is omitted — deploy spawns peers around an existing core.
+// Stronghold layout templates and loot tables ported from @screeps/common (lib/strongholds.js).
+// Each template's `rewardLevel` matches its bunker number. The core's own template entry is omitted
+// — deploy spawns peers around an existing core.
 
 export interface StrongholdStructure {
 	type: typeof C.STRUCTURE_RAMPART | typeof C.STRUCTURE_TOWER | typeof C.STRUCTURE_CONTAINER | typeof C.STRUCTURE_ROAD;

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -1,0 +1,309 @@
+import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import {
+	RESOURCE_BATTERY, RESOURCE_COMPOSITE, RESOURCE_CRYSTAL, RESOURCE_GHODIUM_MELT,
+	RESOURCE_KEANIUM_BAR, RESOURCE_LEMERGIUM_BAR, RESOURCE_LIQUID, RESOURCE_OXIDANT,
+	RESOURCE_PURIFIER, RESOURCE_REDUCTANT, RESOURCE_UTRIUM_BAR, RESOURCE_ZYNTHIUM_BAR,
+} from 'xxscreeps/mods/modern/factory/constants.js';
+
+// Stronghold layout templates and loot tables ported from @screeps/common (lib/strongholds.js),
+// which is ISC-licensed. Each template's `rewardLevel` matches its bunker number. The core's own
+// template entry is omitted — deploy spawns peers around an existing core.
+
+export interface StrongholdStructure {
+	type: typeof C.STRUCTURE_RAMPART | typeof C.STRUCTURE_TOWER | typeof C.STRUCTURE_CONTAINER | typeof C.STRUCTURE_ROAD;
+	dx: number;
+	dy: number;
+}
+
+export interface StrongholdTemplate {
+	rewardLevel: number;
+	structures: StrongholdStructure[];
+}
+
+export const templates = {
+	bunker1: {
+		rewardLevel: 1,
+		structures: [
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
+		],
+	},
+	bunker2: {
+		rewardLevel: 2,
+		structures: [
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_CONTAINER, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
+		],
+	},
+	bunker3: {
+		rewardLevel: 3,
+		structures: [
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
+		],
+	},
+	bunker4: {
+		rewardLevel: 4,
+		structures: [
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 0 },
+			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -2 },
+		],
+	},
+	bunker5: {
+		rewardLevel: 5,
+		structures: [
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
+			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
+			{ type: C.STRUCTURE_TOWER, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
+			{ type: C.STRUCTURE_TOWER, dx: 0, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -2 },
+			{ type: C.STRUCTURE_TOWER, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -3 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -3 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -3 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -3 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -3 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -3 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -3 },
+			{ type: C.STRUCTURE_ROAD, dx: -3, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 3, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: -3, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: 3, dy: -1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: -1 },
+			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 0 },
+			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 0 },
+			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 1 },
+			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 1 },
+			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 3 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 3 },
+			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 3 },
+			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 3 },
+			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 3 },
+			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 3 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 3 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 3 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: -2 },
+			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -2 },
+			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -2 },
+			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
+			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
+		],
+	},
+} satisfies Record<string, StrongholdTemplate>;
+
+// Weighted resource table for the loot in a stronghold's containers, keyed by reward level into
+// `containerAmounts`.
+export const containerRewards: Record<string, number> = {
+	[RESOURCE_UTRIUM_BAR]: 5,
+	[RESOURCE_LEMERGIUM_BAR]: 5,
+	[RESOURCE_ZYNTHIUM_BAR]: 5,
+	[RESOURCE_KEANIUM_BAR]: 5,
+	[RESOURCE_OXIDANT]: 5,
+	[RESOURCE_REDUCTANT]: 5,
+	[RESOURCE_PURIFIER]: 5,
+	[RESOURCE_GHODIUM_MELT]: 20,
+	[RESOURCE_BATTERY]: 10,
+	[RESOURCE_COMPOSITE]: 10,
+	[RESOURCE_CRYSTAL]: 15,
+	[RESOURCE_LIQUID]: 30,
+};
+
+export const containerAmounts = [ 0, 500, 4000, 10000, 50000, 360000 ];
+
+/**
+ * Roll `itemsLimit` resources at random from a weighted table and distribute `targetDensity` units
+ * of weight across them. The chosen resources sum (in weighted density) to roughly the target.
+ */
+export function *calcReward(
+	weights: Record<string, number>,
+	targetDensity: number,
+	itemsLimit: number,
+): Generator<[ ResourceType, number ]> {
+	const picks = Fn.pipe(
+		Object.entries(weights),
+		$$ => Fn.map($$, entry => ({ entry, order: Math.random() })),
+		$$ => [ ...$$ ],
+	);
+	picks.sort(mappedNumericComparator(pick => pick.order));
+	picks.length = Math.min(picks.length, itemsLimit);
+	let currentDensity = 0;
+	for (const [ ii, { entry: [ resource, density ] } ] of picks.entries()) {
+		const remaining = targetDensity - currentDensity;
+		// Divergence from Screeps, whose final item divides by a positional density index (a bug)
+		// rather than the chosen resource's own density.
+		const amount = ii === picks.length - 1
+			? Math.max(0, Math.round(remaining / density))
+			: Math.max(0, Math.round(Math.random() * remaining / density));
+		currentDensity += amount * density;
+		if (amount > 0) {
+			yield [ resource as ResourceType, amount ];
+		}
+	}
+}

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -105,9 +105,10 @@ const containerAmounts = [ 0, 500, 4000, 10000, 50000, 360000 ];
  * Roll three resources at random from the weighted table and distribute the reward level's density
  * across them. The chosen resources sum (in weighted density) to roughly the target.
  */
-export function *calcReward(rewardLevel: number): Generator<[ ResourceType, number ]> {
+export function *calcReward(rewardLevel: number): Iterable<[ ResourceType, number ]> {
 	const targetDensity = containerAmounts[rewardLevel]!;
 	const picks = Object.entries(containerRewards);
+	// TODO: abstract out fisher-yates shuffle
 	for (let ii = picks.length - 1; ii > 0; --ii) {
 		const jj = Math.floor(Math.random() * (ii + 1));
 		[ picks[ii], picks[jj] ] = [ picks[jj]!, picks[ii]! ];

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -23,239 +23,65 @@ export interface StrongholdTemplate {
 	structures: StrongholdStructure[];
 }
 
+// Structures stacked on each picture cell below. Offsets anchor at `x`, the existing core, which
+// spawns only the rampart over it.
+const legend: Record<string, readonly StrongholdStructure['type'][]> = {
+	x: [ C.STRUCTURE_RAMPART ],
+	t: [ C.STRUCTURE_TOWER, C.STRUCTURE_RAMPART ],
+	c: [ C.STRUCTURE_CONTAINER, C.STRUCTURE_ROAD, C.STRUCTURE_RAMPART ],
+	'.': [ C.STRUCTURE_ROAD, C.STRUCTURE_RAMPART ],
+};
+
+function parseTemplate(rewardLevel: number, picture: string): StrongholdTemplate {
+	const rows = picture.split('\n').map(row => row.replace(/^\t+/, ''));
+	const originRow = rows.findIndex(row => row.includes('x'));
+	const originCol = rows[originRow]!.indexOf('x');
+	return {
+		rewardLevel,
+		structures: [ ...function*(): Iterable<StrongholdStructure> {
+			for (const [ rowIndex, row ] of rows.entries()) {
+				for (const [ colIndex, cell ] of [ ...row ].entries()) {
+					for (const type of legend[cell] ?? []) {
+						yield { type, dx: colIndex - originCol, dy: rowIndex - originRow };
+					}
+				}
+			}
+		}() ],
+	};
+}
+
 export const templates = {
-	bunker1: {
-		rewardLevel: 1,
-		structures: [
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
-		],
-	},
-	bunker2: {
-		rewardLevel: 2,
-		structures: [
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_CONTAINER, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
-		],
-	},
-	bunker3: {
-		rewardLevel: 3,
-		structures: [
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
-		],
-	},
-	bunker4: {
-		rewardLevel: 4,
-		structures: [
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 0 },
-			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 0, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -2 },
-		],
-	},
-	bunker5: {
-		rewardLevel: 5,
-		structures: [
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 0 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -1 },
-			{ type: C.STRUCTURE_TOWER, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 1 },
-			{ type: C.STRUCTURE_TOWER, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -1 },
-			{ type: C.STRUCTURE_TOWER, dx: 0, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -2 },
-			{ type: C.STRUCTURE_TOWER, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -3 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -3 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -3 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -3 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -3 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -3 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -3 },
-			{ type: C.STRUCTURE_ROAD, dx: -3, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 3, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: -3, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: 3, dy: -1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: -1 },
-			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 0 },
-			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 0 },
-			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 1 },
-			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 1 },
-			{ type: C.STRUCTURE_ROAD, dx: -3, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -3, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 3, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 3, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 3 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 3 },
-			{ type: C.STRUCTURE_ROAD, dx: -1, dy: 3 },
-			{ type: C.STRUCTURE_RAMPART, dx: -1, dy: 3 },
-			{ type: C.STRUCTURE_ROAD, dx: 0, dy: 3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 0, dy: 3 },
-			{ type: C.STRUCTURE_ROAD, dx: 1, dy: 3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 1, dy: 3 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 3 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 3 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: 2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: -2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: 2, dy: -2 },
-			{ type: C.STRUCTURE_ROAD, dx: 2, dy: -2 },
-			{ type: C.STRUCTURE_RAMPART, dx: 2, dy: -2 },
-			{ type: C.STRUCTURE_CONTAINER, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_ROAD, dx: -2, dy: 2 },
-			{ type: C.STRUCTURE_RAMPART, dx: -2, dy: 2 },
-		],
-	},
+	bunker1: parseTemplate(1, `
+		xc
+		.t
+	`),
+	bunker2: parseTemplate(2, `
+		t..
+		cxc
+		..t
+	`),
+	bunker3: parseTemplate(3, `
+		.t.c
+		c.x.
+		.t.t
+		..c.
+	`),
+	bunker4: parseTemplate(4, `
+		..c..
+		.t.t.
+		c.x.c
+		.t.t.
+		..c..
+	`),
+	bunker5: parseTemplate(5, `
+		 .....
+		.c.t.c.
+		..t.t..
+		...x...
+		..t.t..
+		.c.t.c.
+		 .....
+	`),
 } satisfies Record<string, StrongholdTemplate>;
 
 // Weighted resource table for the loot in a stronghold's containers, keyed by reward level into

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -1,6 +1,4 @@
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
-import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
-import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import {
 	RESOURCE_BATTERY, RESOURCE_COMPOSITE, RESOURCE_CRYSTAL, RESOURCE_GHODIUM_MELT,
@@ -84,9 +82,9 @@ export const templates = {
 	`),
 } satisfies Record<string, StrongholdTemplate>;
 
-// Weighted resource table for the loot in a stronghold's containers, keyed by reward level into
-// `containerAmounts`.
-export const containerRewards: Record<string, number> = {
+// Weighted resource table for the loot in a stronghold's containers; `containerAmounts` maps a
+// template's reward level to the total density distributed across the rolled resources.
+const containerRewards: Record<string, number> = {
 	[RESOURCE_UTRIUM_BAR]: 5,
 	[RESOURCE_LEMERGIUM_BAR]: 5,
 	[RESOURCE_ZYNTHIUM_BAR]: 5,
@@ -101,26 +99,22 @@ export const containerRewards: Record<string, number> = {
 	[RESOURCE_LIQUID]: 30,
 };
 
-export const containerAmounts = [ 0, 500, 4000, 10000, 50000, 360000 ];
+const containerAmounts = [ 0, 500, 4000, 10000, 50000, 360000 ];
 
 /**
- * Roll `itemsLimit` resources at random from a weighted table and distribute `targetDensity` units
- * of weight across them. The chosen resources sum (in weighted density) to roughly the target.
+ * Roll three resources at random from the weighted table and distribute the reward level's density
+ * across them. The chosen resources sum (in weighted density) to roughly the target.
  */
-export function *calcReward(
-	weights: Record<string, number>,
-	targetDensity: number,
-	itemsLimit: number,
-): Generator<[ ResourceType, number ]> {
-	const picks = Fn.pipe(
-		Object.entries(weights),
-		$$ => Fn.map($$, entry => ({ entry, order: Math.random() })),
-		$$ => [ ...$$ ],
-	);
-	picks.sort(mappedNumericComparator(pick => pick.order));
-	picks.length = Math.min(picks.length, itemsLimit);
+export function *calcReward(rewardLevel: number): Generator<[ ResourceType, number ]> {
+	const targetDensity = containerAmounts[rewardLevel]!;
+	const picks = Object.entries(containerRewards);
+	for (let ii = picks.length - 1; ii > 0; --ii) {
+		const jj = Math.floor(Math.random() * (ii + 1));
+		[ picks[ii], picks[jj] ] = [ picks[jj]!, picks[ii]! ];
+	}
+	picks.length = 3;
 	let currentDensity = 0;
-	for (const [ ii, { entry: [ resource, density ] } ] of picks.entries()) {
+	for (const [ ii, [ resource, density ] ] of picks.entries()) {
 		const remaining = targetDensity - currentDensity;
 		// Divergence from Screeps, whose final item divides by a positional density index (a bug)
 		// rather than the chosen resource's own density.

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -633,7 +633,7 @@ describe('mod/invader', () => {
 				const rampart = ramparts[0]!;
 				const container = containers[0]!;
 				assert.strictEqual(tower.store.getUsedCapacity(C.RESOURCE_ENERGY), C.TOWER_CAPACITY, 'tower deploys at full energy');
-				assert.strictEqual(rampart.hits, C.STRONGHOLD_RAMPART_HITS[2]!, 'rampart hits scale with the template reward level');
+				assert.strictEqual(rampart.hits, C.STRONGHOLD_RAMPART_HITS[2], 'rampart hits scale with the template reward level');
 				assert.ok(container.store.getUsedCapacity() > 0, 'container deploys carrying a resource reward');
 				assert.strictEqual(container.store.getCapacity(), 0, 'reward container is withdraw-only');
 
@@ -743,8 +743,8 @@ describe('mod/invader', () => {
 			await peekRoom('W1N1', room => {
 				assert.strictEqual(findRoomCore(room), undefined, 'core removed on collapse');
 				assert.strictEqual(room['#user'], null, 'room ownership released');
-				assert.strictEqual(room.controller!.level, 0, 'controller downgraded to neutral');
-				assert.strictEqual(room.controller!.effects, undefined, 'controller invulnerability cleared');
+				assert.strictEqual(room.controller?.level, 0, 'controller downgraded to neutral');
+				assert.strictEqual(room.controller.effects, undefined, 'controller invulnerability cleared');
 			});
 		}));
 	});

--- a/packages/xxscreeps/mods/invader/test.ts
+++ b/packages/xxscreeps/mods/invader/test.ts
@@ -4,12 +4,14 @@ import type { Room } from 'xxscreeps/game/room/index.js';
 import { pushIntentsForRoomNextTick } from 'xxscreeps/engine/processor/model.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
+import { create as createSite } from 'xxscreeps/mods/classic/construction/construction-site.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
 import { create as createTower } from 'xxscreeps/mods/classic/defense/tower.js';
-import { activateNPC } from 'xxscreeps/mods/npc/processor.js';
 import { create as createContainer } from 'xxscreeps/mods/classic/resource/container.js';
+import { create as createRoad } from 'xxscreeps/mods/classic/road/road.js';
+import { activateNPC } from 'xxscreeps/mods/npc/processor.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
-import { lookForStructures } from '../classic/structure/structure.js';
+import { lookForStructureAt, lookForStructures } from '../classic/structure/structure.js';
 import { create as createInvaderCore } from './invader-core.js';
 
 // W7N7 has exits in all 4 directions and all neighbors have controllers:
@@ -273,11 +275,14 @@ describe('mod/invader', () => {
 			});
 		}));
 
-		// Deploy completes at Game.time === 2; an observer keeps the room visible across the boundary.
+		// Deploy completes at Game.time === 2; an observer outside the bunker1 footprint keeps the room
+		// visible across the boundary without being crushed by the deploy.
 		const deployBoundary = simulate({
 			W1N1: room => {
-				room['#insertObject'](createInvaderCore(corePos, 2, 2));
-				room['#insertObject'](createCreep(new RoomPosition(25, 26, 'W1N1'), [ C.MOVE ], 'observer', '100'));
+				const core = createInvaderCore(corePos, 2, 2);
+				core['#templateName'] = 'bunker1';
+				room['#insertObject'](core);
+				room['#insertObject'](createCreep(new RoomPosition(23, 25, 'W1N1'), [ C.MOVE ], 'observer', '100'));
 			},
 		});
 
@@ -590,7 +595,9 @@ describe('mod/invader', () => {
 		// room processing across the boundary.
 		const deployScene = simulate({
 			W1N1: room => {
-				room['#insertObject'](createInvaderCore(corePos, 2, 1));
+				const core = createInvaderCore(corePos, 2, 1);
+				core['#templateName'] = 'bunker2';
+				room['#insertObject'](core);
 				activateNPC(room, '2');
 			},
 		});
@@ -606,25 +613,91 @@ describe('mod/invader', () => {
 			});
 		}));
 
-		test('deploy spawns the stronghold template sharing the core collapse timer', () => deployScene(async ({ tick, peekRoom }) => {
+		test('deploy spawns the bunker template with loot, scaled ramparts, and a shared id', () => deployScene(async ({ tick, peekRoom }) => {
 			await tick(2);
-			await peekRoom('W1N1', room => {
-				const decayTime = findRoomCore(room)!['#collapseTime'];
-				const tower = lookForStructures(room, C.STRUCTURE_TOWER)[0];
-				const rampart = lookForStructures(room, C.STRUCTURE_RAMPART)[0];
-				const container = lookForStructures(room, C.STRUCTURE_CONTAINER)[0];
-				const road = lookForStructures(room, C.STRUCTURE_ROAD)[0];
-				assert.ok(tower && rampart && container && road, 'deploy spawns every template structure');
+			await peekRoom('W1N1', (room, Game) => {
+				const core = findRoomCore(room)!;
+				const collapseTime = core['#collapseTime'];
+				const strongholdId = core['#strongholdId'];
+				assert.ok(strongholdId !== null, 'the core carries a stronghold id');
+
+				// Two towers and two containers distinguish bunker2 from the single-of-each stub.
+				const towers = lookForStructures(room, C.STRUCTURE_TOWER);
+				const containers = lookForStructures(room, C.STRUCTURE_CONTAINER);
+				const ramparts = lookForStructures(room, C.STRUCTURE_RAMPART);
+				const roads = lookForStructures(room, C.STRUCTURE_ROAD);
+				assert.strictEqual(towers.length, 2, 'bunker2 spawns two towers');
+				assert.strictEqual(containers.length, 2, 'bunker2 spawns two containers');
+
+				const tower = towers[0]!;
+				const rampart = ramparts[0]!;
+				const container = containers[0]!;
+				assert.strictEqual(tower.store.getUsedCapacity(C.RESOURCE_ENERGY), C.TOWER_CAPACITY, 'tower deploys at full energy');
+				assert.strictEqual(rampart.hits, C.STRONGHOLD_RAMPART_HITS[2]!, 'rampart hits scale with the template reward level');
+				assert.ok(container.store.getUsedCapacity() > 0, 'container deploys carrying a resource reward');
+				assert.strictEqual(container.store.getCapacity(), 0, 'reward container is withdraw-only');
+
+				// Co-located structures share a tile: (26,25) holds a container, a road, and a rampart.
+				const stackedPos = new RoomPosition(26, 25, 'W1N1');
+				assert.ok(lookForStructureAt(room, stackedPos, C.STRUCTURE_CONTAINER), 'container shares the tile');
+				assert.ok(lookForStructureAt(room, stackedPos, C.STRUCTURE_ROAD), 'road shares the tile');
+				assert.ok(lookForStructureAt(room, stackedPos, C.STRUCTURE_RAMPART), 'rampart shares the tile');
+
 				assert.strictEqual(tower['#user'], '2', 'tower is owned by the invader NPC');
 				assert.strictEqual(rampart['#user'], '2', 'rampart is owned by the invader NPC');
-				for (const peer of [ tower, rampart, container, road ]) {
-					assert.strictEqual(peer['#collapseTime'], decayTime, 'peer shares the core collapse timer');
+				for (const peer of [ tower, rampart, container, roads[0]! ]) {
+					assert.strictEqual(peer['#collapseTime'], collapseTime, 'peer shares the core collapse timer');
+					assert.strictEqual(peer['#strongholdId'], strongholdId, 'peer shares the stronghold id');
+					assert.deepStrictEqual(peer.effects, [
+						{ effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining: collapseTime - Game.time },
+					], 'peer surfaces the shared collapse timer');
 				}
 				// Pinned to the collapse time so they don't decay (and read a past expiry, which throws)
 				// while the stronghold room sleeps between deploy and collapse.
-				for (const peer of [ rampart, container, road ]) {
-					assert.strictEqual(peer['#nextDecayTime'], decayTime, 'decaying peer will not decay before collapse');
+				for (const peer of [ rampart, container, roads[0]! ]) {
+					assert.strictEqual(peer['#nextDecayTime'], collapseTime, 'decaying peer will not decay before collapse');
 				}
+			});
+		}));
+
+		// Player objects sitting on bunker2 tiles when the deploy fires: a creep on a stacked
+		// container/road/rampart tile, construction sites above and below the refund threshold, and a
+		// road where the template also places one.
+		const crushScene = simulate({
+			W1N1: room => {
+				const core = createInvaderCore(corePos, 2, 1);
+				core['#templateName'] = 'bunker2';
+				room['#insertObject'](core);
+				room['#insertObject'](createCreep(new RoomPosition(26, 25, 'W1N1'), [ C.MOVE ], 'victim', '100'));
+				const site = createSite(new RoomPosition(25, 24, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road);
+				site.progress = 100;
+				room['#insertObject'](site);
+				room['#insertObject'](createSite(new RoomPosition(25, 26, 'W1N1'), 'road', '100', C.CONSTRUCTION_COST.road));
+				room['#insertObject'](createRoad(new RoomPosition(24, 25, 'W1N1')));
+				activateNPC(room, '2');
+			},
+		});
+
+		test('deploy crushes player objects on template tiles', () => crushScene(async ({ tick, peekRoom }) => {
+			await tick(2);
+			await peekRoom('W1N1', room => {
+				// The creep dies where it stood — once, though its tile carries three template entries.
+				assert.strictEqual(room.find(C.FIND_CREEPS).length, 0, 'a creep on a template tile dies');
+				const tombstones = room.find(C.FIND_TOMBSTONES);
+				assert.strictEqual(tombstones.length, 1, 'the crushed creep is buried exactly once');
+				assert.ok(tombstones[0]!.pos.isEqualTo(new RoomPosition(26, 25, 'W1N1')), 'tombstone sits on the crush tile');
+
+				// Sites are removed; only progress above 1 refunds half as dropped energy.
+				assert.strictEqual(room.find(C.FIND_CONSTRUCTION_SITES).length, 0, 'sites on template tiles are removed');
+				const [ refund, ...extra ] = room.find(C.FIND_DROPPED_RESOURCES);
+				assert.strictEqual(extra.length, 0, 'a zero-progress site refunds nothing');
+				assert.ok(refund!.pos.isEqualTo(new RoomPosition(25, 24, 'W1N1')), 'refund drops on the site tile');
+				assert.strictEqual(refund!.amount, 50, 'refund is half the site progress');
+
+				// The player road is destroyed and the tile now holds the stronghold's own road.
+				assert.strictEqual(room.find(C.FIND_RUINS).length, 1, 'the crushed road leaves a Ruin');
+				const road = lookForStructureAt(room, new RoomPosition(24, 25, 'W1N1'), C.STRUCTURE_ROAD)!;
+				assert.ok(road['#collapseTime'] > 0, 'the surviving road is the stronghold peer');
 			});
 		}));
 


### PR DESCRIPTION
Replaces the stub stronghold layout with the five bunker templates from `@screeps/common/lib/strongholds.js` (ISC). On deploy the core clears each template tile the way vanilla does — creeps die, construction sites drop half their progress as energy, player-buildable structures are destroyed — then spawns its template's peers: ramparts at `STRONGHOLD_RAMPART_HITS[rewardLevel]`, towers at full energy, and containers rolling loot from the weighted reward table.

- `#templateName` is stored on the core at placement rather than derived from its level, so layout selection stays independent of core level and deploy just reads it.
- `#strongholdId` groups a stronghold's structures under one id. Deploy only writes it today; the defense/behavior slice (next up) queries by it, so it rides this migration alongside `#collapseTime`. That slice also wants vanilla's rampart `hitsTarget` (stamped at deploy, retuned by antinuke), which will ratchet the Structure archive again regardless — happy to move `#strongholdId` into that PR instead if you'd rather the field land with its first reader.
- Deployed peers surface `EFFECT_COLLAPSE_TIMER` via an `extend(Structure, …)` effects getter in the invader mod, which owns `#collapseTime`; the core's and controller's own getters shadow it.
- Deployed ramparts carry hits above `hitsMax`, which reads 0 in a room the invader doesn't control; live servers show the same.
- Templates reach ±3 tiles from the core, so deploy assumes the core sits at least 3 tiles inside the room edge; placement will enforce that margin when it lands.

## Validation

- 479/479 unit tests; eslint clean on changed files.
- Live smoke in the worktree: bunker3 deployed through the real processor (35 structures, container loot summing to the 10000 target density), server restarted with the stronghold intact, and a shortened collapse timer removed every peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
