### PR TITLE
room-gen: place sources, controller, mineral, and keeper lairs

### DIFF
--- a/.changeset/room-object-generation.md
+++ b/.changeset/room-object-generation.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Place sources, controller, mineral, and keeper lairs in generated rooms; owner-less structures are always active.

--- a/.changeset/room-object-generation.md
+++ b/.changeset/room-object-generation.md
@@ -2,4 +2,4 @@
 "xxscreeps": patch
 ---
 
-Place sources, controller, mineral, and keeper lairs in generated rooms; owner-less structures are always active.
+Place sources, controller, mineral, keeper lairs via mod terrain hooks; owner-less structures always active.

--- a/README.md
+++ b/README.md
@@ -167,14 +167,21 @@ await using shard = await Shard.connect(db, 'shard0');
 
 await generateRoom(shard, 'W12N5');
 await generateRoom(shard, 'W11N5', { terrainType: 3, swampType: 2 });
+await generateRoom(shard, 'W10N5', { sources: 1, mineral: 'H' });
 await Promise.all([ db.save(), shard.save() ]);
 ```
 
-`generateRoom` adds a room with procedurally generated terrain to the shard's
-terrain blob and `rooms` set. Like `npx xxscreeps import`, it is an offline
-operation — stop the server before running it so cached world state in the
-backend, processor, and runner workers doesn't go stale. Exits are read from
-any already-generated neighbor, so adjacent generated rooms connect.
+`generateRoom` adds a room with procedurally generated terrain and objects to
+the shard's terrain blob and `rooms` set. The default loadout is a controller,
+1–2 sources, and a mineral; a source-keeper room is
+`{ controller: false, sources: 3, keeperLairs: true }` and a center room the
+same without the lairs — controller-less rooms hold keeper-capacity sources
+and a prebuilt extractor. `terrainType` picks one of 28 wall layouts and
+`swampType` one of 14 swamp layouts (0 for no swamp); both roll randomly when
+omitted. Like `npx xxscreeps import`, it is an offline operation — stop the
+server before running it so cached world state in the backend, processor, and
+runner workers doesn't go stale. Exits are read from any already-generated
+neighbor, so adjacent generated rooms connect.
 
 ## Docker
 

--- a/packages/xxscreeps/config/declarations/effects.d.ts
+++ b/packages/xxscreeps/config/declarations/effects.d.ts
@@ -5,4 +5,5 @@ declare module 'xxscreeps:mods/main';
 declare module 'xxscreeps:mods/processor';
 declare module 'xxscreeps:mods/schema';
 declare module 'xxscreeps:mods/storage';
+declare module 'xxscreeps:mods/terrain';
 declare module 'xxscreeps:mods/test';

--- a/packages/xxscreeps/config/loader.ts
+++ b/packages/xxscreeps/config/loader.ts
@@ -3,7 +3,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
 import { makeRelativeFragment } from 'xxscreeps/utility/url.js';
 
-const provideNames = [ 'backend', 'config', 'constants', 'driver', 'game', 'main', 'processor', 'schema', 'storage', 'test' ] as const;
+const provideNames = [ 'backend', 'config', 'constants', 'driver', 'game', 'main', 'processor', 'schema', 'storage', 'terrain', 'test' ] as const;
 /** @internal */
 export type Provide = typeof provideNames[number];
 /** @internal */

--- a/packages/xxscreeps/mods/classic/controller/index.ts
+++ b/packages/xxscreeps/mods/classic/controller/index.ts
@@ -7,6 +7,6 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/meta/notifications',
 		'xxscreeps/mods/classic/structure',
 	],
-	provides: [ 'backend', 'constants', 'driver', 'game', 'processor', 'schema', 'test' ],
+	provides: [ 'backend', 'constants', 'driver', 'game', 'processor', 'schema', 'terrain', 'test' ],
 	types,
 };

--- a/packages/xxscreeps/mods/classic/controller/terrain.ts
+++ b/packages/xxscreeps/mods/classic/controller/terrain.ts
@@ -1,0 +1,34 @@
+import { createRoomObject } from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { hooks } from 'xxscreeps/scripts/symbols.js';
+import { StructureController } from './controller.js';
+
+hooks.register('roomGenerator', {
+	order: 1,
+	generate(context) {
+		const { options, room } = context;
+		if (options.controller === false) {
+			room['#level'] = -1;
+			return true;
+		}
+		room['#user'] = null;
+		room['#level'] = 0;
+		const tile = context.findRandomTile(5, 40, context.isPlaceable);
+		if (tile === undefined) {
+			return false;
+		}
+		const controller = createRoomObject(new StructureController(), new RoomPosition(tile[0], tile[1], room.name));
+		context.place(controller, 'controller');
+		return true;
+	},
+});
+
+declare module 'xxscreeps/scripts/symbols.js' {
+	interface GenerateRoomOptions {
+		/**
+		 * Whether the room has a controller. Default is true. Controller-less rooms hold
+		 * keeper-capacity sources and a prebuilt extractor.
+		 */
+		controller?: boolean;
+	}
+}

--- a/packages/xxscreeps/mods/classic/mineral/extractor.ts
+++ b/packages/xxscreeps/mods/classic/mineral/extractor.ts
@@ -37,7 +37,7 @@ export class StructureExtractor extends withOverlay(OwnedStructure, extractorSha
 	override get structureType() { return C.STRUCTURE_EXTRACTOR; }
 }
 
-export function create(pos: RoomPosition, owner: string) {
+export function create(pos: RoomPosition, owner: string | null) {
 	const extractor = assign(createRoomObject(new StructureExtractor(), pos), {
 		hits: C.EXTRACTOR_HITS,
 	});

--- a/packages/xxscreeps/mods/classic/mineral/index.ts
+++ b/packages/xxscreeps/mods/classic/mineral/index.ts
@@ -7,6 +7,6 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/classic/resource',
 		'xxscreeps/mods/classic/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor', 'schema', 'test' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'schema', 'terrain', 'test' ],
 	types,
 };

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -1,0 +1,70 @@
+import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
+import { createRoomObject } from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { hooks } from 'xxscreeps/scripts/symbols.js';
+import * as C from './constants.js';
+import { create as createExtractor } from './extractor.js';
+import { Mineral } from './mineral.js';
+
+// Mineral roll weights: H and O are twice as common as Z/K/U/L, and six times as common as X.
+const mineralPool: ResourceType[] = [
+	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
+	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
+	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
+	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
+	C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM,
+	C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM,
+	C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM,
+	C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM,
+	C.RESOURCE_CATALYST,
+];
+
+const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
+
+function pickMineralDensity(): number {
+	const random = Math.random();
+	return C.MINERAL_DENSITY_PROBABILITY.findIndex(
+		probability => probability !== undefined && random <= probability);
+}
+
+hooks.register('roomGenerator', {
+	order: 2,
+	generate(context) {
+		const { options, room } = context;
+		const mineralType = options.mineral ?? mineralPool[Math.floor(Math.random() * mineralPool.length)]!;
+		if (mineralType === false) {
+			return true;
+		}
+		const tile = context.findRandomTile(4, 42, (xx, yy) =>
+			context.isPlaceable(xx, yy) && !Fn.some(iterateGridInRange(xx, yy, 4), ([ nxx, nyy ]) => {
+				const tags = context.tagsAt(nxx, nyy);
+				return tags.has('source') || tags.has('controller');
+			}));
+		if (tile === undefined) {
+			return false;
+		}
+		const pos = new RoomPosition(tile[0], tile[1], room.name);
+		const density = pickMineralDensity();
+		const mineral = createRoomObject(new Mineral(), pos);
+		mineral.mineralType = mineralType;
+		mineral.density = density;
+		mineral.mineralAmount = C.MINERAL_DENSITY[density]!;
+		context.place(mineral, 'mineral', 'guarded');
+		// Keeper and center rooms ship a pre-built, unowned extractor so the mineral is
+		// harvestable without the player owning it (vanilla blocks harvest only when the
+		// extractor belongs to someone else).
+		if (options.controller === false) {
+			context.place(createExtractor(pos, null));
+		}
+		return true;
+	},
+});
+
+declare module 'xxscreeps/scripts/symbols.js' {
+	interface GenerateRoomOptions {
+		/** Mineral type, or `false` for no mineral; omit for a random type. */
+		mineral?: ResourceType | false;
+	}
+}

--- a/packages/xxscreeps/mods/classic/source/index.ts
+++ b/packages/xxscreeps/mods/classic/source/index.ts
@@ -8,6 +8,6 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/classic/resource',
 		'xxscreeps/mods/classic/structure',
 	],
-	provides: [ 'backend', 'constants', 'game', 'processor', 'schema', 'test' ],
+	provides: [ 'backend', 'constants', 'game', 'processor', 'schema', 'terrain', 'test' ],
 	types,
 };

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -1,0 +1,95 @@
+import type { RoomGeneratorContext } from 'xxscreeps/scripts/symbols.js';
+import { makeLocalIterateArea, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
+import { createRoomObject } from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { isBorder } from 'xxscreeps/game/terrain.js';
+import { hooks } from 'xxscreeps/scripts/symbols.js';
+import * as C from './constants.js';
+import { create as createKeeperLair } from './keeper-lair.js';
+import { Source } from './source.js';
+
+const iterateGrid = makeLocalIterateArea(0, 49);
+const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
+
+// Keeper and center rooms (the controller-less ones) bake their sources' 4000 energy capacity at
+// generation: Source's '#roomStatusDidChange' computes the same thing from the room owner, but the
+// controller processor that drives that hook never runs for a controller-less room.
+hooks.register('roomGenerator', {
+	order: 0,
+	generate(context) {
+		const { options, room } = context;
+		const count = options.sources ?? (Math.random() > 0.5 ? 1 : 2);
+		const energyCapacity = options.controller === false
+			? C.SOURCE_ENERGY_KEEPER_CAPACITY
+			: C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
+		for (let ii = 0; ii < count; ++ii) {
+			const tile = context.findRandomTile(3, 44, context.isPlaceable);
+			if (tile === undefined) {
+				return false;
+			}
+			const source = createRoomObject(new Source(), new RoomPosition(tile[0], tile[1], room.name));
+			source.energy = source.energyCapacity = energyCapacity;
+			context.place(source, 'source', 'guarded');
+		}
+		return true;
+	},
+});
+
+// Searches outward from (xx, yy) through passable terrain for a non-border wall tile 3 to 5 steps
+// away to host a keeper lair, placing one on a uniformly random candidate. Returns false when no
+// tile qualifies, signalling the caller to regenerate.
+function placeKeeperLair(context: RoomGeneratorContext, xx: number, yy: number): boolean {
+	const visited = new Map([ [ yy * 50 + xx, 0 ] ]);
+	const stack = [ [ xx, yy ] as const ];
+	const spots = [ ...function*(): Iterable<readonly [ number, number ]> {
+		while (stack.length > 0) {
+			const [ cxx, cyy ] = stack.pop()!;
+			const distance = visited.get(cyy * 50 + cxx)! + 1;
+			for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
+				const key = nyy * 50 + nxx;
+				if (visited.has(key)) {
+					continue;
+				}
+				visited.set(key, distance);
+				if (distance >= 3 && distance <= 5 && !isBorder(nxx, nyy) && context.isPlaceable(nxx, nyy)) {
+					yield [ nxx, nyy ];
+				}
+				if (!context.isWall(nxx, nyy) && distance < 5) {
+					stack.push([ nxx, nyy ]);
+				}
+			}
+		}
+	}() ];
+	const spot = spots[Math.floor(Math.random() * spots.length)];
+	if (spot === undefined) {
+		return false;
+	}
+	context.place(createKeeperLair(new RoomPosition(spot[0], spot[1], context.room.name)), 'keeperLair');
+	return true;
+}
+
+// Lairs run after every guarded object is placed, so the mineral's guard needs no knowledge of the
+// mineral mod -- any tile tagged 'guarded' gets one.
+hooks.register('roomGenerator', {
+	order: 3,
+	generate(context) {
+		if (context.options.keeperLairs !== true) {
+			return true;
+		}
+		for (const [ xx, yy ] of iterateGrid(0, 0, 49, 49)) {
+			if (context.tagsAt(xx, yy).has('guarded') && !placeKeeperLair(context, xx, yy)) {
+				return false;
+			}
+		}
+		return true;
+	},
+});
+
+declare module 'xxscreeps/scripts/symbols.js' {
+	interface GenerateRoomOptions {
+		/** Number of sources; omit for a random 1 or 2. */
+		sources?: number;
+		/** Whether keeper lairs guard each source and the mineral. Default is false. */
+		keeperLairs?: boolean;
+	}
+}

--- a/packages/xxscreeps/mods/classic/structure/structure.ts
+++ b/packages/xxscreeps/mods/classic/structure/structure.ts
@@ -175,7 +175,12 @@ export function checkActiveStructures(room: Room) {
 	const byType: Record<string, OwnedStructure[]> = {};
 	for (const object of room['#immediateObjects']()) {
 		if (object instanceof OwnedStructure && object.structureType in controllerStructures) {
-			(byType[object.structureType] ??= []).push(object);
+			if (object['#user'] === null) {
+				// Owner-less structures are always active and count against no one's quota
+				object['#active'] = true;
+			} else {
+				(byType[object.structureType] ??= []).push(object);
+			}
 		}
 	}
 	// Sort each group by distance to controller and mark active/inactive

--- a/packages/xxscreeps/mods/classic/structure/test.ts
+++ b/packages/xxscreeps/mods/classic/structure/test.ts
@@ -72,6 +72,27 @@ describe('mod/classic/structure', () => {
 			});
 		}));
 
+		// Owner-less extractor: always active, so the RCL gate doesn't apply
+		const unownedExtractorSim = simulate({
+			W6N1: room => {
+				const mineral = room.find(C.FIND_MINERALS)[0]!;
+				mineral.mineralAmount = 1000;
+				room['#insertObject'](createExtractor(mineral.pos, null));
+				room['#insertObject'](createCreep(mineral.pos, [ C.WORK, C.CARRY, C.MOVE ], 'miner', '100'));
+				room['#level'] = 5;
+				room['#user'] = room.controller!['#user'] = '100';
+			},
+		});
+
+		test('owner-less extractor is active below required RCL', () => unownedExtractorSim(async ({ player }) => {
+			await player('100', Game => {
+				const creep = Game.creeps.miner;
+				const mineral = Game.rooms.W6N1?.find(C.FIND_MINERALS)[0];
+				assert.ok(mineral, 'mineral should exist');
+				assert.strictEqual(creep?.harvest(mineral), C.OK);
+			});
+		}));
+
 		// 6 extensions in a row, controller at (33, 32). RCL3 cap = 10; RCL2 cap = 5.
 		// After downgrade to RCL2 the farthest extension (distance 6) drops to inactive.
 		const downgradeSim = simulate({

--- a/packages/xxscreeps/scripts/generate-room.ts
+++ b/packages/xxscreeps/scripts/generate-room.ts
@@ -1,8 +1,15 @@
+import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import type { GenerateRoomOptions } from 'xxscreeps/scripts/room-gen.js';
 import { checkArguments } from 'xxscreeps/config/arguments.js';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
-import { generateRoom } from 'xxscreeps/scripts/room-gen.js';
+import { generateRoom, mineralPool } from 'xxscreeps/scripts/room-gen.js';
+
+const mineralTypes = new Set<string>(mineralPool);
+
+function isMineralType(value: string): value is ResourceType {
+	return mineralTypes.has(value);
+}
 
 function parseOptionalInteger(value: string | undefined, name: string, min: number, max: number) {
 	if (value === undefined) {
@@ -15,23 +22,34 @@ function parseOptionalInteger(value: string | undefined, name: string, min: numb
 	return parsed;
 }
 
+function parseMineralType(value: string | undefined) {
+	if (value === undefined || isMineralType(value)) {
+		return value;
+	}
+	throw new Error(`mineral must be one of ${[ ...mineralTypes ].join(', ')}`);
+}
+
 async function main() {
 	const argv = checkArguments({
 		argv: true,
-		string: [ 'shard', 'terrain-type', 'swamp-type' ] as const,
+		string: [ 'shard', 'terrain-type', 'swamp-type', 'sources', 'mineral' ] as const,
 	});
 	const roomName = argv.argv[0];
 	if (roomName === undefined) {
-		console.log('Usage: xxscreeps generate-room <room> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14]');
+		console.log('Usage: xxscreeps generate-room <room> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
 		process.exitCode = 1;
 		return;
 	}
 
 	const terrainType = parseOptionalInteger(argv['terrain-type'], 'terrain-type', 1, 28);
 	const swampType = parseOptionalInteger(argv['swamp-type'], 'swamp-type', 0, 14);
+	const sources = parseOptionalInteger(argv.sources, 'sources', 1, 4);
+	const mineral = parseMineralType(argv.mineral);
 	const options: GenerateRoomOptions = {
 		...terrainType !== undefined && { terrainType },
 		...swampType !== undefined && { swampType },
+		...sources !== undefined && { sources },
+		...mineral !== undefined && { mineral },
 	};
 
 	await using db = await Database.connect();

--- a/packages/xxscreeps/scripts/generate-room.ts
+++ b/packages/xxscreeps/scripts/generate-room.ts
@@ -3,12 +3,11 @@ import type { GenerateRoomOptions } from 'xxscreeps/scripts/room-gen.js';
 import { checkArguments } from 'xxscreeps/config/arguments.js';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
-import { generateRoom, mineralPool } from 'xxscreeps/scripts/room-gen.js';
-
-const mineralTypes = new Set<string>(mineralPool);
+import * as C from 'xxscreeps/game/constants/index.js';
+import { generateRoom } from 'xxscreeps/scripts/room-gen.js';
 
 function isMineralType(value: string): value is ResourceType {
-	return mineralTypes.has(value);
+	return value in C.MINERAL_MIN_AMOUNT;
 }
 
 function parseOptionalInteger(value: string | undefined, name: string, min: number, max: number) {
@@ -26,7 +25,7 @@ function parseMineralType(value: string | undefined) {
 	if (value === undefined || isMineralType(value)) {
 		return value;
 	}
-	throw new Error(`mineral must be one of ${[ ...mineralTypes ].join(', ')}`);
+	throw new Error(`mineral must be one of ${Object.keys(C.MINERAL_MIN_AMOUNT).join(', ')}`);
 }
 
 async function main() {

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,13 +1,21 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
+import { createRoomObject } from 'xxscreeps/game/object.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { computeRoomMeta } from 'xxscreeps/game/room/sector.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
+import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
+import { create as createExtractor } from 'xxscreeps/mods/classic/mineral/extractor.js';
+import { Mineral } from 'xxscreeps/mods/classic/mineral/mineral.js';
+import { create as createKeeperLair } from 'xxscreeps/mods/classic/source/keeper-lair.js';
+import { Source } from 'xxscreeps/mods/classic/source/source.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
 
 type ExitSide = 'top' | 'right' | 'bottom' | 'left';
@@ -19,8 +27,21 @@ type WorldTerrain = Awaited<ReturnType<Shard['loadWorld']>>['terrain'];
 
 export interface GenerateRoomOptions {
 	exits?: Partial<ExitMap>;
+	/** Wall layout 1-28; omit for a random layout. */
 	terrainType?: number;
+	/** Swamp layout 1-14, or 0 for no swamp; omit for a random layout. */
 	swampType?: number;
+	/** Number of sources; omit for a random 1 or 2. */
+	sources?: number;
+	/** Mineral type, or `false` for no mineral; omit for a random type. */
+	mineral?: ResourceType | false;
+	/**
+	 * Whether the room has a controller. Default is true. Controller-less rooms hold
+	 * keeper-capacity sources and a prebuilt extractor.
+	 */
+	controller?: boolean;
+	/** Whether keeper lairs guard each source and the mineral. Default is false. */
+	keeperLairs?: boolean;
 }
 
 interface TerrainTypeParams {
@@ -83,10 +104,27 @@ function randomWallType(): number {
 	return Math.floor(Math.random() * 27) + 1;
 }
 
+// Mineral roll weights: H and O are twice as common as Z/K/U/L, and six times as common as X.
+export const mineralPool: ResourceType[] = [
+	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
+	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
+	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
+	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
+	C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM,
+	C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM,
+	C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM,
+	C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM,
+	C.RESOURCE_CATALYST,
+];
+
 interface Cell {
 	wall: boolean;
 	swamp: boolean;
 	forceOpen: boolean;
+	source: boolean;
+	controller: boolean;
+	keeperLair: boolean;
+	mineral: boolean;
 }
 
 type Grid = Cell[][];
@@ -101,7 +139,10 @@ function makeGrid(): Grid {
 		Fn.range(50),
 		$$ => Fn.map($$, () => Fn.pipe(
 			Fn.range(50),
-			$$ => Fn.map($$, (): Cell => ({ wall: false, swamp: false, forceOpen: false })),
+			$$ => Fn.map($$, (): Cell => ({
+				wall: false, swamp: false, forceOpen: false,
+				source: false, controller: false, keeperLair: false, mineral: false,
+			})),
 			$$ => [ ...$$ ])),
 		$$ => [ ...$$ ]);
 }
@@ -294,6 +335,129 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 	return grid;
 }
 
+function hasPassableNeighbor(grid: Grid, xx: number, yy: number): boolean {
+	return Fn.some(iterateGridInRange(xx, yy, 1), ([ nxx, nyy ]) => !grid[nyy]![nxx]!.wall);
+}
+
+// Rolls uniformly random tiles within [min, min + span) on both axes until one satisfies `accept`,
+// returning undefined after 1000 failed rolls to signal terrain that can't host the object.
+function findRandomTile(min: number, span: number, accept: (xx: number, yy: number) => boolean) {
+	for (let ii = 0; ii < 1000; ++ii) {
+		const xx = min + Math.floor(Math.random() * span);
+		const yy = min + Math.floor(Math.random() * span);
+		if (accept(xx, yy)) {
+			return [ xx, yy ] as const;
+		}
+	}
+}
+
+// Searches outward from (xx, yy) through passable terrain for a non-border wall tile 3 to 5 steps
+// away to host a keeper lair, marking a uniformly random candidate. Returns false when no tile
+// qualifies, signalling the caller to regenerate.
+function placeKeeperLair(grid: Grid, xx: number, yy: number): boolean {
+	const visited = new Map([ [ yy * 50 + xx, 0 ] ]);
+	const stack = [ [ xx, yy ] as const ];
+	const spots = [ ...function*(): Iterable<readonly [ number, number ]> {
+		while (stack.length > 0) {
+			const [ cxx, cyy ] = stack.pop()!;
+			const distance = visited.get(cyy * 50 + cxx)! + 1;
+			for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
+				const key = nyy * 50 + nxx;
+				if (visited.has(key)) {
+					continue;
+				}
+				visited.set(key, distance);
+				const neighbor = grid[nyy]![nxx]!;
+				if (
+					distance >= 3 && distance <= 5 && !isBorder(nxx, nyy) &&
+					neighbor.wall && !neighbor.source && !neighbor.keeperLair && !neighbor.controller
+				) {
+					yield [ nxx, nyy ];
+				}
+				if (!neighbor.wall && distance < 5) {
+					stack.push([ nxx, nyy ]);
+				}
+			}
+		}
+	}() ];
+	const spot = spots[Math.floor(Math.random() * spots.length)];
+	if (spot === undefined) {
+		return false;
+	}
+	const [ sxx, syy ] = spot;
+	grid[syy]![sxx]!.keeperLair = true;
+	return true;
+}
+
+interface GenerateParams {
+	wallType: number;
+	swampType: number;
+	sourceCount: number;
+	controller: boolean;
+	keeperLairs: boolean;
+	mineral: boolean;
+}
+
+// Places sources, controller, and mineral (with their keeper lairs) on the grid. Returns false when
+// a placement constraint can't be satisfied on this terrain, signalling the caller to regenerate.
+function tryPlaceObjects(grid: Grid, params: GenerateParams): boolean {
+	const isPlaceable = (xx: number, yy: number) => {
+		const cell = grid[yy]![xx]!;
+		return cell.wall && !cell.source && !cell.keeperLair && hasPassableNeighbor(grid, xx, yy);
+	};
+	for (let ii = 0; ii < params.sourceCount; ++ii) {
+		const source = findRandomTile(3, 44, isPlaceable);
+		if (source === undefined) {
+			return false;
+		}
+		const [ sxx, syy ] = source;
+		grid[syy]![sxx]!.source = true;
+		if (params.keeperLairs && !placeKeeperLair(grid, sxx, syy)) {
+			return false;
+		}
+	}
+	if (params.controller) {
+		const controller = findRandomTile(5, 40, isPlaceable);
+		if (controller === undefined) {
+			return false;
+		}
+		const [ cxx, cyy ] = controller;
+		grid[cyy]![cxx]!.controller = true;
+	}
+	if (params.mineral) {
+		const mineral = findRandomTile(4, 42, (xx, yy) =>
+			isPlaceable(xx, yy) && !Fn.some(iterateGridInRange(xx, yy, 4), ([ nxx, nyy ]) => {
+				const cell = grid[nyy]![nxx]!;
+				return cell.source || cell.controller;
+			}));
+		if (mineral === undefined) {
+			return false;
+		}
+		const [ mxx, myy ] = mineral;
+		grid[myy]![mxx]!.mineral = true;
+		if (params.keeperLairs && !placeKeeperLair(grid, mxx, myy)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+const kMaxGenerateAttempts = 50;
+
+// Generates the room's terrain and object placements, retrying with a fresh wall type when the
+// layout can't satisfy the placement constraints, and giving up (rather than looping forever) after
+// a bounded number of attempts.
+function genTerrain(exits: ExitMap, params: GenerateParams): Grid {
+	for (let attempt = 0; attempt < kMaxGenerateAttempts; ++attempt) {
+		const wallType = attempt === 0 ? params.wallType : randomWallType();
+		const grid = buildBaseTerrain(exits, wallType, params.swampType);
+		if (tryPlaceObjects(grid, params)) {
+			return grid;
+		}
+	}
+	throw new Error(`Failed to generate room terrain after ${kMaxGenerateAttempts} attempts`);
+}
+
 function gridToTerrain(grid: Grid): TerrainWriter {
 	const terrain = new TerrainWriter();
 	for (const [ yy, row ] of grid.entries()) {
@@ -322,8 +486,54 @@ function gridToTerrain(grid: Grid): TerrainWriter {
 	return terrain;
 }
 
-// Builds a room's terrain entirely in memory; performs no storage I/O. `lookupTerrain` resolves an
-// already-built neighbor's terrain so shared exits line up.
+function pickMineralDensity(): number {
+	const random = Math.random();
+	return C.MINERAL_DENSITY_PROBABILITY.findIndex(
+		probability => probability !== undefined && random <= probability);
+}
+
+// Materializes the grid's placement flags into room objects. Keeper and center rooms (the
+// controller-less ones) bake their sources' 4000 energy capacity at generation: Source's
+// '#roomStatusDidChange' computes the same thing from the room owner, but the controller processor
+// that drives that hook never runs for a controller-less room.
+function placeObjects(room: Room, grid: Grid, mineralType: ResourceType | false, hasController: boolean) {
+	const sourceEnergyCapacity = hasController
+		? C.SOURCE_ENERGY_NEUTRAL_CAPACITY
+		: C.SOURCE_ENERGY_KEEPER_CAPACITY;
+	for (const [ yy, row ] of grid.entries()) {
+		for (const [ xx, cell ] of row.entries()) {
+			if (cell.source) {
+				const source = createRoomObject(new Source(), new RoomPosition(xx, yy, room.name));
+				source.energy = source.energyCapacity = sourceEnergyCapacity;
+				room['#insertObject'](source);
+			}
+			if (cell.controller) {
+				room['#insertObject'](createRoomObject(new StructureController(), new RoomPosition(xx, yy, room.name)));
+			}
+			if (cell.keeperLair) {
+				room['#insertObject'](createKeeperLair(new RoomPosition(xx, yy, room.name)));
+			}
+			if (cell.mineral && mineralType !== false) {
+				const pos = new RoomPosition(xx, yy, room.name);
+				const density = pickMineralDensity();
+				const mineral = createRoomObject(new Mineral(), pos);
+				mineral.mineralType = mineralType;
+				mineral.density = density;
+				mineral.mineralAmount = C.MINERAL_DENSITY[density]!;
+				room['#insertObject'](mineral);
+				// Keeper and center rooms ship a pre-built, unowned extractor so the mineral is
+				// harvestable without the player owning it (vanilla blocks harvest only when the
+				// extractor belongs to someone else).
+				if (!hasController) {
+					room['#insertObject'](createExtractor(pos, null));
+				}
+			}
+		}
+	}
+}
+
+// Builds a room's terrain and objects entirely in memory; performs no storage I/O. `lookupTerrain`
+// resolves an already-built neighbor's terrain so shared exits line up.
 function buildRoom(
 	roomName: string,
 	options: GenerateRoomOptions | undefined,
@@ -364,14 +574,25 @@ function buildRoom(
 
 	const wallType = options?.terrainType ?? randomWallType();
 	const swampType = options?.swampType ?? Math.floor(Math.random() * 14);
+	const sourceCount = options?.sources ?? (Math.random() > 0.5 ? 1 : 2);
+	const hasController = options?.controller ?? true;
+	const mineralType = options?.mineral ?? mineralPool[Math.floor(Math.random() * mineralPool.length)]!;
 
-	const grid = buildBaseTerrain(exits, wallType, swampType);
+	const grid = genTerrain(exits, {
+		wallType,
+		swampType,
+		sourceCount,
+		controller: hasController,
+		keeperLairs: options?.keeperLairs ?? false,
+		mineral: mineralType !== false,
+	});
 	const terrain = gridToTerrain(grid);
 
 	const room = new Room();
 	room.name = roomName;
 	room['#user'] = null;
-	room['#level'] = -1;
+	room['#level'] = hasController ? 0 : -1;
+	placeObjects(room, grid, mineralType, hasController);
 	room['#flushObjects'](null);
 	flushUsers(room);
 

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,48 +1,24 @@
+import type { ExitMap, GenerateRoomOptions, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
-import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
-import { createRoomObject } from 'xxscreeps/game/object.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { computeRoomMeta } from 'xxscreeps/game/room/sector.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
-import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
-import { create as createExtractor } from 'xxscreeps/mods/classic/mineral/extractor.js';
-import { Mineral } from 'xxscreeps/mods/classic/mineral/mineral.js';
-import { create as createKeeperLair } from 'xxscreeps/mods/classic/source/keeper-lair.js';
-import { Source } from 'xxscreeps/mods/classic/source/source.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
+import { hooks } from './symbols.js';
+import 'xxscreeps:mods/terrain';
 
-type ExitSide = 'top' | 'right' | 'bottom' | 'left';
-type ExitMap = Record<ExitSide, number[]>;
+export type { GenerateRoomOptions } from './symbols.js';
 
 // The world's per-room terrain map, as returned by `shard.loadWorld()`. The generation entry points
 // accumulate freshly built rooms into one of these and serialize it once, rather than once per room.
 type WorldTerrain = Awaited<ReturnType<Shard['loadWorld']>>['terrain'];
-
-export interface GenerateRoomOptions {
-	exits?: Partial<ExitMap>;
-	/** Wall layout 1-28; omit for a random layout. */
-	terrainType?: number;
-	/** Swamp layout 1-14, or 0 for no swamp; omit for a random layout. */
-	swampType?: number;
-	/** Number of sources; omit for a random 1 or 2. */
-	sources?: number;
-	/** Mineral type, or `false` for no mineral; omit for a random type. */
-	mineral?: ResourceType | false;
-	/**
-	 * Whether the room has a controller. Default is true. Controller-less rooms hold
-	 * keeper-capacity sources and a prebuilt extractor.
-	 */
-	controller?: boolean;
-	/** Whether keeper lairs guard each source and the mineral. Default is false. */
-	keeperLairs?: boolean;
-}
 
 interface TerrainTypeParams {
 	fill: number;
@@ -104,27 +80,10 @@ function randomWallType(): number {
 	return Math.floor(Math.random() * 27) + 1;
 }
 
-// Mineral roll weights: H and O are twice as common as Z/K/U/L, and six times as common as X.
-export const mineralPool: ResourceType[] = [
-	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
-	C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN, C.RESOURCE_HYDROGEN,
-	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
-	C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN, C.RESOURCE_OXYGEN,
-	C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM, C.RESOURCE_ZYNTHIUM,
-	C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM, C.RESOURCE_KEANIUM,
-	C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM, C.RESOURCE_UTRIUM,
-	C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM, C.RESOURCE_LEMERGIUM,
-	C.RESOURCE_CATALYST,
-];
-
 interface Cell {
 	wall: boolean;
 	swamp: boolean;
 	forceOpen: boolean;
-	source: boolean;
-	controller: boolean;
-	keeperLair: boolean;
-	mineral: boolean;
 }
 
 type Grid = Cell[][];
@@ -139,10 +98,7 @@ function makeGrid(): Grid {
 		Fn.range(50),
 		$$ => Fn.map($$, () => Fn.pipe(
 			Fn.range(50),
-			$$ => Fn.map($$, (): Cell => ({
-				wall: false, swamp: false, forceOpen: false,
-				source: false, controller: false, keeperLair: false, mineral: false,
-			})),
+			$$ => Fn.map($$, (): Cell => ({ wall: false, swamp: false, forceOpen: false })),
 			$$ => [ ...$$ ])),
 		$$ => [ ...$$ ]);
 }
@@ -351,108 +307,47 @@ function findRandomTile(min: number, span: number, accept: (xx: number, yy: numb
 	}
 }
 
-// Searches outward from (xx, yy) through passable terrain for a non-border wall tile 3 to 5 steps
-// away to host a keeper lair, marking a uniformly random candidate. Returns false when no tile
-// qualifies, signalling the caller to regenerate.
-function placeKeeperLair(grid: Grid, xx: number, yy: number): boolean {
-	const visited = new Map([ [ yy * 50 + xx, 0 ] ]);
-	const stack = [ [ xx, yy ] as const ];
-	const spots = [ ...function*(): Iterable<readonly [ number, number ]> {
-		while (stack.length > 0) {
-			const [ cxx, cyy ] = stack.pop()!;
-			const distance = visited.get(cyy * 50 + cxx)! + 1;
-			for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
-				const key = nyy * 50 + nxx;
-				if (visited.has(key)) {
-					continue;
-				}
-				visited.set(key, distance);
-				const neighbor = grid[nyy]![nxx]!;
-				if (
-					distance >= 3 && distance <= 5 && !isBorder(nxx, nyy) &&
-					neighbor.wall && !neighbor.source && !neighbor.keeperLair && !neighbor.controller
-				) {
-					yield [ nxx, nyy ];
-				}
-				if (!neighbor.wall && distance < 5) {
-					stack.push([ nxx, nyy ]);
-				}
+const kNoTags: ReadonlySet<string> = new Set();
+
+function makeGeneratorContext(room: Room, grid: Grid, options: GenerateRoomOptions): RoomGeneratorContext {
+	const tags = new Map<number, Set<string>>();
+	const tagsAt = (xx: number, yy: number): ReadonlySet<string> => tags.get(yy * 50 + xx) ?? kNoTags;
+	const isWall = (xx: number, yy: number) => grid[yy]![xx]!.wall;
+	return {
+		options,
+		room,
+		findRandomTile,
+		isPlaceable: (xx, yy) => isWall(xx, yy) && tagsAt(xx, yy).size === 0 && hasPassableNeighbor(grid, xx, yy),
+		isWall,
+		place(object, ...objectTags) {
+			room['#insertObject'](object);
+			const key = object.pos.y * 50 + object.pos.x;
+			const tileTags = tags.get(key) ?? new Set();
+			for (const tag of objectTags) {
+				tileTags.add(tag);
 			}
-		}
-	}() ];
-	const spot = spots[Math.floor(Math.random() * spots.length)];
-	if (spot === undefined) {
-		return false;
-	}
-	const [ sxx, syy ] = spot;
-	grid[syy]![sxx]!.keeperLair = true;
-	return true;
-}
-
-interface GenerateParams {
-	wallType: number;
-	swampType: number;
-	sourceCount: number;
-	controller: boolean;
-	keeperLairs: boolean;
-	mineral: boolean;
-}
-
-// Places sources, controller, and mineral (with their keeper lairs) on the grid. Returns false when
-// a placement constraint can't be satisfied on this terrain, signalling the caller to regenerate.
-function tryPlaceObjects(grid: Grid, params: GenerateParams): boolean {
-	const isPlaceable = (xx: number, yy: number) => {
-		const cell = grid[yy]![xx]!;
-		return cell.wall && !cell.source && !cell.keeperLair && hasPassableNeighbor(grid, xx, yy);
+			tags.set(key, tileTags);
+		},
+		tagsAt,
 	};
-	for (let ii = 0; ii < params.sourceCount; ++ii) {
-		const source = findRandomTile(3, 44, isPlaceable);
-		if (source === undefined) {
-			return false;
-		}
-		const [ sxx, syy ] = source;
-		grid[syy]![sxx]!.source = true;
-		if (params.keeperLairs && !placeKeeperLair(grid, sxx, syy)) {
-			return false;
-		}
-	}
-	if (params.controller) {
-		const controller = findRandomTile(5, 40, isPlaceable);
-		if (controller === undefined) {
-			return false;
-		}
-		const [ cxx, cyy ] = controller;
-		grid[cyy]![cxx]!.controller = true;
-	}
-	if (params.mineral) {
-		const mineral = findRandomTile(4, 42, (xx, yy) =>
-			isPlaceable(xx, yy) && !Fn.some(iterateGridInRange(xx, yy, 4), ([ nxx, nyy ]) => {
-				const cell = grid[nyy]![nxx]!;
-				return cell.source || cell.controller;
-			}));
-		if (mineral === undefined) {
-			return false;
-		}
-		const [ mxx, myy ] = mineral;
-		grid[myy]![mxx]!.mineral = true;
-		if (params.keeperLairs && !placeKeeperLair(grid, mxx, myy)) {
-			return false;
-		}
-	}
-	return true;
 }
 
 const kMaxGenerateAttempts = 50;
 
 // Generates the room's terrain and object placements, retrying with a fresh wall type when the
-// layout can't satisfy the placement constraints, and giving up (rather than looping forever) after
-// a bounded number of attempts.
-function genTerrain(exits: ExitMap, params: GenerateParams): Grid {
+// layout can't satisfy every generator's placement constraints, and giving up (rather than looping
+// forever) after a bounded number of attempts.
+function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions) {
+	const generators = [ ...hooks.map('roomGenerator') ].sort(mappedNumericComparator(generator => generator.order));
+	const swampType = options.swampType ?? Math.floor(Math.random() * 14);
 	for (let attempt = 0; attempt < kMaxGenerateAttempts; ++attempt) {
-		const wallType = attempt === 0 ? params.wallType : randomWallType();
-		const grid = buildBaseTerrain(exits, wallType, params.swampType);
-		if (tryPlaceObjects(grid, params)) {
-			return grid;
+		const wallType = attempt === 0 ? options.terrainType ?? randomWallType() : randomWallType();
+		const grid = buildBaseTerrain(exits, wallType, swampType);
+		const room = new Room();
+		room.name = roomName;
+		const context = makeGeneratorContext(room, grid, options);
+		if (generators.every(generator => generator.generate(context))) {
+			return { room, terrain: gridToTerrain(grid) };
 		}
 	}
 	throw new Error(`Failed to generate room terrain after ${kMaxGenerateAttempts} attempts`);
@@ -484,52 +379,6 @@ function gridToTerrain(grid: Grid): TerrainWriter {
 		}
 	}
 	return terrain;
-}
-
-function pickMineralDensity(): number {
-	const random = Math.random();
-	return C.MINERAL_DENSITY_PROBABILITY.findIndex(
-		probability => probability !== undefined && random <= probability);
-}
-
-// Materializes the grid's placement flags into room objects. Keeper and center rooms (the
-// controller-less ones) bake their sources' 4000 energy capacity at generation: Source's
-// '#roomStatusDidChange' computes the same thing from the room owner, but the controller processor
-// that drives that hook never runs for a controller-less room.
-function placeObjects(room: Room, grid: Grid, mineralType: ResourceType | false, hasController: boolean) {
-	const sourceEnergyCapacity = hasController
-		? C.SOURCE_ENERGY_NEUTRAL_CAPACITY
-		: C.SOURCE_ENERGY_KEEPER_CAPACITY;
-	for (const [ yy, row ] of grid.entries()) {
-		for (const [ xx, cell ] of row.entries()) {
-			if (cell.source) {
-				const source = createRoomObject(new Source(), new RoomPosition(xx, yy, room.name));
-				source.energy = source.energyCapacity = sourceEnergyCapacity;
-				room['#insertObject'](source);
-			}
-			if (cell.controller) {
-				room['#insertObject'](createRoomObject(new StructureController(), new RoomPosition(xx, yy, room.name)));
-			}
-			if (cell.keeperLair) {
-				room['#insertObject'](createKeeperLair(new RoomPosition(xx, yy, room.name)));
-			}
-			if (cell.mineral && mineralType !== false) {
-				const pos = new RoomPosition(xx, yy, room.name);
-				const density = pickMineralDensity();
-				const mineral = createRoomObject(new Mineral(), pos);
-				mineral.mineralType = mineralType;
-				mineral.density = density;
-				mineral.mineralAmount = C.MINERAL_DENSITY[density]!;
-				room['#insertObject'](mineral);
-				// Keeper and center rooms ship a pre-built, unowned extractor so the mineral is
-				// harvestable without the player owning it (vanilla blocks harvest only when the
-				// extractor belongs to someone else).
-				if (!hasController) {
-					room['#insertObject'](createExtractor(pos, null));
-				}
-			}
-		}
-	}
 }
 
 // Builds a room's terrain and objects entirely in memory; performs no storage I/O. `lookupTerrain`
@@ -572,27 +421,7 @@ function buildRoom(
 		}
 	}
 
-	const wallType = options?.terrainType ?? randomWallType();
-	const swampType = options?.swampType ?? Math.floor(Math.random() * 14);
-	const sourceCount = options?.sources ?? (Math.random() > 0.5 ? 1 : 2);
-	const hasController = options?.controller ?? true;
-	const mineralType = options?.mineral ?? mineralPool[Math.floor(Math.random() * mineralPool.length)]!;
-
-	const grid = genTerrain(exits, {
-		wallType,
-		swampType,
-		sourceCount,
-		controller: hasController,
-		keeperLairs: options?.keeperLairs ?? false,
-		mineral: mineralType !== false,
-	});
-	const terrain = gridToTerrain(grid);
-
-	const room = new Room();
-	room.name = roomName;
-	room['#user'] = null;
-	room['#level'] = hasController ? 0 : -1;
-	placeObjects(room, grid, mineralType, hasController);
+	const { room, terrain } = genRoom(roomName, exits, options ?? {});
 	room['#flushObjects'](null);
 	flushUsers(room);
 

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -1,0 +1,47 @@
+import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
+import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
+
+type ExitSide = 'top' | 'right' | 'bottom' | 'left';
+export type ExitMap = Record<ExitSide, number[]>;
+
+export interface GenerateRoomOptions {
+	exits?: Partial<ExitMap>;
+	/** Wall layout 1-28; omit for a random layout. */
+	terrainType?: number;
+	/** Swamp layout 1-14, or 0 for no swamp; omit for a random layout. */
+	swampType?: number;
+}
+
+export interface RoomGeneratorContext {
+	options: GenerateRoomOptions;
+	/** The room being generated. Insert objects through `place` so their tiles are tagged. */
+	room: Room;
+	/**
+	 * Rolls uniformly random tiles within [min, min + span) on both axes until one satisfies
+	 * `accept`, returning undefined after 1000 failed rolls to signal terrain that can't host the
+	 * object.
+	 */
+	findRandomTile: (min: number, span: number, accept: (xx: number, yy: number) => boolean) =>
+		readonly [ number, number ] | undefined;
+	/** Whether (xx, yy) is an untagged wall tile with at least one passable neighbor. */
+	isPlaceable: (xx: number, yy: number) => boolean;
+	/** Whether (xx, yy) is a wall tile. */
+	isWall: (xx: number, yy: number) => boolean;
+	/** Inserts `object` into the room and tags its tile. */
+	place: (object: RoomObject, ...tags: string[]) => void;
+	/** Tags applied by earlier placements at (xx, yy). */
+	tagsAt: (xx: number, yy: number) => ReadonlySet<string>;
+}
+
+export const hooks = makeHookRegistration<{
+	roomGenerator: {
+		/** Passes run in ascending order; constraints may consult earlier placements. */
+		order: number;
+		/**
+		 * Returns false when the terrain can't satisfy this pass's placement constraints; the room
+		 * is discarded and regenerated on fresh terrain, up to a bounded number of attempts.
+		 */
+		generate: (context: RoomGeneratorContext) => boolean;
+	};
+}>();


### PR DESCRIPTION
Follows #308 with the placement half of `@screeps/backend`'s `cli/map.js`: sources (random 1–2 by default), controller, mineral with density roll, and keeper lairs 3–5 tiles from each source and the mineral (vanilla's `map.js` guards only sources; live SK rooms guard the mineral too). New `GenerateRoomOptions` fields — `sources`, `mineral`, `controller`, `keeperLairs` — plus `--sources`/`--mineral` flags on `generate-room`.

Controller-less rooms (keeper/center) bake `SOURCE_ENERGY_KEEPER_CAPACITY` at generation — `Source` computes the same value in `'#roomStatusDidChange'`, but the controller processor that drives that hook never runs without a controller — and ship an unowned extractor so the mineral is harvestable. That surfaced a latent gap: `checkActiveStructures` never ported vanilla's owner-less-structures-are-always-active rule, so any unowned quota-typed structure was permanently inactive. The first commit fixes that with a regression test; `extractor.create` widens to `owner: string | null`.

The third commit integrates with mods: a new `terrain` provide slot, with `source`, `controller`, and `mineral` registering `roomGenerator` hooks on `scripts/symbols.ts` (the future home of import/export hooks). Each attempt builds CA terrain, then runs the hooks against a placement context (`place`/`isPlaceable`/`tagsAt`/`findRandomTile`); any hook returning false rerolls the terrain. Hooks carry an explicit `order` because mod resolution order (mineral → source → controller) can't express the mineral's stay-clear-of-sources-and-controller constraint. `room['#level']`/`'#user'` moved into the controller hook — controller-less rooms now leave `'#user'` `undefined` per the schema's tri-state — and mod options (`sources`, `mineral`, …) ride `GenerateRoomOptions` interface augmentation. The source and mineral hooks read `options.controller` for vanilla's keeper-room semantics (4000-capacity sources, prebuilt extractor) — a deliberate option-level leak rather than a cross-mod import. Two behavior notes: placeability is now "untagged", closing a latent edge where a keeper lair could land on the mineral tile; and source count / mineral type re-roll on each placement attempt (swamp layout still rolls once per room). A config that omits one of these mods generates rooms without those objects.

## Validation

- New test: an owner-less extractor below required RCL harvests `OK` — fails (`-14`) with the structure fix reverted. Full suite 485/485 after the mods rework.
- Offline smoke on fresh local shards (16 runs) re-run through the hook path: normal / keeper / center / custom-option / no-mineral rooms, asserting object counts, 4000 vs 1500 source capacity, mineral ≥ 5 from sources and controller, a lair near each source and the mineral on distinct tiles, an unowned extractor on the mineral tile, `#user` tri-state, all placements on wall tiles, and a `loadRoom` round-trip. `generate-room` CLI runs with valid and invalid `--mineral` (validation now reads `C.MINERAL_MIN_AMOUNT` keys, so the CLI no longer loads the mineral mod's registration module).
- `xxscreeps types` emits cleanly; the `terrain` provide never enters the player types program.
- Build and eslint clean. No tests for the generation script itself, matching #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
