### PR TITLE
(Stats diff #1) backend: add a mapStats hook and move map-stats decorations into mods

### DIFF
--- a/.changeset/map-stats-mod-hook.md
+++ b/.changeset/map-stats-mod-hook.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add a `mapStats` backend hook so mods decorate `/api/game/map-stats` themselves.

--- a/packages/xxscreeps/backend/endpoints/game/map-stats.ts
+++ b/packages/xxscreeps/backend/endpoints/game/map-stats.ts
@@ -1,96 +1,55 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Endpoint } from 'xxscreeps/backend/index.js';
 import type { UserBadge } from 'xxscreeps/engine/db/user/badge.js';
-import { makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
-import { Mineral } from 'xxscreeps/mods/classic/mineral/mineral.js';
 
 interface MapStatsRequest {
 	rooms: string[];
+	statName?: string | null;
 }
 
 const mapStatsSchema: JSONSchemaType<MapStatsRequest> = {
 	type: 'object',
 	properties: {
 		rooms: { type: 'array', items: { type: 'string' } },
+		statName: { type: 'string', nullable: true },
 	},
 	required: [ 'rooms' ],
 };
+
+const decorateMapStats = hooks.makeMapped('mapStats');
 
 export const MapStatsEndpoint: Endpoint = {
 	method: 'post',
 	path: '/api/game/map-stats',
 
 	execute: makeValidatedPayloadRoute(mapStatsSchema, async context => {
-		const { rooms: roomNames } = context.request.body;
+		const { rooms: roomNames, statName } = context.request.body;
 		if (!roomNames.every(room => /^[EW][0-9]+[NS][0-9]+$/.test(room))) {
 			throw new Error('Invalid room payload');
 		}
 
-		const { time } = context.backend.shard;
-		const userIds = new Set<string>();
-		const stats = Fn.fromEntries(Fn.filter(await Promise.all(Fn.map(roomNames, async roomName => {
+		// TODO: A room status blob that doesn't change every tick would be good
+		const rooms = [ ...Fn.filter(await Promise.all(Fn.map(roomNames, async roomName => {
 			// The client spams requests for rooms that don't exist
-			if (!context.backend.world.map.getRoomStatus(roomName, true)) {
-				return;
+			if (context.backend.world.map.getRoomStatus(roomName, true)) {
+				return context.backend.shard.loadRoom(roomName, undefined, true);
 			}
+		}))) ];
 
-			// TODO: A room status blob that doesn't change every tick would be good
-			const room = await context.backend.shard.loadRoom(roomName, undefined, true);
-
-			// Build rooms payload
-			return [ room.name, {
-				status: 'normal',
-				// Owner, level information
-				...function() {
-					const user = room['#user'];
-					if (user != null) {
-						userIds.add(user);
-						return {
-							own: {
-								user,
-								level: room['#level'],
-							},
-						};
-					}
-				}(),
-				// Sign
-				...function() {
-					const sign = room['#sign'];
-					if (sign) {
-						userIds.add(sign.userId);
-						return {
-							sign: {
-								datetime: sign.datetime,
-								text: sign.text,
-								time: sign.time,
-								user: sign.userId,
-							},
-						};
-					}
-				}(),
-				// Mineral info
-				...function() {
-					const mineral = room['#objects'].find(instanceOfPredicate(Mineral));
-					if (mineral) {
-						return {
-							minerals0: {
-								type: mineral.mineralType,
-								density: mineral.density,
-							},
-						};
-					}
-				}(),
-				...room['#safeModeUntil'] > time && {
-					safeMode: true,
-				},
-			} ] as const;
-		}))));
+		// Mods decorate the per-room payloads via `mapStats` hooks
+		const payload = {
+			...statName != null && { statName },
+			rooms: rooms.map(room => ({ room, stats: { status: 'normal' } })),
+			userIds: new Set<string>(),
+		};
+		await Promise.all(decorateMapStats(context, payload));
+		const stats = Fn.fromEntries(payload.rooms, ({ room, stats }) => [ room.name, stats ]);
 
 		// Read users
-		const userObjects = await Promise.all(Fn.map(userIds, async id =>
+		const userObjects = await Promise.all(Fn.map(payload.userIds, async id =>
 			({ id, info: await context.db.data.hmGet(User.infoKey(id), [ 'badge', 'username' ]) })));
 		const users = Fn.fromEntries(userObjects, user => [
 			user.id, {

--- a/packages/xxscreeps/backend/symbols.ts
+++ b/packages/xxscreeps/backend/symbols.ts
@@ -3,6 +3,7 @@ import type Koa from 'koa';
 import type Router from 'koa-router';
 import type { Context, Endpoint, State } from 'xxscreeps/backend/index.js';
 import type { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
 import type { AsyncEffectAndResult, MaybePromise } from 'xxscreeps/utility/types.js';
 import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 
@@ -10,8 +11,25 @@ export const MapRender = Symbol('mapRender');
 export const Render = Symbol('render');
 export const TerrainRender = Symbol('terrainRender');
 
+// A loaded room paired with the per-room response entry `mapStats` hooks decorate
+export interface MapStatsRoom {
+	room: Room;
+	stats: Record<string, unknown>;
+}
+
+// `/api/game/map-stats` payload handed to `mapStats` hooks, which decorate it in place
+export interface MapStatsPayload {
+	/** The stat layer the client requested, e.g. `minerals0` */
+	statName?: string;
+	/** Loaded rooms paired with their per-room response entry */
+	rooms: MapStatsRoom[];
+	/** Users referenced by the response; the endpoint resolves them into its `users` index */
+	userIds: Set<string>;
+}
+
 export const hooks = makeHookRegistration<{
 	backendReady: (db: Database, shard: Shard) => void;
+	mapStats: (context: Context, payload: MapStatsPayload) => MaybePromise<void>;
 	middleware: (koa: Koa<State, Context>, router: Router<State, Context>) => void;
 	roomSocket: (shard: Shard, userId: string | undefined, roomName: string) =>
 		AsyncEffectAndResult<((time: number) => MaybePromise<object>) | undefined>;

--- a/packages/xxscreeps/mods/classic/controller/backend.ts
+++ b/packages/xxscreeps/mods/classic/controller/backend.ts
@@ -41,6 +41,27 @@ hooks.register('sendUserInfo', async (db, userId, userInfo) => {
 	userInfo.gcl = Number(await db.data.hGet(User.infoKey(userId), 'gcl')) || 0;
 });
 
+// Owner / level, sign, and safe-mode world-map decorations; these fields live on this mod's room
+// schema.
+hooks.register('mapStats', (context, { rooms, userIds }) => {
+	const { time } = context.backend.shard;
+	for (const { room, stats } of rooms) {
+		const user = room['#user'];
+		if (user != null) {
+			userIds.add(user);
+			stats.own = { user, level: room['#level'] };
+		}
+		const sign = room['#sign'];
+		if (sign) {
+			userIds.add(sign.userId);
+			stats.sign = { datetime: sign.datetime, text: sign.text, time: sign.time, user: sign.userId };
+		}
+		if (room['#safeModeUntil'] > time) {
+			stats.safeMode = true;
+		}
+	}
+});
+
 interface RoomStatusQuery {
 	id: string;
 }

--- a/packages/xxscreeps/mods/classic/mineral/backend.ts
+++ b/packages/xxscreeps/mods/classic/mineral/backend.ts
@@ -1,9 +1,22 @@
-import { bindMapRenderer, bindRenderer, bindTerrainRenderer } from 'xxscreeps/backend/index.js';
+import { bindMapRenderer, bindRenderer, bindTerrainRenderer, hooks } from 'xxscreeps/backend/index.js';
+import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import { StructureExtractor } from './extractor.js';
 import { Mineral } from './mineral.js';
 
 bindMapRenderer(Mineral, () => 'm');
 bindTerrainRenderer(Mineral, () => 0xaeaeae);
+
+// The world map only shows mineral info on its own layer; every other map-stats request skips it
+hooks.register('mapStats', (context, { statName, rooms }) => {
+	if (statName === 'minerals0') {
+		for (const { room, stats } of rooms) {
+			const mineral = room['#objects'].find(instanceOfPredicate(Mineral));
+			if (mineral) {
+				stats.minerals0 = { type: mineral.mineralType, density: mineral.density };
+			}
+		}
+	}
+});
 
 bindRenderer(Mineral, (mineral, next) => ({
 	...next(),


### PR DESCRIPTION
Mods need a way to contribute to /api/game/map-stats. Add a backend `mapStats` hook invoked with the loaded rooms; owner / sign / safe-mode move to the controller mod (whose room schema owns those fields) and mineral info moves to the mineral mod. Mineral info is now only included when its `minerals0` layer is requested, matching the reference server.