### PR TITLE
sandbox: register schema provide in isolated webpack virtual modules

### DIFF
--- a/.changeset/isolated-sandbox-schema-provide.md
+++ b/.changeset/isolated-sandbox-schema-provide.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Register the `xxscreeps:mods/schema` virtual module in the isolated sandbox runtime bundle.

--- a/packages/xxscreeps/driver/sandbox/isolated/index.ts
+++ b/packages/xxscreeps/driver/sandbox/isolated/index.ts
@@ -46,6 +46,7 @@ const getRuntimeSource = runOnce(() => {
 			new VirtualModulesPlugin({
 				'/xxscreeps:mods/constants': makeModSourceText(mods, 'constants'),
 				'/xxscreeps:mods/game': makeModSourceText(mods, 'game'),
+				'/xxscreeps:mods/schema': makeModSourceText(mods, 'schema'),
 				'/xxscreeps:packages': makePackagesModule(),
 			}),
 		],


### PR DESCRIPTION
The mods-resolution overhaul made `makeSideEffectsSource` emit `import "xxscreeps:mods/schema"` from every side-effect mod module, and updated the `nodejs` and `experimental` sandboxes to serve that provide. The `isolated` (webpack) sandbox was missed — its `VirtualModulesPlugin` never registered `/xxscreeps:mods/schema` — so on the default sandbox the runner worker crashes at startup:

```
Module not found: Error: Can't resolve '/xxscreeps:mods/schema' in '/xxscreeps:mods'
```

Register the `schema` provide alongside `constants` and `game`, restoring parity with the other two sandbox backends.

## Validation

- `tsc -b packages/xxscreeps` — clean (node 24).
- `xxscreeps test` — 478 passed / 0 failed on the default `isolated` sandbox, which builds and runs the affected runtime bundle.
- `eslint` on the changed file — no new warnings.
