### PR TITLE
(Stats diff #2) processor: track per-user room stats on the room blob

### DIFF
--- a/.changeset/room-stats-processor.md
+++ b/.changeset/room-stats-processor.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Track per-user room stats on the room blob via `ProcessorContext.incrementRoomStat`.

--- a/packages/xxscreeps/engine/processor/room.ts
+++ b/packages/xxscreeps/engine/processor/room.ts
@@ -52,6 +52,12 @@ export interface ProcessorContext {
 	wakeAt: (time: number) => void;
 
 	/**
+	 * Attribute a gameplay statistic to a user's activity in this room. Implemented by a stats mod;
+	 * without one this is `undefined` and contributions are dropped.
+	 */
+	incrementRoomStat?: (userId: string | null | undefined, stat: string, amount: number) => void;
+
+	/**
 	 * Send an intent to another room
 	 */
 	sendRoomIntent: <Intent extends IntentsForReceiver<Room>>(

--- a/packages/xxscreeps/mods/classic/construction/processor.ts
+++ b/packages/xxscreeps/mods/classic/construction/processor.ts
@@ -59,6 +59,7 @@ const intents = [
 				const applied = Math.min(boosted, buildRemaining);
 				creep.store['#subtract'](C.RESOURCE_ENERGY, energy);
 				target.progress += applied;
+				context.incrementRoomStat?.(creep['#user'], 'energyConstruction', energy);
 				saveAction(creep, 'build', target.pos);
 				appendEventLog(target.room, {
 					event: C.EVENT_BUILD,
@@ -126,6 +127,7 @@ const intents = [
 				const applied = Math.min(boosted, repairHitsMax);
 				creep.store['#subtract'](C.RESOURCE_ENERGY, energyCost);
 				target.hits += applied;
+				context.incrementRoomStat?.(creep['#user'], 'energyConstruction', energyCost);
 				saveAction(creep, 'repair', target.pos);
 				appendEventLog(target.room, {
 					event: C.EVENT_REPAIR,

--- a/packages/xxscreeps/mods/classic/controller/processor.ts
+++ b/packages/xxscreeps/mods/classic/controller/processor.ts
@@ -266,6 +266,7 @@ registerObjectTickProcessor(StructureController, (controller, context) => {
 				controller['#downgradeTime'] + C.CONTROLLER_DOWNGRADE_RESTORE,
 				Game.time + C.CONTROLLER_DOWNGRADE[controller.level]!);
 			context.task(incrementGlobalControlLevel(context.shard, controller['#user']!, upgradePower));
+			context.incrementRoomStat?.(controller['#user'], 'energyControl', upgradePower);
 			context.didUpdate();
 		} else if (ticksToDowngrade === 0) {
 			const { room } = controller;

--- a/packages/xxscreeps/mods/classic/creep/processor.ts
+++ b/packages/xxscreeps/mods/classic/creep/processor.ts
@@ -382,6 +382,10 @@ registerObjectTickProcessor(Creep, (creep, context) => {
 		context.didUpdate();
 	}
 	if (creep.ticksToLive === 0 || creep.hits <= 0) {
+		if (creep.hits <= 0) {
+			// Only violent deaths count; old age is not a loss
+			context.incrementRoomStat?.(creep['#user'], 'creepsLost', creep.body.length);
+		}
 		buryCreep(creep);
 		context.setActive();
 		return;

--- a/packages/xxscreeps/mods/classic/harvestable/processor.ts
+++ b/packages/xxscreeps/mods/classic/harvestable/processor.ts
@@ -1,4 +1,5 @@
 import type { Harvestable } from './game.js';
+import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { RoomObject } from 'xxscreeps/game/object.js';
 import type { Implementation } from 'xxscreeps/utility/types.js';
 import { registerIntentProcessor } from 'xxscreeps/engine/processor/index.js';
@@ -13,14 +14,14 @@ import { checkHarvest } from './creep.js';
 const ProcessHarvest = Symbol('processHarvest');
 declare module 'xxscreeps/game/object.js' {
 	interface RoomObject {
-		[ProcessHarvest]: (creep: Creep, target: RoomObject) => number;
+		[ProcessHarvest]: (creep: Creep, target: RoomObject, context: ProcessorContext) => number;
 	}
 }
 
 // `Creep.harvest` intent processor registration hook
 export function registerHarvestProcessor<Type extends RoomObject>(
 	target: Implementation<Type>,
-	process: (creep: Creep, target: Type) => number,
+	process: (creep: Creep, target: Type, context: ProcessorContext) => number,
 ) {
 	return target.prototype[ProcessHarvest] = process as RoomObject[typeof ProcessHarvest];
 }
@@ -36,7 +37,7 @@ const intent = registerIntentProcessor(Creep, 'harvest', {
 }, (creep, context, id: string) => {
 	const target = Game.getObjectById<Harvestable>(id)!;
 	if (checkHarvest(creep, target) === C.OK) {
-		const amount = target[ProcessHarvest](creep, target);
+		const amount = target[ProcessHarvest](creep, target, context);
 		appendEventLog(target.room, {
 			event: C.EVENT_HARVEST,
 			amount,

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -14,6 +14,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/meta/flag',
 		'xxscreeps/mods/meta/messages',
 		'xxscreeps/mods/meta/notifications',
+		'xxscreeps/mods/meta/stats',
 		'xxscreeps/mods/meta/visual',
 
 		'xxscreeps/mods/modern/deposit',

--- a/packages/xxscreeps/mods/classic/source/processor.ts
+++ b/packages/xxscreeps/mods/classic/source/processor.ts
@@ -17,7 +17,7 @@ import { Source } from './source.js';
 
 const kKeeperUserId = '3';
 
-registerHarvestProcessor(Source, (creep, source) => {
+registerHarvestProcessor(Source, (creep, source, context) => {
 	const power = calculatePower(creep, C.WORK, C.HARVEST_POWER, 'harvest');
 	const energy = Math.min(source.energy, power);
 	const overflow = Math.max(energy - creep.store.getFreeCapacity('energy'), 0);
@@ -27,6 +27,7 @@ registerHarvestProcessor(Source, (creep, source) => {
 		Resource.drop(creep.pos, 'energy', overflow);
 	}
 	creep.room['#cumulativeEnergyHarvested'] += energy;
+	context.incrementRoomStat?.(creep['#user'], 'energyHarvested', energy);
 	return energy;
 });
 

--- a/packages/xxscreeps/mods/classic/spawn/processor.ts
+++ b/packages/xxscreeps/mods/classic/spawn/processor.ts
@@ -132,6 +132,7 @@ const intents = [
 		if (checkRenewCreep(spawn, creep) === C.OK) {
 			const cost = calculateRenewCost(creep);
 			if (consumeEnergy(spawn, cost)) {
+				context.incrementRoomStat?.(spawn['#user'], 'energyCreeps', cost);
 				saveAction(creep, 'healed', spawn.pos);
 				creep['#ageTime'] += calculateRenewAmount(creep);
 				if (creep.body.some(part => part.boost)) {
@@ -173,6 +174,8 @@ const intents = [
 		if (!consumeEnergy(spawn, cost, structures)) {
 			return;
 		}
+		context.incrementRoomStat?.(me, 'energyCreeps', cost);
+		context.incrementRoomStat?.(me, 'creepsProduced', body.length);
 
 		// Add new creep to room objects
 		const creep = createCreep(spawn.pos, body, name, me);

--- a/packages/xxscreeps/mods/meta/stats/index.ts
+++ b/packages/xxscreeps/mods/meta/stats/index.ts
@@ -1,7 +1,5 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
-import * as types from 'xxscreeps/tsroot.js';
 
 export const manifest: Manifest = {
 	provides: [ 'processor', 'schema', 'test' ],
-	types,
 };

--- a/packages/xxscreeps/mods/meta/stats/index.ts
+++ b/packages/xxscreeps/mods/meta/stats/index.ts
@@ -1,0 +1,7 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+import * as types from 'xxscreeps/tsroot.js';
+
+export const manifest: Manifest = {
+	provides: [ 'processor', 'schema', 'test' ],
+	types,
+};

--- a/packages/xxscreeps/mods/meta/stats/processor.ts
+++ b/packages/xxscreeps/mods/meta/stats/processor.ts
@@ -1,0 +1,31 @@
+import { RoomProcessor } from 'xxscreeps/engine/processor/room.js';
+import { isStatName } from './schema.js';
+
+declare module 'xxscreeps/engine/processor/room.js' {
+	interface RoomProcessor {
+		// eslint-disable-next-line @typescript-eslint/method-signature-style
+		incrementRoomStat(userId: string | null | undefined, stat: string, amount: number): void;
+	}
+}
+
+// Accumulate contributions directly on the room blob, which is being written every tick anyway.
+// NPC ids (two characters or fewer, e.g. invaders / keepers) are ignored.
+RoomProcessor.prototype.incrementRoomStat = function(userId, stat, amount) {
+	if (amount === 0 || userId == null || userId.length <= 2) {
+		return;
+	}
+	if (!isStatName(stat)) {
+		throw new Error(`Unknown room stat: ${stat}`);
+	}
+	const stats = this.room['#userStats'];
+	if (stats.length === 0) {
+		this.room['#userStatsTime'] = Date.now();
+	}
+	const entry = stats.find(entry => entry.userId === userId && entry.stat === stat);
+	if (entry) {
+		entry.amount += amount;
+	} else {
+		stats.push({ amount, stat, userId });
+	}
+	this.didUpdate();
+};

--- a/packages/xxscreeps/mods/meta/stats/schema.ts
+++ b/packages/xxscreeps/mods/meta/stats/schema.ts
@@ -3,13 +3,11 @@ import { registerStruct } from 'xxscreeps/engine/schema/index.js';
 import { declare, enumerated, struct, vector } from 'xxscreeps/schema/index.js';
 
 // The seven series the classic client renders on the profile / overview pages and the world map
-export type StatName =
-	'creepsLost' | 'creepsProduced' | 'energyConstruction' | 'energyControl' |
-	'energyCreeps' | 'energyHarvested' | 'powerProcessed';
-export const statNames: StatName[] = [
+export type StatName = typeof statNames[number];
+export const statNames = [
 	'creepsLost', 'creepsProduced', 'energyConstruction', 'energyControl',
 	'energyCreeps', 'energyHarvested', 'powerProcessed',
-];
+] as const;
 
 export function isStatName(value: string): value is StatName {
 	return statNames.some(name => name === value);

--- a/packages/xxscreeps/mods/meta/stats/schema.ts
+++ b/packages/xxscreeps/mods/meta/stats/schema.ts
@@ -1,0 +1,33 @@
+import * as Id from 'xxscreeps/engine/schema/id.js';
+import { registerStruct } from 'xxscreeps/engine/schema/index.js';
+import { declare, enumerated, struct, vector } from 'xxscreeps/schema/index.js';
+
+// The seven series the classic client renders on the profile / overview pages and the world map
+export type StatName =
+	'creepsLost' | 'creepsProduced' | 'energyConstruction' | 'energyControl' |
+	'energyCreeps' | 'energyHarvested' | 'powerProcessed';
+export const statNames: StatName[] = [
+	'creepsLost', 'creepsProduced', 'energyConstruction', 'energyControl',
+	'energyCreeps', 'energyHarvested', 'powerProcessed',
+];
+
+export function isStatName(value: string): value is StatName {
+	return statNames.some(name => name === value);
+}
+
+// Per-user stat contributions accumulated on the room blob since it last began to fill, coalesced
+// to one entry per (user, stat) pair
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const roomSchema = registerStruct('Room', {
+	'#userStats': vector(declare('UserStats', struct({
+		amount: 'int32',
+		stat: enumerated(...statNames),
+		userId: Id.format,
+	}))),
+	// Wall-clock time the first entry landed
+	'#userStatsTime': 'double',
+});
+
+declare module 'xxscreeps/game/room/index.js' {
+	interface RoomSchema { stats: [ typeof roomSchema ] }
+}

--- a/packages/xxscreeps/mods/meta/stats/test.ts
+++ b/packages/xxscreeps/mods/meta/stats/test.ts
@@ -1,0 +1,73 @@
+import { mappedPrimitiveComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { iterateNeighbors } from 'xxscreeps/game/position.js';
+import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+
+const alice = '100';
+const bob = '101';
+
+describe('mod/meta/stats', () => {
+	const sim = simulate({
+		W1N1: room => {
+			const source = room.find(C.FIND_SOURCES)[0]!;
+			source.energy = 3000;
+			const terrain = room.getTerrain();
+			const [ first, second ] = [ ...Fn.reject(
+				iterateNeighbors(source.pos), pos => terrain.get(pos.x, pos.y) === C.TERRAIN_MASK_WALL) ];
+			room['#insertObject'](createCreep(first!, [ C.WORK, C.WORK, C.CARRY, C.MOVE ], 'harvester', alice));
+			room['#insertObject'](createCreep(second!, [ C.WORK, C.CARRY, C.MOVE ], 'poacher', bob));
+		},
+	});
+
+	test('contributions coalesce per (user, stat) on the room blob', () => sim(async ({ player, tick }) => {
+		const perTick = 2 * C.HARVEST_POWER;
+
+		await player(alice, Game => {
+			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
+			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+		});
+		await tick();
+		let statsTime = 0;
+		await player(alice, Game => {
+			const stats = Game.rooms.W1N1!['#userStats'];
+			assert.strictEqual(stats.length, 1);
+			assert.strictEqual(stats[0]!.userId, alice);
+			assert.strictEqual(stats[0]!.stat, 'energyHarvested');
+			assert.strictEqual(stats[0]!.amount, perTick);
+			statsTime = Game.rooms.W1N1!['#userStatsTime'];
+			assert.ok(statsTime > 0);
+			// A second harvest accumulates into the same entry
+			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
+			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+		});
+		await tick();
+		await player(alice, Game => {
+			const stats = Game.rooms.W1N1!['#userStats'];
+			assert.strictEqual(stats.length, 1);
+			assert.strictEqual(stats[0]!.amount, 2 * perTick);
+			// The bucket timestamp is stamped once
+			assert.strictEqual(Game.rooms.W1N1!['#userStatsTime'], statsTime);
+		});
+	}));
+
+	test('contributions are attributed per user', () => sim(async ({ player, tick }) => {
+		await player(alice, Game => {
+			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
+			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+		});
+		await player(bob, Game => {
+			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
+			assert.strictEqual(Game.creeps.poacher!.harvest(source), C.OK);
+		});
+		await tick();
+		await player(alice, Game => {
+			const stats = Game.rooms.W1N1!['#userStats'];
+			assert.deepStrictEqual(
+				stats.map(entry => [ entry.userId, entry.stat, entry.amount ] as const)
+					.sort(mappedPrimitiveComparator(entry => entry[0])),
+				[ [ alice, 'energyHarvested', 2 * C.HARVEST_POWER ], [ bob, 'energyHarvested', C.HARVEST_POWER ] ]);
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/meta/stats/test.ts
+++ b/packages/xxscreeps/mods/meta/stats/test.ts
@@ -14,8 +14,8 @@ describe('mod/meta/stats', () => {
 			const source = room.find(C.FIND_SOURCES)[0]!;
 			source.energy = 3000;
 			const terrain = room.getTerrain();
-			const [ first, second ] = [ ...Fn.reject(
-				iterateNeighbors(source.pos), pos => terrain.get(pos.x, pos.y) === C.TERRAIN_MASK_WALL) ];
+			const [ first, second ] = Fn.reject(
+				iterateNeighbors(source.pos), pos => terrain.get(pos.x, pos.y) === C.TERRAIN_MASK_WALL);
 			room['#insertObject'](createCreep(first!, [ C.WORK, C.WORK, C.CARRY, C.MOVE ], 'harvester', alice));
 			room['#insertObject'](createCreep(second!, [ C.WORK, C.CARRY, C.MOVE ], 'poacher', bob));
 		},
@@ -25,47 +25,49 @@ describe('mod/meta/stats', () => {
 		const perTick = 2 * C.HARVEST_POWER;
 
 		await player(alice, Game => {
-			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
-			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.strictEqual(Game.creeps.harvester?.harvest(source!), C.OK);
 		});
 		await tick();
 		let statsTime = 0;
 		await player(alice, Game => {
-			const stats = Game.rooms.W1N1!['#userStats'];
-			assert.strictEqual(stats.length, 1);
-			assert.strictEqual(stats[0]!.userId, alice);
-			assert.strictEqual(stats[0]!.stat, 'energyHarvested');
-			assert.strictEqual(stats[0]!.amount, perTick);
-			statsTime = Game.rooms.W1N1!['#userStatsTime'];
+			const [ stats, aggregate ] = Game.rooms.W1N1?.['#userStats'] ?? [];
+			assert.ok(stats);
+			assert.strictEqual(aggregate, undefined);
+			assert.strictEqual(stats.userId, alice);
+			assert.strictEqual(stats.stat, 'energyHarvested');
+			assert.strictEqual(stats.amount, perTick);
+			statsTime = Game.rooms.W1N1?.['#userStatsTime'] ?? 0;
 			assert.ok(statsTime > 0);
 			// A second harvest accumulates into the same entry
-			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
-			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.strictEqual(Game.creeps.harvester?.harvest(source!), C.OK);
 		});
 		await tick();
 		await player(alice, Game => {
-			const stats = Game.rooms.W1N1!['#userStats'];
-			assert.strictEqual(stats.length, 1);
-			assert.strictEqual(stats[0]!.amount, 2 * perTick);
+			const [ stats, aggregate ] = Game.rooms.W1N1?.['#userStats'] ?? [];
+			assert.ok(stats);
+			assert.strictEqual(aggregate, undefined);
+			assert.strictEqual(stats.amount, 2 * perTick);
 			// The bucket timestamp is stamped once
-			assert.strictEqual(Game.rooms.W1N1!['#userStatsTime'], statsTime);
+			assert.strictEqual(Game.rooms.W1N1?.['#userStatsTime'], statsTime);
 		});
 	}));
 
 	test('contributions are attributed per user', () => sim(async ({ player, tick }) => {
 		await player(alice, Game => {
-			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
-			assert.strictEqual(Game.creeps.harvester!.harvest(source), C.OK);
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.strictEqual(Game.creeps.harvester?.harvest(source!), C.OK);
 		});
 		await player(bob, Game => {
-			const source = Game.rooms.W1N1!.find(C.FIND_SOURCES)[0]!;
-			assert.strictEqual(Game.creeps.poacher!.harvest(source), C.OK);
+			const source = Game.rooms.W1N1?.find(C.FIND_SOURCES)[0];
+			assert.strictEqual(Game.creeps.poacher?.harvest(source!), C.OK);
 		});
 		await tick();
 		await player(alice, Game => {
-			const stats = Game.rooms.W1N1!['#userStats'];
+			const stats = Game.rooms.W1N1?.['#userStats'];
 			assert.deepStrictEqual(
-				stats.map(entry => [ entry.userId, entry.stat, entry.amount ] as const)
+				stats?.map(entry => [ entry.userId, entry.stat, entry.amount ] as const)
 					.sort(mappedPrimitiveComparator(entry => entry[0])),
 				[ [ alice, 'energyHarvested', 2 * C.HARVEST_POWER ], [ bob, 'energyHarvested', C.HARVEST_POWER ] ]);
 		});

--- a/packages/xxscreeps/mods/modern/powerspawn/processor.ts
+++ b/packages/xxscreeps/mods/modern/powerspawn/processor.ts
@@ -15,6 +15,7 @@ const intents = [
 		powerSpawn.store['#subtract'](C.RESOURCE_POWER, 1);
 		powerSpawn.store['#subtract'](C.RESOURCE_ENERGY, C.POWER_SPAWN_ENERGY_RATIO);
 		context.task(incrementGlobalPowerLevel(context.shard, powerSpawn['#user']!, 1));
+		context.incrementRoomStat?.(powerSpawn['#user'], 'powerProcessed', 1);
 		context.didUpdate();
 	}),
 ];


### PR DESCRIPTION
Add an optional `incrementRoomStat` to `ProcessorContext` and report the classic client's seven gameplay series (energy harvested / control / construction / creeps, creeps produced and lost, power processed) from their intent processors. The new `mods/meta/stats` mod implements it by patching `RoomProcessor.prototype`, accumulating one coalesced entry per (user, stat) pair directly on the room blob - which is written every tick anyway - stamped with the wall-clock time the bucket began to fill. Without the mod the reports are dropped. Aggregation into queryable buckets is left to a follow-up.