### PR TITLE
memory: skip the save when Memory fails to serialize

### DIFF
--- a/.changeset/spicy-donuts-refuse.md
+++ b/.changeset/spicy-donuts-refuse.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Unserializable `Memory` now skips the save instead of erroring every tick

--- a/packages/xxscreeps/mods/meta/memory/memory.ts
+++ b/packages/xxscreeps/mods/meta/memory/memory.ts
@@ -267,12 +267,14 @@ export function flush() {
 	if (_parsed) {
 		// Typical case: user accessed `Memory`, so we simulate vanilla reconstruction and save the
 		// string.
-		crunch(previousJson = _parsed as MemoryRecord);
 		try {
+			crunch(previousJson = _parsed as MemoryRecord);
 			string = JSON.stringify(previousJson);
 			isBufferOutOfDate = true;
 		} catch (err) {
 			console.error(err);
+			// The save was skipped, so the object may hold mutations the saved string never received
+			previousJson = undefined;
 			return { size: memoryLength };
 		}
 	} else if (!isBufferOutOfDate || string === undefined) {

--- a/packages/xxscreeps/mods/meta/memory/memory.ts
+++ b/packages/xxscreeps/mods/meta/memory/memory.ts
@@ -273,7 +273,10 @@ export function flush() {
 			isBufferOutOfDate = true;
 		} catch (err) {
 			console.error(err);
-			// The save was skipped, so the object may hold mutations the saved string never received
+			// The user's memory object cannot be serialized. Probably, it is circular or contains some
+			// other `toJSON` error. It will be reparsed from `string` or `memory` next tick.
+			// TODO: Does it make sense to do a sandbox reset here instead of attempt to continue
+			// gracefully?
 			previousJson = undefined;
 			return { size: memoryLength };
 		}


### PR DESCRIPTION
Storing an unserializable value in `Memory` — a circular reference being the easy accident — errored every tick: `crunch` walked the structure outside the `try`, so the failure escaped `flush` instead of being contained to the save. `crunch` now runs inside the `try`, and the catch also drops `previousJson`, so the next read re-parses the last saved string rather than serving cached mutations the save never captured — without that, the save fails silently-in-effect while cached `Memory` keeps working, and the failure only surfaces as a rollback at the next isolate reset.

This degrades more gently than vanilla, where the post-tick stringify is unwrapped ([runtime.js L246-248](https://github.com/screeps/driver/blob/cf63d8adf902663e2ebddd7f8c5b7baa425dc928/lib/runtime/runtime.js#L246-L248)) and a circular `Memory` costs the whole out-message, intents included. Here it's a console error and a skipped save; the rest of the tick's payload still flushes.

Previous revision of this PR also extended `crunch`'s coercions (`NaN`/`Infinity`/functions) and invalidated the cache on a deliberate `_parsed` discard — both withdrawn per review: no observed script breakage, and the bots shipping `delete RawMemory._parsed` (ZeSwarm, wiki MemHack) pair it with a heap-cached `Memory` or `RawMemory.set`, so they never touch the cache path.

## Validation

- screeps-ok `UNDOC-MEMJSON-005` (circular `Memory` per-tick error, the `memory-circular-ref-crash` gap) — passed; the `-001`/`-003`/`-004`/`MEMHACK-011` IDs from the previous revision return to expected-fail
- No local sandbox test: the expected `console.error` trips the harness's player-error assert; coverage lives in screeps-ok 005
- `npx xxscreeps test` — 489 passed
- `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
