### PR TITLE
memory: add memory-segment API endpoints

### DIFF
--- a/.changeset/memory-segment-endpoints.md
+++ b/.changeset/memory-segment-endpoints.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `/api/user/memory-segment` endpoints; active segments pick up out-of-band writes.

--- a/packages/xxscreeps/mods/meta/memory/backend.ts
+++ b/packages/xxscreeps/mods/meta/memory/backend.ts
@@ -4,11 +4,11 @@ import { gzip } from 'node:zlib';
 import { hooks, makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import { requestRunnerEval } from 'xxscreeps/engine/runner/model.js';
-import { isValidSegmentId, kMaxMemorySegmentLength } from 'xxscreeps/mods/meta/memory/memory.js';
-import { getPublicSegmentChannel, loadMemorySegmentBlob, loadUserMemoryString, saveMemorySegmentBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import { mustNotReject } from 'xxscreeps/utility/async.js';
 import { typedArrayToString, utf16ToBuffer } from 'xxscreeps/utility/string.js';
 import { throttle } from 'xxscreeps/utility/utility.js';
+import { isValidSegmentId, kMaxMemorySegmentLength } from './memory.js';
+import { loadMemorySegmentBlob, loadUserMemoryString, publicSegmentChannel, saveMemorySegmentBlob } from './model.js';
 
 const invalidPath = 'Incorrect memory path';
 const emptyObject = Object.create(null);
@@ -145,7 +145,7 @@ interface SegmentGetRequest {
 const segmentGetRequestSchema: JSONSchemaType<SegmentGetRequest> = {
 	type: 'object',
 	properties: {
-		segment: { type: 'string', pattern: '^\\d+$' },
+		segment: { type: 'string' },
 	},
 	required: [ 'segment' ],
 };
@@ -199,11 +199,9 @@ hooks.register('route', {
 		if (data.length > kMaxMemorySegmentLength) {
 			throw new Error('Memory segment size is too large');
 		}
-		// The publish wakes up subscribers, same as the runner connector does on save. Firing it
-		// alongside the write is safe because reads are synchronized on tick.
 		await Promise.all([
 			saveMemorySegmentBlob(context.shard, userId, segment, utf16ToBuffer(data)),
-			getPublicSegmentChannel(context.shard, userId).publish({ type: 'segment', id: segment }),
+			publicSegmentChannel(context.shard, userId).publish({ type: 'segment', id: segment }),
 		]);
 		return { ok: 1 };
 	}, { coerceTypes: true }),

--- a/packages/xxscreeps/mods/meta/memory/backend.ts
+++ b/packages/xxscreeps/mods/meta/memory/backend.ts
@@ -4,8 +4,10 @@ import { gzip } from 'node:zlib';
 import { hooks, makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import { requestRunnerEval } from 'xxscreeps/engine/runner/model.js';
-import { loadUserMemoryString } from 'xxscreeps/mods/meta/memory/model.js';
+import { isValidSegmentId, kMaxMemorySegmentLength } from 'xxscreeps/mods/meta/memory/memory.js';
+import { getPublicSegmentChannel, loadMemorySegmentBlob, loadUserMemoryString, saveMemorySegmentBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import { mustNotReject } from 'xxscreeps/utility/async.js';
+import { typedArrayToString, utf16ToBuffer } from 'xxscreeps/utility/string.js';
 import { throttle } from 'xxscreeps/utility/utility.js';
 
 const invalidPath = 'Incorrect memory path';
@@ -134,4 +136,75 @@ hooks.register('route', {
 		await requestRunnerEval(context.shard, userId, expression, false);
 		return { ok: 1 };
 	}),
+});
+
+interface SegmentGetRequest {
+	segment: string;
+}
+
+const segmentGetRequestSchema: JSONSchemaType<SegmentGetRequest> = {
+	type: 'object',
+	properties: {
+		segment: { type: 'string', pattern: '^\\d+$' },
+	},
+	required: [ 'segment' ],
+};
+
+hooks.register('route', {
+	path: '/api/user/memory-segment',
+
+	execute: makeValidatedQueryRoute(segmentGetRequestSchema, async context => {
+		const { userId } = context.state;
+		if (userId == null) {
+			return;
+		}
+		const segmentId = Number(context.request.query.segment);
+		if (!isValidSegmentId(segmentId)) {
+			return { error: 'invalid segment' };
+		}
+		const blob = await loadMemorySegmentBlob(context.shard, userId, segmentId);
+		// Missing segments read as an empty string, same as `RawMemory.segments` in the runtime
+		const data = blob === null ? '' : typedArrayToString(new Uint16Array(blob.buffer, blob.byteOffset, blob.length >>> 1));
+		return { ok: 1, data };
+	}),
+});
+
+interface SegmentPostRequest {
+	segment: number;
+	data: string;
+}
+
+const segmentPostRequestSchema: JSONSchemaType<SegmentPostRequest> = {
+	type: 'object',
+	properties: {
+		segment: { type: 'number' },
+		data: { type: 'string' },
+	},
+	required: [ 'segment', 'data' ],
+};
+
+hooks.register('route', {
+	path: '/api/user/memory-segment',
+	method: 'post',
+
+	execute: makeValidatedPayloadRoute(segmentPostRequestSchema, async context => {
+		const { userId } = context.state;
+		if (userId == null) {
+			return;
+		}
+		const { segment, data } = context.request.body;
+		if (!isValidSegmentId(segment)) {
+			return { error: 'invalid segment' };
+		}
+		if (data.length > kMaxMemorySegmentLength) {
+			throw new Error('Memory segment size is too large');
+		}
+		// The publish wakes up subscribers, same as the runner connector does on save. Firing it
+		// alongside the write is safe because reads are synchronized on tick.
+		await Promise.all([
+			saveMemorySegmentBlob(context.shard, userId, segment, utf16ToBuffer(data)),
+			getPublicSegmentChannel(context.shard, userId).publish({ type: 'segment', id: segment }),
+		]);
+		return { ok: 1 };
+	}, { coerceTypes: true }),
 });

--- a/packages/xxscreeps/mods/meta/memory/driver.ts
+++ b/packages/xxscreeps/mods/meta/memory/driver.ts
@@ -1,5 +1,6 @@
 import type { ForeignSegmentPayload, SegmentPayload, flush } from './memory.js';
 import type { ForeignSegmentRequest, StoredForeignSegmentRequest } from './model.js';
+import type { SubscriptionFor } from 'xxscreeps/engine/db/channel.js';
 import type { Effect } from 'xxscreeps/utility/types.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -29,6 +30,8 @@ hooks.register('runnerConnector', player => {
 	const { shard, userId } = player;
 	let activeSegments: Set<number>;
 	let nextSegments: Set<number> | undefined;
+	const dirtySegments = new Set<number>();
+	let ownSubscription: SubscriptionFor<ReturnType<typeof getPublicSegmentChannel>> | undefined;
 	let activeForeignSegment: StoredForeignSegmentRequest | null = null;
 	let subscribedUserId: string | null = null;
 	let subscriptionEffect: Effect | undefined;
@@ -54,11 +57,29 @@ hooks.register('runnerConnector', player => {
 		}
 	}
 
-	return [ () => subscriptionEffect?.(), {
+	return [ () => {
+		subscriptionEffect?.();
+		ownSubscription?.disconnect();
+	}, {
 		async initialize(payload) {
 			activeSegments = new Set();
 			nextSegments = undefined;
-			activeForeignSegment = await loadActiveForeignSegment(shard, userId);
+			dirtySegments.clear();
+			// The own-channel subscription watches for out-of-band segment writes, e.g. from the
+			// memory-segment API endpoint. This runner's own saves publish through this same
+			// subscription, so they are not echoed back.
+			[ ownSubscription, activeForeignSegment ] = await Promise.all([
+				ownSubscription ?? async function() {
+					const subscription = await getPublicSegmentChannel(shard, userId).subscribe();
+					subscription.listen(message => {
+						if (message.type === 'segment' && (activeSegments.has(message.id) || nextSegments?.has(message.id) === true)) {
+							dirtySegments.add(message.id);
+						}
+					});
+					return subscription;
+				}(),
+				loadActiveForeignSegment(shard, userId),
+			]);
 			await syncForeignSubscription();
 			payload.memoryBlob = await loadUserMemoryBlob(shard, userId);
 		},
@@ -75,6 +96,20 @@ hooks.register('runnerConnector', player => {
 				));
 				activeSegments = nextSegments;
 				nextSegments = undefined;
+			}
+			// Resend active segments written out-of-band since the last tick. A duplicate id from the
+			// newly-requested batch above is fine: the runtime applies payloads in order, so this
+			// fresher read wins.
+			if (dirtySegments.size !== 0) {
+				const ids = [ ...Fn.filter(dirtySegments, id => activeSegments.has(id)) ];
+				dirtySegments.clear();
+				payload.memorySegments = [
+					...payload.memorySegments ?? [],
+					...await Fn.mapAwait(ids, async id => ({
+						id,
+						payload: await loadMemorySegmentBlob(shard, userId, id),
+					})),
+				];
 			}
 			// Only refetch and push to the runtime when the publisher notified us (or on target
 			// change). Otherwise the runtime holds last tick's payload and doesn't recreate the
@@ -102,8 +137,9 @@ hooks.register('runnerConnector', player => {
 				nextSegments = new Set(Fn.take(payload.activeSegmentsRequest, kMaxActiveSegments));
 			}
 
-			// Dispatch updates
-			const channel = getPublicSegmentChannel(shard, userId);
+			// Dispatch updates. Publishing through our own subscription keeps these saves from echoing
+			// back into the out-of-band listener above.
+			const channel = ownSubscription!;
 			await Promise.all([
 				// Save primary memory blob
 				payload.memoryUpdated.payload && saveMemoryBlob(shard, userId, payload.memoryUpdated.payload),

--- a/packages/xxscreeps/mods/meta/memory/driver.ts
+++ b/packages/xxscreeps/mods/meta/memory/driver.ts
@@ -5,7 +5,7 @@ import type { Effect } from 'xxscreeps/utility/types.js';
 import { hooks } from 'xxscreeps/engine/runner/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { kMaxActiveSegments } from './memory.js';
-import { getPublicSegmentChannel, isPublicSegment, loadActiveForeignSegment, loadMemorySegmentBlob, loadUserMemoryBlob, saveActiveForeignSegment, saveDefaultPublicSegment, saveMemoryBlob, saveMemorySegmentBlob, savePublicSegments } from './model.js';
+import { isPublicSegment, loadActiveForeignSegment, loadMemorySegmentBlob, loadUserMemoryBlob, publicSegmentChannel, saveActiveForeignSegment, saveDefaultPublicSegment, saveMemoryBlob, saveMemorySegmentBlob, savePublicSegments } from './model.js';
 
 declare module 'xxscreeps/engine/runner/index.js' {
 	interface InitializationPayload {
@@ -31,7 +31,7 @@ hooks.register('runnerConnector', player => {
 	let activeSegments: Set<number>;
 	let nextSegments: Set<number> | undefined;
 	const dirtySegments = new Set<number>();
-	let ownSubscription: SubscriptionFor<ReturnType<typeof getPublicSegmentChannel>> | undefined;
+	let ownSubscription: SubscriptionFor<ReturnType<typeof publicSegmentChannel>> | undefined;
 	let activeForeignSegment: StoredForeignSegmentRequest | null = null;
 	let subscribedUserId: string | null = null;
 	let subscriptionEffect: Effect | undefined;
@@ -47,7 +47,7 @@ hooks.register('runnerConnector', player => {
 		subscribedUserId = target;
 		foreignDirty = true;
 		if (target !== null) {
-			const subscription = await getPublicSegmentChannel(shard, target).subscribe();
+			const subscription = await publicSegmentChannel(shard, target).subscribe();
 			subscription.listen(message => {
 				if (message.type === 'publicSet' || message.id === activeForeignSegment?.segmentId) {
 					foreignDirty = true;
@@ -70,7 +70,7 @@ hooks.register('runnerConnector', player => {
 			// subscription, so they are not echoed back.
 			[ ownSubscription, activeForeignSegment ] = await Promise.all([
 				ownSubscription ?? async function() {
-					const subscription = await getPublicSegmentChannel(shard, userId).subscribe();
+					const subscription = await publicSegmentChannel(shard, userId).subscribe();
 					subscription.listen(message => {
 						if (message.type === 'segment' && (activeSegments.has(message.id) || nextSegments?.has(message.id) === true)) {
 							dirtySegments.add(message.id);

--- a/packages/xxscreeps/mods/meta/memory/model.ts
+++ b/packages/xxscreeps/mods/meta/memory/model.ts
@@ -1,4 +1,5 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
+import * as assert from 'node:assert/strict';
 import { Channel } from 'xxscreeps/engine/db/channel.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -19,12 +20,13 @@ export type StoredForeignSegmentRequest = {
 	segmentId: number;
 };
 
-type PublicSegmentMessage =
+export type PublicSegmentChannel = Channel<
 	{ type: 'segment'; id: number } |
-	{ type: 'publicSet' };
+	{ type: 'publicSet' }
+>;
 
-export function getPublicSegmentChannel(shard: Shard, userId: string) {
-	return new Channel<PublicSegmentMessage>(shard.pubsub, `user/${userId}/publicSegments`);
+export function publicSegmentChannel(shard: Shard, userId: string): PublicSegmentChannel {
+	return new Channel(shard.pubsub, `user/${userId}/publicSegments`);
 }
 
 export function loadUserMemoryBlob(shard: Shard, user: string) {
@@ -46,18 +48,20 @@ export function deleteUserMemoryBlob(shard: Shard, userId: string) {
 	return shard.data.vDel(`user/${userId}/memory`);
 }
 
+const memorySegmentKey = (userId: string, segmentId: number) => `user/${userId}/segments/${segmentId}`;
+
 export function loadMemorySegmentBlob(shard: Shard, userId: string, segmentId: number) {
-	return shard.data.get(`user/${userId}/segment${segmentId}`, { blob: true });
+	return shard.data.get(memorySegmentKey(userId, segmentId), { blob: true });
 }
 
 export async function saveMemorySegmentBlob(shard: Shard, userId: string, segmentId: number, blob: Readonly<Uint8Array> | null) {
-	if (isValidSegmentId(segmentId)) {
-		const key = `user/${userId}/segment${segmentId}`;
-		if (blob === null || blob.byteLength === 0) {
-			await shard.data.vDel(key);
-		} else if (blob.byteLength <= kMaxMemorySegmentSize) {
-			return shard.data.set(key, blob);
-		}
+	assert.ok(isValidSegmentId(segmentId));
+	const key = memorySegmentKey(userId, segmentId);
+	if (blob === null || blob.byteLength === 0) {
+		return shard.data.vDel(key);
+	} else {
+		assert.ok(blob.byteLength <= kMaxMemorySegmentSize);
+		return shard.data.set(key, blob);
 	}
 }
 

--- a/packages/xxscreeps/mods/meta/memory/test.ts
+++ b/packages/xxscreeps/mods/meta/memory/test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { RoomPosition } from 'xxscreeps/game/position.js';
-import { getPublicSegmentChannel, saveMemorySegmentBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import * as Spawn from 'xxscreeps/mods/classic/spawn/spawn.js';
+import { publicSegmentChannel, saveMemorySegmentBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import { describe, simulate, test } from 'xxscreeps/test/index.js';
 import { utf16ToBuffer } from 'xxscreeps/utility/string.js';
 // nb: Try not to include too much in this file because `sandbox` uses a fake function that gets
@@ -167,7 +167,7 @@ describe('mod/meta/memory', () => {
 		await tick(2);
 		// Simulates the memory-segment API endpoint: write the blob, then notify
 		await saveMemorySegmentBlob(shard, '200', 0, utf16ToBuffer('foo'));
-		await getPublicSegmentChannel(shard, '200').publish({ type: 'segment', id: 0 });
+		await publicSegmentChannel(shard, '200').publish({ type: 'segment', id: 0 });
 		await tick(2);
 	}));
 });

--- a/packages/xxscreeps/mods/meta/memory/test.ts
+++ b/packages/xxscreeps/mods/meta/memory/test.ts
@@ -1,7 +1,9 @@
 import * as assert from 'node:assert/strict';
 import { RoomPosition } from 'xxscreeps/game/position.js';
+import { getPublicSegmentChannel, saveMemorySegmentBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import * as Spawn from 'xxscreeps/mods/classic/spawn/spawn.js';
 import { describe, simulate, test } from 'xxscreeps/test/index.js';
+import { utf16ToBuffer } from 'xxscreeps/utility/string.js';
 // nb: Try not to include too much in this file because `sandbox` uses a fake function that gets
 // stringified. So includes here confuse the seen globals.
 
@@ -150,5 +152,22 @@ describe('mod/meta/memory', () => {
 			assert.equal(global.Memory.test, 'bar');
 		});
 		await tick(1);
+	}));
+
+	test('Out-of-band segment write reaches an active segment', () => sim(async ({ shard, sandbox, tick }) => {
+		await using player = await sandbox('200', global => {
+			// The shard's starting time is an implementation detail; count ticks explicitly
+			const tickCount = global.Memory.tick = (global.Memory.tick as number | undefined ?? 0) + 1;
+			switch (tickCount) {
+				case 1: global.RawMemory.setActiveSegments([ 0 ]); break;
+				case 2: assert.equal(global.RawMemory.segments[0], ''); break;
+				case 4: assert.equal(global.RawMemory.segments[0], 'foo'); break;
+			}
+		});
+		await tick(2);
+		// Simulates the memory-segment API endpoint: write the blob, then notify
+		await saveMemorySegmentBlob(shard, '200', 0, utf16ToBuffer('foo'));
+		await getPublicSegmentChannel(shard, '200').publish({ type: 'segment', id: 0 });
+		await tick(2);
 	}));
 });


### PR DESCRIPTION
GET/POST /api/user/memory-segment read and write segment blobs directly. The runner connector subscribes to the user's own public-segment channel and resends active segments written out-of-band; its own saves publish through that subscription so they are not echoed back.
