### PR TITLE
game: export mod constants to sandbox globals from `xxscreeps:mods/constants`

### DIFF
--- a/.changeset/runtime-global-constants.md
+++ b/.changeset/runtime-global-constants.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Import constants from `xxscreeps:mods/constants` in `game/runtime.ts` so mod-provided constants are exported to the sandbox again

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -1,5 +1,5 @@
 import lodash from '@xxscreeps/lodash3';
-import * as C from './constants/index.js';
+import * as C from 'xxscreeps:mods/constants';
 import { hooks, registerGlobal } from './symbols.js';
 
 const { apply } = Reflect;


### PR DESCRIPTION
### Problem

Player code that relies on globally-available game constants throws `ReferenceError: MOVE is not defined` at runtime (e.g. from a class static initializer at module-eval time). Only the core `find`/`structure`/`world` constants remain available as sandbox globals; every mod-provided constant (`MOVE`, `WORK`, `CARRY`, `FIND_CREEPS`, `RESOURCE_*`, …) is missing.

### Cause

Commit 84944c22 (`mods: use 'xxscreeps:mods/constants' as import`) flipped the constants dependency direction: `xxscreeps:mods/constants` became the complete set (`export * from 'xxscreeps/game/constants/index.js'` + every mod's constants), and `game/constants/index.js` was reduced to core-only (`find`/`structure`/`world`). 156 files were migrated to import from `xxscreeps:mods/constants`.

`game/runtime.ts` was missed. It is the file whose `runtimeConnector.initialize` hook iterates a constants module and assigns every entry onto the sandbox `globalThis`, but it still imports `./constants/index.js` — now core-only — so mod constants stopped being injected as globals.

### Fix

Point `game/runtime.ts` at `xxscreeps:mods/constants` (the complete set), matching the rest of the tree (e.g. `engine/processor/movement.ts`). One-line change plus a changeset.
