### PR TITLE
runner: publish console of a failed tick to the player instead of dropping it

### DIFF
--- a/.changeset/publish-console-on-error-tick.md
+++ b/.changeset/publish-console-on-error-tick.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Publish a failed tick's captured console to the player instead of dropping it in `PlayerInstance#run`.

--- a/packages/xxscreeps/engine/runner/instance.ts
+++ b/packages/xxscreeps/engine/runner/instance.ts
@@ -297,6 +297,11 @@ export class PlayerInstance {
 						fd: 2,
 						data: `Script timed out${result.stack == null ? '' : `; ${result.stack}`}`,
 					} ])));
+
+				} else if (result.console != null) {
+					// Surface console output captured while the tick failed (e.g. an error thrown during
+					// module evaluation) so the player sees their crash instead of it being dropped here.
+					tasks.push(this.consoleChannel.publish(result.console));
 				}
 			}
 			// Publish empty results to move processing along


### PR DESCRIPTION
When a tick fails during setup — e.g. an error thrown while the player's `main` module is first evaluated — the runtime returns `{ result: 'error', console }` with the captured console buffer. `PlayerInstance#run` handled the `disposed` and `timedOut` completions but let the `error` completion's console fall through unpublished, so the player never saw the crash that killed their tick.

This adds the missing branch: when a failed tick carries a console buffer, publish it to the player's console channel. `result.console` is the same `flush()` output (`JSON.stringify([{ fd, data }])`) the success path already publishes, so no reformatting is needed — unlike the `disposed`/`timedOut` arms, which synthesize a `fd: 2` line because they have no runtime buffer.

## Validation

Manually traced the completion union (`TickErrorCompletion` in `driver/sandbox/index.ts`) and confirmed the new `else if (result.console != null)` branch narrows correctly and that `result.console` shares the success path's wire format (`driver/runtime/index.ts` sets `console: flush()` on both paths). Did not run a full build/typecheck for this 10-line diff.
