### PR TITLE
room-gen: flatten the generator hook context to Terrain and RoomPosition

### DIFF
--- a/.changeset/room-gen-context.md
+++ b/.changeset/room-gen-context.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Flattened the room-generator hook context to Terrain and RoomPosition.

--- a/packages/xxscreeps/mods/classic/controller/terrain.ts
+++ b/packages/xxscreeps/mods/classic/controller/terrain.ts
@@ -1,5 +1,4 @@
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import { StructureController } from './controller.js';
 
@@ -13,12 +12,11 @@ hooks.register('roomGenerator', {
 		}
 		room['#user'] = null;
 		room['#level'] = 0;
-		const tile = context.findRandomTile(5, 40, context.isPlaceable);
-		if (tile === undefined) {
+		const position = context.findRandomPosition(5, 40, context.isPlaceable);
+		if (position === undefined) {
 			return false;
 		}
-		const controller = createRoomObject(new StructureController(), new RoomPosition(tile[0], tile[1], room.name));
-		context.place(controller, 'controller');
+		context.place(createRoomObject(new StructureController(), position), 'controller');
 		return true;
 	},
 });

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -1,8 +1,7 @@
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
+import { iterateInRangeTo } from 'xxscreeps/game/position.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from './constants.js';
 import { create as createExtractor } from './extractor.js';
@@ -21,8 +20,6 @@ const mineralPool: ResourceType[] = [
 	C.RESOURCE_CATALYST,
 ];
 
