### PR TITLE
utility: iterate random placement through a feistel permutation

### DIFF
--- a/.changeset/random-placement-primitive.md
+++ b/.changeset/random-placement-primitive.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Unified random placement on a feistel permutation; placement fails only when no position qualifies.

--- a/packages/xxscreeps/mods/invader/strongholds.ts
+++ b/packages/xxscreeps/mods/invader/strongholds.ts
@@ -1,10 +1,12 @@
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import {
 	RESOURCE_BATTERY, RESOURCE_COMPOSITE, RESOURCE_CRYSTAL, RESOURCE_GHODIUM_MELT,
 	RESOURCE_KEANIUM_BAR, RESOURCE_LEMERGIUM_BAR, RESOURCE_LIQUID, RESOURCE_OXIDANT,
 	RESOURCE_PURIFIER, RESOURCE_REDUCTANT, RESOURCE_UTRIUM_BAR, RESOURCE_ZYNTHIUM_BAR,
 } from 'xxscreeps/mods/modern/factory/constants.js';
+import { shuffle } from 'xxscreeps/utility/random.js';
 
 // Stronghold layout templates and loot tables ported from @screeps/common (lib/strongholds.js).
 // Each template's `rewardLevel` matches its bunker number. The core's own template entry is omitted
@@ -107,13 +109,7 @@ const containerAmounts = [ 0, 500, 4000, 10000, 50000, 360000 ];
  */
 export function *calcReward(rewardLevel: number): Iterable<[ ResourceType, number ]> {
 	const targetDensity = containerAmounts[rewardLevel]!;
-	const picks = Object.entries(containerRewards);
-	// TODO: abstract out fisher-yates shuffle
-	for (let ii = picks.length - 1; ii > 0; --ii) {
-		const jj = Math.floor(Math.random() * (ii + 1));
-		[ picks[ii], picks[jj] ] = [ picks[jj]!, picks[ii]! ];
-	}
-	picks.length = 3;
+	const picks = [ ...Fn.take(shuffle(Object.entries(containerRewards)), 3) ];
 	let currentDensity = 0;
 	for (const [ ii, [ resource, density ] ] of picks.entries()) {
 		const remaining = targetDensity - currentDensity;

--- a/packages/xxscreeps/mods/modern/deposit/processor.ts
+++ b/packages/xxscreeps/mods/modern/deposit/processor.ts
@@ -11,37 +11,25 @@ import { calculatePower } from 'xxscreeps/mods/classic/creep/creep.js';
 import { registerHarvestProcessor } from 'xxscreeps/mods/classic/harvestable/processor.js';
 import * as Resource from 'xxscreeps/mods/classic/resource/processor/resource.js';
 import { makeSectorRadiusPredicate } from 'xxscreeps/mods/modern/sector/sector.js';
+import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import { Deposit } from './deposit.js';
 import { scheduleSector } from './model.js';
 
-const MAX_PLACEMENT_ATTEMPTS = 1000;
-
-// Picks a wall position in 5..44 with at least one non-wall neighbor (incl. diagonals), inside the
-// sector's 250-square radius, and 2 squares clear of any other room object.
+// The first wall position in 5..44, in random order, with at least one non-wall neighbor (incl.
+// diagonals), inside the sector's 250-square radius, and 2 squares clear of any other room object.
 function findPlacement(world: World, centralRoom: string, targetRoom: RoomClass) {
 	const { terrain, sectors } = world.map['#getRoomTraits'](targetRoom.name);
 	const objects = targetRoom['#objects'];
 	const inSector = makeSectorRadiusPredicate(centralRoom, targetRoom.name, sectors);
-	for (let attempt = 0; attempt < MAX_PLACEMENT_ATTEMPTS; ++attempt) {
-		const xx = Math.floor(Math.random() * 40) + 5;
-		const yy = Math.floor(Math.random() * 40) + 5;
-		if (terrain.get(xx, yy) !== C.TERRAIN_MASK_WALL) {
-			continue;
-		}
+	return Fn.pipe(
+		shuffledSquare(5, 40),
+		$$ => Fn.filter($$, ([ xx, yy ]) => terrain.get(xx, yy) === C.TERRAIN_MASK_WALL),
 		// Divergence from the official cron, which computes this check but never enforces it.
-		if (!inSector(xx, yy)) {
-			continue;
-		}
-		const from = new RoomPosition(xx, yy, targetRoom.name);
-		const hasExit = Fn.some(iterateNeighbors(from), pos => terrain.get(pos.x, pos.y) !== C.TERRAIN_MASK_WALL);
-		if (!hasExit) {
-			continue;
-		}
-		if (Fn.some(objects, object => object.pos.getRangeTo(xx, yy) <= 2)) {
-			continue;
-		}
-		return { xx, yy } as const;
-	}
+		$$ => Fn.filter($$, ([ xx, yy ]) => inSector(xx, yy)),
+		$$ => Fn.map($$, ([ xx, yy ]) => new RoomPosition(xx, yy, targetRoom.name)),
+		$$ => Fn.filter($$, from => Fn.some(iterateNeighbors(from), pos => terrain.get(pos.x, pos.y) !== C.TERRAIN_MASK_WALL)),
+		$$ => Fn.reject($$, from => Fn.some(objects, object => object.pos.getRangeTo(from) <= 2)),
+		$$ => Fn.first($$));
 }
 
 registerHarvestProcessor(Deposit, (creep, deposit) => {
@@ -90,7 +78,7 @@ const placeDepositIntent = registerIntentProcessor(
 		if (pos === undefined) {
 			return;
 		}
-		const deposit = createRoomObject(new Deposit(), new RoomPosition(pos.xx, pos.yy, room.name));
+		const deposit = createRoomObject(new Deposit(), pos);
 		deposit.depositType = depositType;
 		deposit['#nextDecayTime'] = Game.time + C.DEPOSIT_DECAY_TIME;
 		room['#insertObject'](deposit);

--- a/packages/xxscreeps/mods/modern/powerbank/processor.ts
+++ b/packages/xxscreeps/mods/modern/powerbank/processor.ts
@@ -4,9 +4,8 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { Room as RoomClass } from 'xxscreeps/game/room/index.js';
+import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import { StructurePowerBank, create } from './powerbank.js';
-
-const MAX_PLACEMENT_ATTEMPTS = 1000;
 
 registerObjectTickProcessor(StructurePowerBank, (powerBank, context) => {
 	if (powerBank.ticksToDecay === 0) {
@@ -17,19 +16,15 @@ registerObjectTickProcessor(StructurePowerBank, (powerBank, context) => {
 	}
 });
 
-// A wall position in 5..44 with at least one non-wall neighbour (incl. diagonals). The bounded loop
-// guards against a wall-less room hanging the official unbounded `do/while`.
+// The first wall position in 5..44, in random order, with at least one non-wall neighbour (incl.
+// diagonals), or undefined in a room without a qualifying wall.
 function findPlacement(world: World, roomName: string) {
 	const terrain = world.map.getRoomTerrain(roomName);
-	for (let attempt = 0; attempt < MAX_PLACEMENT_ATTEMPTS; ++attempt) {
-		const xx = Math.floor(Math.random() * 40) + 5;
-		const yy = Math.floor(Math.random() * 40) + 5;
-		if (terrain.get(xx, yy) !== C.TERRAIN_MASK_WALL) continue;
-		const from = new RoomPosition(xx, yy, roomName);
-		const hasExit = Fn.some(iterateNeighbors(from), pos => terrain.get(pos.x, pos.y) !== C.TERRAIN_MASK_WALL);
-		if (!hasExit) continue;
-		return from;
-	}
+	return Fn.pipe(
+		shuffledSquare(5, 40),
+		$$ => Fn.filter($$, ([ xx, yy ]) => terrain.get(xx, yy) === C.TERRAIN_MASK_WALL),
+		$$ => Fn.map($$, ([ xx, yy ]) => new RoomPosition(xx, yy, roomName)),
+		$$ => Fn.find($$, from => Fn.some(iterateNeighbors(from), pos => terrain.get(pos.x, pos.y) !== C.TERRAIN_MASK_WALL)));
 }
 
 // Placement runs at the room intent stage so it reads terrain via the live `world.map`.

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -11,6 +11,7 @@ import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
 import { computeRoomMeta } from 'xxscreeps/mods/modern/sector/sector.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
+import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import { hooks } from './symbols.js';
 import 'xxscreeps:mods/terrain';
 
@@ -295,16 +296,10 @@ function hasPassableNeighbor(grid: Grid, xx: number, yy: number): boolean {
 	return Fn.some(iterateGridInRange(xx, yy, 1), ([ nxx, nyy ]) => !grid[nyy]![nxx]!.wall);
 }
 
-// Rolls uniformly random tiles within [min, min + span) on both axes until one satisfies `accept`,
-// returning undefined after 1000 failed rolls to signal terrain that can't host the object.
+// The first tile in random order within [min, min + span) on both axes satisfying `accept`, or
+// undefined when terrain can't host the object anywhere.
 function findRandomTile(min: number, span: number, accept: (xx: number, yy: number) => boolean) {
-	for (let ii = 0; ii < 1000; ++ii) {
-		const xx = min + Math.floor(Math.random() * span);
-		const yy = min + Math.floor(Math.random() * span);
-		if (accept(xx, yy)) {
-			return [ xx, yy ] as const;
-		}
-	}
+	return Fn.find(shuffledSquare(min, span), ([ xx, yy ]) => accept(xx, yy));
 }
 
 const kNoTags: ReadonlySet<string> = new Set();

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -6,6 +6,7 @@ await import('xxscreeps/driver/private/test.js');
 await import('xxscreeps/engine/db/storage/local/test.js');
 await import('xxscreeps/engine/db/user/test.js');
 await import('xxscreeps/game/test.js');
+await import('xxscreeps/utility/test.js');
 await import('xxscreeps:mods/test');
 await import('xxscreeps/cli/test.js');
 try {

--- a/packages/xxscreeps/utility/random.ts
+++ b/packages/xxscreeps/utility/random.ts
@@ -1,0 +1,39 @@
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { hashCombine } from './utility.js';
+
+/**
+ * Yields every integer in `[0, count)` exactly once, in a pseudo-random order drawn from
+ * `Math.random()` at the time of the call. The order comes from a feistel permutation over the
+ * smallest enclosing power-of-4 domain, cycle-walking values that land outside `[0, count)`, so no
+ * backing array is allocated. The int32 half-swap bounds `count` at 2^30.
+ */
+export function shuffledRange(count: number): Iterable<number> {
+	const halfBits = Math.ceil(Math.log2(Math.max(2, count)) / 2);
+	const mask = (1 << halfBits) - 1;
+	const keys = [ ...Fn.map(Fn.range(4), () => Math.floor(Math.random() * 0x100000000)) ];
+	const permute = (index: number) => {
+		let left = index >>> halfBits;
+		let right = index & mask;
+		for (const key of keys) {
+			[ left, right ] = [ right, left ^ (hashCombine(right, key) & mask) ];
+		}
+		return (left << halfBits) | right;
+	};
+	const walk = (value: number): number => value < count ? value : walk(permute(value));
+	return Fn.map(Fn.range(count), index => walk(permute(index)));
+}
+
+/**
+ * Yields every element of `list` exactly once, in pseudo-random order, without mutating the list.
+ */
+export function shuffle<Type>(list: readonly Type[]): Iterable<Type> {
+	return Fn.map(shuffledRange(list.length), index => list[index]!);
+}
+
+/**
+ * Yields every (xx, yy) pair with both coordinates in `[min, min + span)` exactly once, in
+ * pseudo-random order.
+ */
+export function shuffledSquare(min: number, span: number): Iterable<readonly [ number, number ]> {
+	return Fn.map(shuffledRange(span * span), index => [ min + index % span, min + Math.floor(index / span) ] as const);
+}

--- a/packages/xxscreeps/utility/test.ts
+++ b/packages/xxscreeps/utility/test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'node:assert';
+import { numericComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
+import { describe, test } from 'xxscreeps/test/index.js';
+import { shuffle, shuffledRange, shuffledSquare } from './random.js';
+
+describe('utility', () => {
+	describe('random', () => {
+		test('shuffledRange yields each index exactly once', () => {
+			using rng = deterministicRandomForTesting();
+			for (const count of [ 0, 1, 2, 3, 4, 15, 16, 17, 100, 1000 ]) {
+				assert.deepStrictEqual([ ...shuffledRange(count) ].sort(numericComparator), [ ...Fn.range(count) ]);
+			}
+		});
+
+		test('shuffledSquare visits every position exactly once', () => {
+			using rng = deterministicRandomForTesting();
+			const visited = Fn.pipe(
+				shuffledSquare(5, 40),
+				$$ => Fn.map($$, ([ xx, yy ]) => yy * 50 + xx),
+				$$ => [ ...$$ ]);
+			assert.strictEqual(visited.length, 1600);
+			assert.strictEqual(new Set(visited).size, 1600);
+			assert.ok(Fn.every(shuffledSquare(5, 40), ([ xx, yy ]) => xx >= 5 && xx < 45 && yy >= 5 && yy < 45));
+		});
+
+		test('shuffle yields each element exactly once', () => {
+			using rng = deterministicRandomForTesting();
+			const list = [ ...Fn.range(26) ];
+			assert.deepStrictEqual([ ...shuffle(list) ].sort(numericComparator), list);
+		});
+
+		test('first yielded index is roughly uniform', () => {
+			using rng = deterministicRandomForTesting();
+			const trials = 10000;
+			const counts = [ ...Fn.map(Fn.range(10), () => 0) ];
+			for (let ii = 0; ii < trials; ++ii) {
+				++counts[Fn.first(shuffledRange(10))!]!;
+			}
+			// Expected 1000 per bin; a bin outside ±30% signals a badly biased permutation, not noise.
+			assert.ok(counts.every(count => count > 700 && count < 1300), `biased: ${counts.join()}`);
+		});
+	});
+});


### PR DESCRIPTION
Adds `utility/random.ts` — a feistel permutation over `[0, count)` (cycle-walking non-power-of-4 domains) with lazy `shuffle` and `shuffledSquare` views — and converts the hand-rolled randomness sites onto it: room-gen's `findRandomTile`, deposit and powerbank `findPlacement`, and the stronghold loot shuffle (retiring its fisher-yates TODO). Follows the #321 merge comment's suggestion.

Semantics change worth noting: exhaustive random-order iteration replaces capped rejection sampling, so placement fails only when no position qualifies — never spuriously after 1000 misses. Distribution is unchanged: the first accepted element of a uniform permutation is uniform over the accepted set.

## Validation
- Added a pure-math spec test: the permutation yields each index exactly once (including 0, 1, and power-of-4 domains) plus a coarse first-index uniformity smoke, under the deterministic RNG fixture.
- Full suite passed (511 tests); eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)