### PR TITLE
backend: trust X-Forwarded-* headers via configurable proxy settings

### DIFF
--- a/.changeset/backend-trusted-proxy-config.md
+++ b/.changeset/backend-trusted-proxy-config.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add backend proxy config to trust `X-Forwarded-*` headers behind a reverse proxy.

--- a/packages/xxscreeps/backend/server.ts
+++ b/packages/xxscreeps/backend/server.ts
@@ -22,7 +22,11 @@ initializeGameEnvironment();
 // Initialize services
 await using backendContext = await BackendContext.connect();
 hooks.makeIterated('backendReady')(backendContext.db, backendContext.shard);
-const koa = new Koa<State, Context>();
+const koa = new Koa<State, Context>({
+	proxy: config.backend.proxy,
+	...config.backend.proxyIpHeader !== undefined && { proxyIpHeader: config.backend.proxyIpHeader },
+	...config.backend.maxIpsCount !== undefined && { maxIpsCount: config.backend.maxIpsCount },
+});
 const router = new Router<State, Context>();
 
 // Set up endpoints

--- a/packages/xxscreeps/config/config.schema.json
+++ b/packages/xxscreeps/config/config.schema.json
@@ -19,6 +19,20 @@
                     "description": "Network interface to bind server to. Format is: \"host\" or \"host:port\". Host can be * to bind\nto all interfaces: \"*:port\". Port is 21025, if not specified.",
                     "type": "string"
                 },
+                "maxIpsCount": {
+                    "default": 0,
+                    "description": "Maximum number of `X-Forwarded-For` entries to trust, counted from the proxy inward, when\n`proxy` is enabled. This limits IP spoofing by ignoring any addresses a client prepends beyond\nthe known number of proxy hops. `0` (the default) trusts the whole chain, so set it to the\nnumber of proxies in front of the backend.",
+                    "type": "number"
+                },
+                "proxy": {
+                    "default": false,
+                    "description": "Trust `X-Forwarded-*` headers set by a reverse proxy. When enabled, the backend derives the\nrequest protocol from `X-Forwarded-Proto` (so `ctx.secure`/`ctx.protocol` correctly report\n`https` when TLS is terminated at the proxy), the host from `X-Forwarded-Host`, and the client\nIP from `X-Forwarded-For`.\n\nOnly enable this when the backend is exclusively reachable through a trusted proxy that sets\nthese headers. A direct client can forge them otherwise (e.g. spoofing `https`).",
+                    "type": "boolean"
+                },
+                "proxyIpHeader": {
+                    "description": "Header used to read the client IP when `proxy` is enabled. Defaults to `X-Forwarded-For`. Set\nthis if your proxy uses a different header, e.g. `X-Real-IP`.",
+                    "type": "string"
+                },
                 "secret": {
                     "description": "Secret used for session authentication. If not specified a new secret will be generated each\nrestart.",
                     "type": "string"

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -26,6 +26,33 @@ export interface BackendConfig {
 	bind?: string;
 
 	/**
+	 * Trust `X-Forwarded-*` headers set by a reverse proxy. When enabled, the backend derives the
+	 * request protocol from `X-Forwarded-Proto` (so `ctx.secure`/`ctx.protocol` correctly report
+	 * `https` when TLS is terminated at the proxy), the host from `X-Forwarded-Host`, and the client
+	 * IP from `X-Forwarded-For`.
+	 *
+	 * Only enable this when the backend is exclusively reachable through a trusted proxy that sets
+	 * these headers. A direct client can forge them otherwise (e.g. spoofing `https`).
+	 * @default false
+	 */
+	proxy?: boolean;
+
+	/**
+	 * Header used to read the client IP when `proxy` is enabled. Defaults to `X-Forwarded-For`. Set
+	 * this if your proxy uses a different header, e.g. `X-Real-IP`.
+	 */
+	proxyIpHeader?: string;
+
+	/**
+	 * Maximum number of `X-Forwarded-For` entries to trust, counted from the proxy inward, when
+	 * `proxy` is enabled. This limits IP spoofing by ignoring any addresses a client prepends beyond
+	 * the known number of proxy hops. `0` (the default) trusts the whole chain, so set it to the
+	 * number of proxies in front of the backend.
+	 * @default 0
+	 */
+	maxIpsCount?: number;
+
+	/**
 	 * Secret used for session authentication. If not specified a new secret will be generated each
 	 * restart.
 	 */
@@ -260,6 +287,7 @@ export const defaults = {
 	backend: {
 		allowGuestAccess: true,
 		bind: '*',
+		proxy: false,
 		socketThrottle: 125,
 	},
 	game: {


### PR DESCRIPTION
For generating correct urls the server needs to know the external urls and whether https was used behind a reverse proxy 

Add backend.proxy, backend.proxyIpHeader, and backend.maxIpsCount config options so the Koa app can honor X-Forwarded-Proto/Host/For when running behind a trusted reverse proxy. This makes ctx.secure/ctx.protocol report https correctly when TLS is terminated upstream (e.g. for OAuth redirect URIs).