### PR TITLE
pf: keep multi-goal storage alive during search

### DIFF
--- a/.changeset/pathfinder-goal-lifetime.md
+++ b/.changeset/pathfinder-goal-lifetime.md
@@ -1,0 +1,5 @@
+---
+"@xxscreeps/pathfinder": patch
+---
+
+fix use-after-free of multi-goal storage in search

--- a/packages/pathfinder/src/heuristic.cc
+++ b/packages/pathfinder/src/heuristic.cc
@@ -38,13 +38,16 @@ export class heuristic_t {
 		// Extract 1 or N goals from passed runtime array, avoiding `std::vector` allocation in the
 		// common 1 case. `storage` owns the N goals and must outlive the returned heuristic.
 		template <class Lock, class Range>
-		static auto make_from_runtime(Lock& lock, Range goals, bool flee, std::vector<goal_t>& storage) -> heuristic_t {
+		static auto make_from_runtime(Lock& lock, Range goals, bool flee) -> auto {
 			if (goals.size() == 1) {
+				auto storage = std::vector<goal_t>{};
 				auto element = (*util::into_range(goals).begin()).second;
-				return {js::transfer_out<heuristic_t::goal_t>(element, lock), flee};
+				auto heuristic = heuristic_t{js::transfer_out<heuristic_t::goal_t>(element, lock), flee};
+				return std::pair{heuristic, std::move(storage)};
 			} else {
-				storage = js::transfer_out<std::vector<heuristic_t::goal_t>>(goals, lock);
-				return {std::span{storage}, flee};
+				auto storage = js::transfer_out<std::vector<heuristic_t::goal_t>>(goals, lock);
+				auto heuristic = heuristic_t{std::span{storage}, flee};
+				return std::pair{heuristic, std::move(storage)};
 			}
 		}
 

--- a/packages/pathfinder/src/heuristic.cc
+++ b/packages/pathfinder/src/heuristic.cc
@@ -36,7 +36,7 @@ export class heuristic_t {
 		}
 
 		// Extract 1 or N goals from passed runtime array, avoiding `std::vector` allocation in the
-		// common 1 case. `storage` owns the N goals and must outlive the returned heuristic.
+		// common 1 case.
 		template <class Lock, class Range>
 		static auto make_from_runtime(Lock& lock, Range goals, bool flee) -> auto {
 			if (goals.size() == 1) {

--- a/packages/pathfinder/src/heuristic.cc
+++ b/packages/pathfinder/src/heuristic.cc
@@ -36,18 +36,15 @@ export class heuristic_t {
 		}
 
 		// Extract 1 or N goals from passed runtime array, avoiding `std::vector` allocation in the
-		// common 1 case.
+		// common 1 case. `storage` owns the N goals and must outlive the returned heuristic.
 		template <class Lock, class Range>
-		static auto make_from_runtime(Lock& lock, Range goals, bool flee) -> heuristic_t {
-			heuristic_t::goal_t one_goal;
-			std::vector<heuristic_t::goal_t> n_goals;
+		static auto make_from_runtime(Lock& lock, Range goals, bool flee, std::vector<goal_t>& storage) -> heuristic_t {
 			if (goals.size() == 1) {
 				auto element = (*util::into_range(goals).begin()).second;
-				one_goal = js::transfer_out<heuristic_t::goal_t>(element, lock);
-				return {one_goal, flee};
+				return {js::transfer_out<heuristic_t::goal_t>(element, lock), flee};
 			} else {
-				n_goals = js::transfer_out<std::vector<heuristic_t::goal_t>>(goals, lock);
-				return {std::span{n_goals}, flee};
+				storage = js::transfer_out<std::vector<heuristic_t::goal_t>>(goals, lock);
+				return {std::span{storage}, flee};
 			}
 		}
 

--- a/packages/pathfinder/src/iv.cc
+++ b/packages/pathfinder/src/iv.cc
@@ -100,8 +100,7 @@ auto search(
 	bool flee,
 	double heuristic_weight
 ) -> std::optional<result> {
-	auto goals_storage = std::vector<heuristic_t::goal_t>{};
-	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee, goals_storage);
+	auto [ heuristic, storage ] = heuristic_t::make_from_runtime(lock, goals, flee);
 	return pathfinders<Callback>(util::overloaded{
 		[]() -> std::optional<result> { throw js::runtime_error{u"too many concurrent pathfinder searches"}; },
 		[ & ](auto& pf) -> std::optional<result> {

--- a/packages/pathfinder/src/iv.cc
+++ b/packages/pathfinder/src/iv.cc
@@ -100,7 +100,8 @@ auto search(
 	bool flee,
 	double heuristic_weight
 ) -> std::optional<result> {
-	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee);
+	auto goals_storage = std::vector<heuristic_t::goal_t>{};
+	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee, goals_storage);
 	return pathfinders<Callback>(util::overloaded{
 		[]() -> std::optional<result> { throw js::runtime_error{u"too many concurrent pathfinder searches"}; },
 		[ & ](auto& pf) -> std::optional<result> {

--- a/packages/pathfinder/src/main.cc
+++ b/packages/pathfinder/src/main.cc
@@ -68,8 +68,7 @@ auto search(
 	bool flee,
 	double heuristic_weight
 ) -> std::optional<result> {
-	auto goals_storage = std::vector<heuristic_t::goal_t>{};
-	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee, goals_storage);
+	auto [ heuristic, storage ] = heuristic_t::make_from_runtime(lock, goals, flee);
 	return pathfinders(
 		util::overloaded{
 			[]() -> std::optional<result> { throw js::runtime_error{u"too many concurrent pathfinder searches"}; },

--- a/packages/pathfinder/src/main.cc
+++ b/packages/pathfinder/src/main.cc
@@ -68,7 +68,8 @@ auto search(
 	bool flee,
 	double heuristic_weight
 ) -> std::optional<result> {
-	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee);
+	auto goals_storage = std::vector<heuristic_t::goal_t>{};
+	auto heuristic = heuristic_t::make_from_runtime(lock, goals, flee, goals_storage);
 	return pathfinders(
 		util::overloaded{
 			[]() -> std::optional<result> { throw js::runtime_error{u"too many concurrent pathfinder searches"}; },


### PR DESCRIPTION
`make_from_runtime` returned a heuristic whose goals span pointed into a local vector, so every multi-goal search read freed memory after the factory returned — searches with several goals came back `incomplete` (platform- and run-dependent). Goal storage now lives in the caller's frame for the duration of the search; the 1-goal no-allocation path is unchanged.

## Validation

Reproduced against screeps-ok at 0.4.1 and confirmed fixed with locally-built binaries: PATHFINDER-006 (multi-goal `PathFinder.search` routes to the closest goal), ROOMPOS-FIND-002 (`findClosestByPath` ignores unreachable targets), ROOMPOS-FIND-009 (`costCallback` walling off the cheapest route), ROOMPOS-FIND-001 (same-tile target, previously flaky on darwin-arm64) — 4 consecutive green runs on darwin-arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)