-const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
-
 function pickMineralDensity(): number {
 	const random = Math.random();
 	return C.MINERAL_DENSITY_PROBABILITY.findIndex(
@@ -32,22 +29,21 @@ function pickMineralDensity(): number {
 hooks.register('roomGenerator', {
 	order: 2,
 	generate(context) {
-		const { options, room } = context;
+		const { options } = context;
 		const mineralType = options.mineral ?? mineralPool[Math.floor(Math.random() * mineralPool.length)]!;
 		if (mineralType === false) {
 			return true;
 		}
-		const tile = context.findRandomTile(4, 42, (xx, yy) =>
-			context.isPlaceable(xx, yy) && !Fn.some(iterateGridInRange(xx, yy, 4), ([ nxx, nyy ]) => {
-				const tags = context.tagsAt(nxx, nyy);
+		const position = context.findRandomPosition(4, 42, candidate =>
+			context.isPlaceable(candidate) && !Fn.some(iterateInRangeTo(candidate, 4), near => {
+				const tags = context.tagsAt(near);
 				return tags.has('source') || tags.has('controller');
 			}));
-		if (tile === undefined) {
+		if (position === undefined) {
 			return false;
 		}
-		const pos = new RoomPosition(tile[0], tile[1], room.name);
 		const density = pickMineralDensity();
-		const mineral = createRoomObject(new Mineral(), pos);
+		const mineral = createRoomObject(new Mineral(), position);
 		mineral.mineralType = mineralType;
 		mineral.density = density;
 		mineral.mineralAmount = C.MINERAL_DENSITY[density]!;
@@ -56,7 +52,7 @@ hooks.register('roomGenerator', {
 		// harvestable without the player owning it (vanilla blocks harvest only when the
 		// extractor belongs to someone else).
 		if (options.controller === false) {
-			context.place(createExtractor(pos, null));
+			context.place(createExtractor(position, null));
 		}
 		return true;
 	},

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -1,15 +1,12 @@
+import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { RoomGeneratorContext } from 'xxscreeps/scripts/symbols.js';
-import { makeLocalIterateArea, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
+import { iterateArea, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
-import * as C from './constants.js';
+import * as C from 'xxscreeps:mods/constants';
 import { create as createKeeperLair } from './keeper-lair.js';
 import { Source } from './source.js';
-
-const iterateGrid = makeLocalIterateArea(0, 49);
-const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
 
 // Keeper and center rooms (the controller-less ones) bake their sources' 4000 energy capacity at
 // generation: Source's '#roomStatusDidChange' computes the same thing from the room owner, but the
@@ -17,17 +14,17 @@ const iterateGridInRange = makeLocalIterateInRangeTo(0, 49);
 hooks.register('roomGenerator', {
 	order: 0,
 	generate(context) {
-		const { options, room } = context;
+		const { options } = context;
 		const count = options.sources ?? (Math.random() > 0.5 ? 1 : 2);
 		const energyCapacity = options.controller === false
 			? C.SOURCE_ENERGY_KEEPER_CAPACITY
 			: C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
 		for (let ii = 0; ii < count; ++ii) {
-			const tile = context.findRandomTile(3, 44, context.isPlaceable);
-			if (tile === undefined) {
+			const position = context.findRandomPosition(3, 44, context.isPlaceable);
+			if (position === undefined) {
 				return false;
 			}
-			const source = createRoomObject(new Source(), new RoomPosition(tile[0], tile[1], room.name));
+			const source = createRoomObject(new Source(), position);
 			source.energy = source.energyCapacity = energyCapacity;
 			context.place(source, 'source', 'guarded');
 		}
@@ -35,27 +32,27 @@ hooks.register('roomGenerator', {
 	},
 });
 
-// Searches outward from (xx, yy) through passable terrain for a non-border wall tile 3 to 5 steps
+// Searches outward from `origin` through passable terrain for a non-border wall tile 3 to 5 steps
 // away to host a keeper lair, placing one on a uniformly random candidate. Returns false when no
 // tile qualifies, signalling the caller to regenerate.
-function placeKeeperLair(context: RoomGeneratorContext, xx: number, yy: number): boolean {
-	const visited = new Map([ [ yy * 50 + xx, 0 ] ]);
-	const stack = [ [ xx, yy ] as const ];
-	const spots = [ ...function*(): Iterable<readonly [ number, number ]> {
+function placeKeeperLair(context: RoomGeneratorContext, origin: RoomPosition): boolean {
+	const visited = new Map([ [ origin['#id'], 0 ] ]);
+	const stack = [ origin ];
+	const spots = [ ...function*(): Iterable<RoomPosition> {
 		while (stack.length > 0) {
-			const [ cxx, cyy ] = stack.pop()!;
-			const distance = visited.get(cyy * 50 + cxx)! + 1;
-			for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
-				const key = nyy * 50 + nxx;
+			const current = stack.pop()!;
+			const distance = visited.get(current['#id'])! + 1;
+			for (const neighbor of iterateNeighbors(current)) {
+				const key = neighbor['#id'];
 				if (visited.has(key)) {
 					continue;
 				}
 				visited.set(key, distance);
-				if (distance >= 3 && distance <= 5 && !isBorder(nxx, nyy) && context.isPlaceable(nxx, nyy)) {
-					yield [ nxx, nyy ];
+				if (distance >= 3 && distance <= 5 && !isBorder(neighbor.x, neighbor.y) && context.isPlaceable(neighbor)) {
+					yield neighbor;
 				}
-				if (!context.isWall(nxx, nyy) && distance < 5) {
-					stack.push([ nxx, nyy ]);
+				if (context.terrain.get(neighbor.x, neighbor.y) !== C.TERRAIN_MASK_WALL && distance < 5) {
+					stack.push(neighbor);
 				}
 			}
 		}
@@ -64,7 +61,7 @@ function placeKeeperLair(context: RoomGeneratorContext, xx: number, yy: number):
 	if (spot === undefined) {
 		return false;
 	}
-	context.place(createKeeperLair(new RoomPosition(spot[0], spot[1], context.room.name)), 'keeperLair');
+	context.place(createKeeperLair(spot), 'keeperLair');
 	return true;
 }
 
@@ -76,8 +73,8 @@ hooks.register('roomGenerator', {
 		if (context.options.keeperLairs !== true) {
 			return true;
 		}
-		for (const [ xx, yy ] of iterateGrid(0, 0, 49, 49)) {
-			if (context.tagsAt(xx, yy).has('guarded') && !placeKeeperLair(context, xx, yy)) {
+		for (const position of iterateArea(context.room.name, 0, 0, 49, 49)) {
+			if (context.tagsAt(position).has('guarded') && !placeKeeperLair(context, position)) {
 				return false;
 			}
 		}

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -5,6 +5,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
+import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
@@ -292,31 +293,25 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 	return grid;
 }
 
-function hasPassableNeighbor(grid: Grid, xx: number, yy: number): boolean {
-	return Fn.some(iterateGridInRange(xx, yy, 1), ([ nxx, nyy ]) => !grid[nyy]![nxx]!.wall);
-}
-
-// The first tile in random order within [min, min + span) on both axes satisfying `accept`, or
-// undefined when terrain can't host the object anywhere.
-function findRandomTile(min: number, span: number, accept: (xx: number, yy: number) => boolean) {
-	return Fn.find(shuffledSquare(min, span), ([ xx, yy ]) => accept(xx, yy));
-}
-
 const kNoTags: ReadonlySet<string> = new Set();
 
-function makeGeneratorContext(room: Room, grid: Grid, options: GenerateRoomOptions): RoomGeneratorContext {
+function makeGeneratorContext(room: Room, terrain: Terrain, options: GenerateRoomOptions): RoomGeneratorContext {
 	const tags = new Map<number, Set<string>>();
-	const tagsAt = (xx: number, yy: number): ReadonlySet<string> => tags.get(yy * 50 + xx) ?? kNoTags;
-	const isWall = (xx: number, yy: number) => grid[yy]![xx]!.wall;
+	const tagsAt = (position: RoomPosition): ReadonlySet<string> => tags.get(position['#id']) ?? kNoTags;
+	const isWall = (position: RoomPosition) => terrain.get(position.x, position.y) === C.TERRAIN_MASK_WALL;
 	return {
 		options,
 		room,
-		findRandomTile,
-		isPlaceable: (xx, yy) => isWall(xx, yy) && tagsAt(xx, yy).size === 0 && hasPassableNeighbor(grid, xx, yy),
-		isWall,
+		terrain,
+		findRandomPosition: (min, span, accept) => Fn.pipe(
+			shuffledSquare(min, span),
+			$$ => Fn.map($$, ([ xx, yy ]) => new RoomPosition(xx, yy, room.name)),
+			$$ => Fn.find($$, accept)),
+		isPlaceable: position => isWall(position) && tagsAt(position).size === 0 &&
+			Fn.some(iterateNeighbors(position), neighbor => !isWall(neighbor)),
 		place(object, ...objectTags) {
 			room['#insertObject'](object);
-			const key = object.pos.y * 50 + object.pos.x;
+			const key = object.pos['#id'];
 			const tileTags = tags.get(key) ?? new Set();
 			for (const tag of objectTags) {
 				tileTags.add(tag);
@@ -337,12 +332,12 @@ function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions)
 	const swampType = options.swampType ?? Math.floor(Math.random() * 14);
 	for (let attempt = 0; attempt < kMaxGenerateAttempts; ++attempt) {
 		const wallType = attempt === 0 ? options.terrainType ?? randomWallType() : randomWallType();
-		const grid = buildBaseTerrain(exits, wallType, swampType);
+		const terrain = gridToTerrain(buildBaseTerrain(exits, wallType, swampType));
 		const room = new Room();
 		room.name = roomName;
-		const context = makeGeneratorContext(room, grid, options);
+		const context = makeGeneratorContext(room, terrain, options);
 		if (generators.every(generator => generator.generate(context))) {
-			return { room, terrain: gridToTerrain(grid) };
+			return { room, terrain };
 		}
 	}
 	throw new Error(`Failed to generate room terrain after ${kMaxGenerateAttempts} attempts`);

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -1,5 +1,7 @@
 import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
+import type { Terrain } from 'xxscreeps/game/terrain.js';
 import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 
 type ExitSide = 'top' | 'right' | 'bottom' | 'left';
@@ -15,23 +17,22 @@ export interface GenerateRoomOptions {
 
 export interface RoomGeneratorContext {
 	options: GenerateRoomOptions;
-	/** The room being generated. Insert objects through `place` so their tiles are tagged. */
+	/** The room being generated. Insert objects through `place` so their positions are tagged. */
 	room: Room;
+	/** The room's generated terrain. */
+	terrain: Terrain;
 	/**
-	 * Rolls uniformly random tiles within [min, min + span) on both axes until one satisfies
-	 * `accept`, returning undefined after 1000 failed rolls to signal terrain that can't host the
-	 * object.
+	 * The first position in random order within [min, min + span) on both axes satisfying `accept`,
+	 * or undefined when the terrain can't host the object anywhere.
 	 */
-	findRandomTile: (min: number, span: number, accept: (xx: number, yy: number) => boolean) =>
-		readonly [ number, number ] | undefined;
-	/** Whether (xx, yy) is an untagged wall tile with at least one passable neighbor. */
-	isPlaceable: (xx: number, yy: number) => boolean;
-	/** Whether (xx, yy) is a wall tile. */
-	isWall: (xx: number, yy: number) => boolean;
-	/** Inserts `object` into the room and tags its tile. */
+	findRandomPosition: (min: number, span: number, accept: (position: RoomPosition) => boolean) =>
+		RoomPosition | undefined;
+	/** Whether `position` is an untagged wall tile with at least one passable neighbor. */
+	isPlaceable: (position: RoomPosition) => boolean;
+	/** Inserts `object` into the room and tags its position. */
 	place: (object: RoomObject, ...tags: string[]) => void;
-	/** Tags applied by earlier placements at (xx, yy). */
-	tagsAt: (xx: number, yy: number) => ReadonlySet<string>;
+	/** Tags applied by earlier placements at `position`. */
+	tagsAt: (position: RoomPosition) => ReadonlySet<string>;
 }
 
 export const hooks = makeHookRegistration<{


### PR DESCRIPTION
Flattens the room-generator hook context onto domain types, following the #321 merge note: hooks now receive `RoomPosition`s and a `Terrain` instead of raw `(xx, yy)` tuples and grid callbacks. `findRandomTile` becomes `findRandomPosition`, `isWall` is replaced by exposing the room's `terrain`, and the placement mods drop their local grid iterators for `iterateArea` / `iterateInRangeTo` / `iterateNeighbors`.

Terrain is now materialized before the generator hooks run, so the `Grid` intermediate stays private to terrain generation.

## Validation
- `tsc -b` and eslint clean; test suite 520/520.
- Offline smoke on an isolated local shard: generated a normal room and a keeper-style room (`controller: false, keeperLairs: true, sources: 3`) and read both back — loadouts exact (2 sources + controller + mineral; 3 sources + mineral + 4 keeper lairs + extractor), all placements flowing through `findRandomPosition` / `isPlaceable` / `tagsAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
