### PR TITLE
invader: reset room controller on core collapse expiry

### DIFF
--- a/.changeset/invader-core-collapse-controller-reset.md
+++ b/.changeset/invader-core-collapse-controller-reset.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reset the room controller to neutral when an invader core collapse timer expires.

--- a/packages/xxscreeps/mods/classic/controller/processor.ts
+++ b/packages/xxscreeps/mods/classic/controller/processor.ts
@@ -37,6 +37,8 @@ export function release(context: ProcessorContext, controller: StructureControll
 	controller['#reservationEndTime'] = 0;
 	controller['#safeModeCooldownTime'] = 0;
 	controller['#user'] = null;
+	controller.isPowerEnabled = false;
+	controller.safeModeAvailable = 0;
 	room['#safeModeUntil'] = 0;
 	updateRoomStatus(room, 0, null);
 	context.didUpdate();

--- a/packages/xxscreeps/mods/classic/controller/processor.ts
+++ b/packages/xxscreeps/mods/classic/controller/processor.ts
@@ -7,8 +7,8 @@ import { Game } from 'xxscreeps/game/index.js';
 import { saveAction } from 'xxscreeps/game/object.js';
 import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { Creep, calculateBoundedEffect } from 'xxscreeps/mods/classic/creep/creep.js';
-import { upsertNotification } from 'xxscreeps/mods/meta/notifications/model.js';
 import { checkActiveStructures } from 'xxscreeps/mods/classic/structure/structure.js';
+import { upsertNotification } from 'xxscreeps/mods/meta/notifications/model.js';
 import { StructureController, checkActivateSafeMode, checkUnclaim } from './controller.js';
 import * as CreepLib from './creep.js';
 import { controlledRoomsKey, incrementGlobalControlLevel, insertControlledRoom, insertReservedRoom, removeControlledRoom, removeReservedRoom } from './model.js';
@@ -37,6 +37,7 @@ export function release(context: ProcessorContext, controller: StructureControll
 	controller['#reservationEndTime'] = 0;
 	controller['#safeModeCooldownTime'] = 0;
 	controller['#user'] = null;
+	// TODO: Power needs to be moved to the powercreep mod
 	controller.isPowerEnabled = false;
 	controller.safeModeAvailable = 0;
 	room['#safeModeUntil'] = 0;

--- a/packages/xxscreeps/mods/invader/processor.ts
+++ b/packages/xxscreeps/mods/invader/processor.ts
@@ -208,12 +208,12 @@ registerObjectPreTickProcessor(Structure, (structure, context) => {
 	}
 });
 
-// The core shadows that removal to first release a controller it had taken over. Its reservation, if
-// any, is left to expire on its own — a level-0 controller short-circuits before the release.
+// The core shadows that removal to first reset any owned controller in its room to neutral. A
+// level-0 controller short-circuits so its reservation, if any, expires on its own.
 registerObjectPreTickProcessor(StructureInvaderCore, (core, context, next) => {
 	if (optionalExpiryTime(core['#collapseTime']) === 0) {
 		const controller = core.room.controller;
-		if (controller && controller.level > 0 && core.room['#user'] === '2') {
+		if (controller && controller.level > 0) {
 			release(context, controller);
 			controller['#upgradeInvulnerableUntil'] = 0;
 		}


### PR DESCRIPTION
Collapse expiry only reset a controller owned by the invader NPC (`core.room['#user'] === '2'`), leaving any other owner's controller with its level and ownership intact. This drops that gate, and moves the `isPowerEnabled` / `safeModeAvailable` resets into `release()` so every neutralization path (unclaim, downgrade-to-zero, unspawn, collapse) clears them. Reservations are untouched — a level-0 controller still short-circuits before the release.

## Validation

- screeps-ok INVADER-CORE-001..005: all pass; INVADER-CORE-004 (collapse resets an owned room controller to neutral) failed before this change.
- screeps-ok controller family (223 tests): no new failures; the two pre-existing expected failures (CTRL-UNCLAIM-001 / CTRL-DOWNGRADE-002, the `controller.my` undefined-after-neutral gap) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)