### PR TITLE
room-gen: generate full sectors under the mod-10 template

### DIFF
--- a/.changeset/sector-generation.md
+++ b/.changeset/sector-generation.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Added `generateSector`: full sector blocks with highways, source-keeper core, and sealed borders.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ and gives full TypeScript types on the operations you call.
 
 ```ts
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
-import { generateRoom } from 'xxscreeps/scripts/room-gen.js';
+import { generateRoom, generateSector } from 'xxscreeps/scripts/room-gen.js';
 
 await using db = await Database.connect();
 await using shard = await Shard.connect(db, 'shard0');
@@ -168,6 +168,7 @@ await using shard = await Shard.connect(db, 'shard0');
 await generateRoom(shard, 'W12N5');
 await generateRoom(shard, 'W11N5', { terrainType: 3, swampType: 2 });
 await generateRoom(shard, 'W10N5', { sources: 1, mineral: 'H' });
+await generateSector(shard, 'W20N20');
 await Promise.all([ db.save(), shard.save() ]);
 ```
 
@@ -182,6 +183,17 @@ omitted. Like `npx xxscreeps import`, it is an offline operation — stop the
 server before running it so cached world state in the backend, processor, and
 runner workers doesn't go stale. Exits are read from any already-generated
 neighbor, so adjacent generated rooms connect.
+
+`generateSector` builds the full 11×11 room block from an origin corner (a
+room at printed multiples of 10 on both axes) under the vanilla mod-10 sector
+template: highway rooms on the boundary rings, the central room and its 3×3
+source-keeper core, and normal rooms elsewhere. Highway terrain is an open
+travel lane flanked by wall masses that flow continuously across room borders,
+and some borders between normal and highway rooms seal at random, like the
+live world's. Rooms that already exist are skipped, so adjacent sectors share
+their boundary rings and a partially built sector can be re-entered. The same
+options apply to the sector's normal rooms. Also available as
+`npx xxscreeps generate-sector W20N20`.
 
 ## Docker
 

--- a/packages/xxscreeps/game/position.ts
+++ b/packages/xxscreeps/game/position.ts
@@ -554,6 +554,13 @@ export const iterateWithRangeTo = function() {
 }();
 
 /**
+ * Iterate all positions in a room.
+ */
+export function iterateAllPositions(roomName: string) {
+	return iterateArea(roomName, 0, 0, 49, 49);
+}
+
+/**
  * Iterate all direct neighbors of the given position.
  */
 export function iterateNeighbors(position: RoomPosition) {

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -1,7 +1,8 @@
+import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { iterateInRangeTo } from 'xxscreeps/game/position.js';
+import { iterateArea, iterateInRangeTo } from 'xxscreeps/game/position.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from './constants.js';
 import { create as createExtractor } from './extractor.js';
@@ -26,6 +27,10 @@ function pickMineralDensity(): number {
 		probability => probability !== undefined && random <= probability);
 }
 
+// Rooms whose sources were spread (three or more) spread their mineral the same way, like a
+// fourth source; the keeper lairs guarding them then land apart as well.
+const kSpreadSourceThreshold = 3;
+
 hooks.register('roomGenerator', {
 	order: 2,
 	generate(context) {
@@ -34,11 +39,17 @@ hooks.register('roomGenerator', {
 		if (mineralType === false) {
 			return true;
 		}
-		const position = context.findRandomPosition(4, 42, candidate =>
+		const accept = (candidate: RoomPosition) =>
 			context.isPlaceable(candidate) && !Fn.some(iterateInRangeTo(candidate, 4), near => {
 				const tags = context.tagsAt(near);
 				return tags.has('source') || tags.has('controller');
-			}));
+			});
+		const sources = [ ...Fn.filter(
+			iterateArea(context.room.name, 0, 0, 49, 49),
+			candidate => context.tagsAt(candidate).has('source')) ];
+		const position = sources.length >= kSpreadSourceThreshold
+			? context.findSpreadPosition(4, 42, accept, sources)
+			: context.findRandomPosition(4, 42, accept);
 		if (position === undefined) {
 			return false;
 		}

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -2,7 +2,7 @@ import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { iterateArea, iterateInRangeTo } from 'xxscreeps/game/position.js';
+import { iterateAllPositions, iterateInRangeTo } from 'xxscreeps/game/position.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from './constants.js';
 import { create as createExtractor } from './extractor.js';
@@ -45,7 +45,7 @@ hooks.register('roomGenerator', {
 				return tags.has('source') || tags.has('controller');
 			});
 		const sources = [ ...Fn.filter(
-			iterateArea(context.room.name, 0, 0, 49, 49),
+			iterateAllPositions(context.room.name),
 			candidate => context.tagsAt(candidate).has('source')) ];
 		const position = sources.length >= kSpreadSourceThreshold
 			? context.findSpreadPosition(4, 42, accept, sources)

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -8,6 +8,11 @@ import * as C from 'xxscreeps:mods/constants';
 import { create as createKeeperLair } from './keeper-lair.js';
 import { Source } from './source.js';
 
+// Rooms with three or more sources (keeper and center rooms) spread their sources across the room
+// rather than dropping each on a random wall tile, which clusters them; a failed spread signals
+// the caller to regenerate the terrain.
+const kSpreadSourceThreshold = 3;
+
 // Keeper and center rooms (the controller-less ones) bake their sources' 4000 energy capacity at
 // generation: Source's '#roomStatusDidChange' computes the same thing from the room owner, but the
 // controller processor that drives that hook never runs for a controller-less room.
@@ -19,11 +24,15 @@ hooks.register('roomGenerator', {
 		const energyCapacity = options.controller === false
 			? C.SOURCE_ENERGY_KEEPER_CAPACITY
 			: C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
+		const placed: RoomPosition[] = [];
 		for (let ii = 0; ii < count; ++ii) {
-			const position = context.findRandomPosition(3, 44, context.isPlaceable);
+			const position = count >= kSpreadSourceThreshold && placed.length > 0
+				? context.findSpreadPosition(3, 44, context.isPlaceable, placed)
+				: context.findRandomPosition(3, 44, context.isPlaceable);
 			if (position === undefined) {
 				return false;
 			}
+			placed.push(position);
 			const source = createRoomObject(new Source(), position);
 			source.energy = source.energyCapacity = energyCapacity;
 			context.place(source, 'source', 'guarded');

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -1,7 +1,7 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { RoomGeneratorContext } from 'xxscreeps/scripts/symbols.js';
 import { createRoomObject } from 'xxscreeps/game/object.js';
-import { iterateArea, iterateNeighbors } from 'xxscreeps/game/position.js';
+import { iterateAllPositions, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from 'xxscreeps:mods/constants';
@@ -82,7 +82,7 @@ hooks.register('roomGenerator', {
 		if (context.options.keeperLairs !== true) {
 			return true;
 		}
-		for (const position of iterateArea(context.room.name, 0, 0, 49, 49)) {
+		for (const position of iterateAllPositions(context.room.name)) {
 			if (context.tagsAt(position).has('guarded') && !placeKeeperLair(context, position)) {
 				return false;
 			}

--- a/packages/xxscreeps/mods/modern/sector/sector.ts
+++ b/packages/xxscreeps/mods/modern/sector/sector.ts
@@ -1,5 +1,6 @@
 import type { SectorControl } from './schema.js';
 import type { World } from 'xxscreeps/game/map.js';
+import type { HighwayOrientation } from 'xxscreeps/scripts/symbols.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { makeAbstractIterateWithRangeTo, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import { makeSignedRoomName, parseSignedRoomName, roomLinearDistance } from 'xxscreeps/game/room/name.js';
@@ -19,6 +20,45 @@ export function *iterateSectors(world: World): IterableIterator<[ center: string
 // residue) so the test holds at any world size rather than a fixed half-world offset.
 function isCentralAxis(coord: number): boolean {
 	return coord < 0 ? coord % 10 === -6 : coord % 10 === 5;
+}
+
+// A highway axis sits exactly 5 rooms from a sector-center axis (the `{..}0` boundary). Defined off
+// `isCentralAxis` so the W/N sign phase-shift is handled in one place rather than re-derived.
+function isHighwayAxis(coord: number): boolean {
+	return isCentralAxis(coord - 5) || isCentralAxis(coord + 5);
+}
+
+// The 3-wide central band of a sector -- printed digits 4, 5, 6, sign-agnostic so W4 and E4 both
+// yield 4. Both axes in-band marks the 3x3 sector core: the center plus its 8 source-keeper rooms.
+function isCenterNineAxis(coord: number): boolean {
+	const digit = (coord < 0 ? -1 - coord : coord) % 10;
+	return digit >= 4 && digit <= 6;
+}
+
+export type RoomType = 'normal' | 'highway' | 'sourceKeeper' | 'center';
+
+/** Classifies a room by its role in the mod-10 sector template. */
+export function roomType(roomName: string): RoomType {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (isHighwayAxis(rx) || isHighwayAxis(ry)) {
+		return 'highway';
+	} else if (isCentralAxis(rx) && isCentralAxis(ry)) {
+		return 'center';
+	} else if (isCenterNineAxis(rx) && isCenterNineAxis(ry)) {
+		return 'sourceKeeper';
+	}
+	return 'normal';
+}
+
+// Which sector-facing borders a highway room walls off: rooms on a vertical highway axis bound
+// their east+west sides, rooms on a horizontal axis their top+bottom, and rooms on both axes are
+// the crossings whose masses sit in the four corners.
+export function highwayOrientation(roomName: string): HighwayOrientation {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (isHighwayAxis(rx)) {
+		return isHighwayAxis(ry) ? 'crossing' : 'vertical';
+	}
+	return 'horizontal';
 }
 
 const iterateRoomRing = makeAbstractIterateWithRangeTo(-Infinity, Infinity);

--- a/packages/xxscreeps/mods/modern/sector/sector.ts
+++ b/packages/xxscreeps/mods/modern/sector/sector.ts
@@ -1,9 +1,6 @@
 import type { SectorControl } from './schema.js';
 import type { World } from 'xxscreeps/game/map.js';
-import type { HighwayOrientation } from 'xxscreeps/scripts/symbols.js';
-import { Fn } from 'xxscreeps/functional/fn.js';
-import { makeAbstractIterateWithRangeTo, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
-import { makeSignedRoomName, parseSignedRoomName, roomLinearDistance } from 'xxscreeps/game/room/name.js';
+import { parseSignedRoomName, roomLinearDistance } from 'xxscreeps/game/room/name.js';
 
 // Iterates the sector-control records stamped on the world's center rooms.
 export function *iterateSectors(world: World): IterableIterator<[ center: string, sector: SectorControl ]> {
@@ -12,85 +9,6 @@ export function *iterateSectors(world: World): IterableIterator<[ center: string
 		if (sectorControl) {
 			yield [ roomName, sectorControl ];
 		}
-	}
-}
-
-// Sector centers are the rooms numbered `{..}5` on each axis; the highway ring sits on the `{..}0`
-// boundary rooms +-5 away. Keyed off the sign of the signed coordinate (W/N use the negative
-// residue) so the test holds at any world size rather than a fixed half-world offset.
-function isCentralAxis(coord: number): boolean {
-	return coord < 0 ? coord % 10 === -6 : coord % 10 === 5;
-}
-
-// A highway axis sits exactly 5 rooms from a sector-center axis (the `{..}0` boundary). Defined off
-// `isCentralAxis` so the W/N sign phase-shift is handled in one place rather than re-derived.
-function isHighwayAxis(coord: number): boolean {
-	return isCentralAxis(coord - 5) || isCentralAxis(coord + 5);
-}
-
-// The 3-wide central band of a sector -- printed digits 4, 5, 6, sign-agnostic so W4 and E4 both
-// yield 4. Both axes in-band marks the 3x3 sector core: the center plus its 8 source-keeper rooms.
-function isCenterNineAxis(coord: number): boolean {
-	const digit = (coord < 0 ? -1 - coord : coord) % 10;
-	return digit >= 4 && digit <= 6;
-}
-
-export type RoomType = 'normal' | 'highway' | 'sourceKeeper' | 'center';
-
-/** Classifies a room by its role in the mod-10 sector template. */
-export function roomType(roomName: string): RoomType {
-	const { rx, ry } = parseSignedRoomName(roomName);
-	if (isHighwayAxis(rx) || isHighwayAxis(ry)) {
-		return 'highway';
-	} else if (isCentralAxis(rx) && isCentralAxis(ry)) {
-		return 'center';
-	} else if (isCenterNineAxis(rx) && isCenterNineAxis(ry)) {
-		return 'sourceKeeper';
-	}
-	return 'normal';
-}
-
-// Which sector-facing borders a highway room walls off: rooms on a vertical highway axis bound
-// their east+west sides, rooms on a horizontal axis their top+bottom, and rooms on both axes are
-// the crossings whose masses sit in the four corners.
-export function highwayOrientation(roomName: string): HighwayOrientation {
-	const { rx, ry } = parseSignedRoomName(roomName);
-	if (isHighwayAxis(rx)) {
-		return isHighwayAxis(ry) ? 'crossing' : 'vertical';
-	}
-	return 'horizontal';
-}
-
-const iterateRoomRing = makeAbstractIterateWithRangeTo(-Infinity, Infinity);
-const iterateRoomArea = makeLocalIterateInRangeTo(-Infinity, Infinity);
-
-// Derives a room's `meta` from the Screeps 9x9 (+1) sector template, for terraformation paths.
-// `roomName` is assumed to be a sector center.
-export function computeRoomMeta(roomName: string, rooms: ReadonlySet<string>) {
-	const { rx, ry } = parseSignedRoomName(roomName);
-	if (isCentralAxis(rx) && isCentralAxis(ry)) {
-		const flatten = (coords: Iterable<readonly [ number, number ]>) => Fn.pipe(
-			coords,
-			$$ => Fn.map($$, ([ xx, yy ]) => makeSignedRoomName(xx, yy)),
-			$$ => Fn.filter($$, name => rooms.has(name)),
-			$$ => [ ...$$ ]);
-		return {
-			sectors: [ roomName ],
-			sectorControl: {
-				edges: flatten(iterateRoomRing(rx, ry, 5)),
-				members: flatten(iterateRoomArea(rx, ry, 4)),
-			},
-		};
-	} else {
-		return {
-			sectors: Fn.pipe(
-				iterateRoomArea(rx, ry, 5),
-				$$ => Fn.filter($$, ([ xx, yy ]) => isCentralAxis(xx) && isCentralAxis(yy)),
-				$$ => Fn.map($$, ([ xx, yy ]) => makeSignedRoomName(xx, yy)),
-				$$ => Fn.filter($$, name => rooms.has(name)),
-				$$ => [ ...$$ ]),
-			sectorControl: undefined,
-		};
 	}
 }
 

--- a/packages/xxscreeps/mods/modern/sector/terrain.ts
+++ b/packages/xxscreeps/mods/modern/sector/terrain.ts
@@ -1,0 +1,95 @@
+import type { SectorControl } from './schema.js';
+import type { World } from 'xxscreeps/game/map.js';
+import type { HighwayOrientation } from 'xxscreeps/scripts/symbols.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { makeAbstractIterateWithRangeTo, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
+import { makeSignedRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
+
+const iterateRoomRing = makeAbstractIterateWithRangeTo(-Infinity, Infinity);
+const iterateRoomArea = makeLocalIterateInRangeTo(-Infinity, Infinity);
+
+// Iterates the sector-control records stamped on the world's center rooms.
+export function *iterateSectors(world: World): IterableIterator<[ center: string, sector: SectorControl ]> {
+	for (const [ roomName, entry ] of world.terrain) {
+		const { sectorControl } = entry;
+		if (sectorControl) {
+			yield [ roomName, sectorControl ];
+		}
+	}
+}
+
+// Sector centers are the rooms numbered `{..}5` on each axis; the highway ring sits on the `{..}0`
+// boundary rooms +-5 away. Keyed off the sign of the signed coordinate (W/N use the negative
+// residue) so the test holds at any world size rather than a fixed half-world offset.
+function isCentralAxis(coord: number): boolean {
+	return coord < 0 ? coord % 10 === -6 : coord % 10 === 5;
+}
+
+// A highway axis sits exactly 5 rooms from a sector-center axis (the `{..}0` boundary). Defined off
+// `isCentralAxis` so the W/N sign phase-shift is handled in one place rather than re-derived.
+function isHighwayAxis(coord: number): boolean {
+	return isCentralAxis(coord - 5) || isCentralAxis(coord + 5);
+}
+
+// The 3-wide central band of a sector -- printed digits 4, 5, 6, sign-agnostic so W4 and E4 both
+// yield 4. Both axes in-band marks the 3x3 sector core: the center plus its 8 source-keeper rooms.
+function isCenterNineAxis(coord: number): boolean {
+	const digit = (coord < 0 ? -1 - coord : coord) % 10;
+	return digit >= 4 && digit <= 6;
+}
+
+export type RoomType = 'normal' | 'highway' | 'sourceKeeper' | 'center';
+
+/** Classifies a room by its role in the mod-10 sector template. */
+export function roomType(roomName: string): RoomType {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (isHighwayAxis(rx) || isHighwayAxis(ry)) {
+		return 'highway';
+	} else if (isCentralAxis(rx) && isCentralAxis(ry)) {
+		return 'center';
+	} else if (isCenterNineAxis(rx) && isCenterNineAxis(ry)) {
+		return 'sourceKeeper';
+	}
+	return 'normal';
+}
+
+// Which sector-facing borders a highway room walls off: rooms on a vertical highway axis bound
+// their east+west sides, rooms on a horizontal axis their top+bottom, and rooms on both axes are
+// the crossings whose masses sit in the four corners.
+export function highwayOrientation(roomName: string): HighwayOrientation {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (isHighwayAxis(rx)) {
+		return isHighwayAxis(ry) ? 'crossing' : 'vertical';
+	}
+	return 'horizontal';
+}
+
+// Derives a room's `meta` from the Screeps 9x9 (+1) sector template, for terraformation paths.
+// `roomName` is assumed to be a sector center.
+export function computeRoomMeta(roomName: string, rooms: ReadonlySet<string>) {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	if (isCentralAxis(rx) && isCentralAxis(ry)) {
+		const flatten = (coords: Iterable<readonly [ number, number ]>) => Fn.pipe(
+			coords,
+			$$ => Fn.map($$, ([ xx, yy ]) => makeSignedRoomName(xx, yy)),
+			$$ => Fn.filter($$, name => rooms.has(name)),
+			$$ => [ ...$$ ]);
+		return {
+			sectors: [ roomName ],
+			sectorControl: {
+				edges: flatten(iterateRoomRing(rx, ry, 5)),
+				members: flatten(iterateRoomArea(rx, ry, 4)),
+			},
+		};
+	} else {
+		return {
+			sectors: Fn.pipe(
+				iterateRoomArea(rx, ry, 5),
+				$$ => Fn.filter($$, ([ xx, yy ]) => isCentralAxis(xx) && isCentralAxis(yy)),
+				$$ => Fn.map($$, ([ xx, yy ]) => makeSignedRoomName(xx, yy)),
+				$$ => Fn.filter($$, name => rooms.has(name)),
+				$$ => [ ...$$ ]),
+			sectorControl: undefined,
+		};
+	}
+}

--- a/packages/xxscreeps/scripts/generate-room.ts
+++ b/packages/xxscreeps/scripts/generate-room.ts
@@ -28,10 +28,26 @@ function parseMineralType(value: string | undefined) {
 	throw new Error(`mineral must be one of ${Object.keys(C.MINERAL_MIN_AMOUNT).join(', ')}`);
 }
 
+// The room-shape flags shared between `generate-room` and `generate-sector`.
+export const roomOptionArguments = [ 'terrain-type', 'swamp-type', 'sources', 'mineral' ] as const;
+
+export function parseRoomOptions(argv: Partial<Record<typeof roomOptionArguments[number], string>>): GenerateRoomOptions {
+	const terrainType = parseOptionalInteger(argv['terrain-type'], 'terrain-type', 1, 28);
+	const swampType = parseOptionalInteger(argv['swamp-type'], 'swamp-type', 0, 14);
+	const sources = parseOptionalInteger(argv.sources, 'sources', 1, 4);
+	const mineral = parseMineralType(argv.mineral);
+	return {
+		...terrainType !== undefined && { terrainType },
+		...swampType !== undefined && { swampType },
+		...sources !== undefined && { sources },
+		...mineral !== undefined && { mineral },
+	};
+}
+
 async function main() {
 	const argv = checkArguments({
 		argv: true,
-		string: [ 'shard', 'terrain-type', 'swamp-type', 'sources', 'mineral' ] as const,
+		string: [ 'shard', ...roomOptionArguments ] as const,
 	});
 	const roomName = argv.argv[0];
 	if (roomName === undefined) {
@@ -40,17 +56,7 @@ async function main() {
 		return;
 	}
 
-	const terrainType = parseOptionalInteger(argv['terrain-type'], 'terrain-type', 1, 28);
-	const swampType = parseOptionalInteger(argv['swamp-type'], 'swamp-type', 0, 14);
-	const sources = parseOptionalInteger(argv.sources, 'sources', 1, 4);
-	const mineral = parseMineralType(argv.mineral);
-	const options: GenerateRoomOptions = {
-		...terrainType !== undefined && { terrainType },
-		...swampType !== undefined && { swampType },
-		...sources !== undefined && { sources },
-		...mineral !== undefined && { mineral },
-	};
-
+	const options = parseRoomOptions(argv);
 	await using db = await Database.connect();
 	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
 	const room = await generateRoom(shard, roomName, options);

--- a/packages/xxscreeps/scripts/generate-sector.ts
+++ b/packages/xxscreeps/scripts/generate-sector.ts
@@ -1,0 +1,33 @@
+import { checkArguments } from 'xxscreeps/config/arguments.js';
+import { config } from 'xxscreeps/config/index.js';
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { parseRoomOptions, roomOptionArguments } from 'xxscreeps/scripts/generate-room.js';
+import { generateSector } from 'xxscreeps/scripts/room-gen.js';
+
+// Generates a full sector from an origin room -- the 11x11 = 121-room block including the highway
+// rings shared with adjacent sectors. Shares the room-shape flags with `generate-room`; they apply
+// to the sector's normal rooms, while highways, the source-keeper ring, and the center core follow
+// the vanilla mod-10 template.
+async function main() {
+	const argv = checkArguments({
+		argv: true,
+		string: [ 'shard', ...roomOptionArguments ] as const,
+	});
+	const origin = argv.argv[0];
+	if (origin === undefined) {
+		console.log('Usage: xxscreeps generate-sector <origin> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
+		process.exitCode = 1;
+		return;
+	}
+
+	const options = parseRoomOptions(argv);
+	await using db = await Database.connect();
+	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
+	const rooms = await generateSector(shard, origin, options);
+	await Promise.all([ db.save(), shard.save() ]);
+	console.log(`Generated ${rooms.length} room${rooms.length === 1 ? '' : 's'} from ${origin}`);
+}
+
+if (process.argv[1] === 'generate-sector') {
+	await main();
+}

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,5 +1,6 @@
 import type { ExitMap, GenerateRoomOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { RoomType } from 'xxscreeps/mods/modern/sector/sector.js';
 import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
@@ -7,10 +8,10 @@ import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
 import { RoomPosition, iterateArea, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
-import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
+import { kMaxWorldSize, makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
-import { computeRoomMeta } from 'xxscreeps/mods/modern/sector/sector.js';
+import { computeRoomMeta, highwayOrientation, roomType } from 'xxscreeps/mods/modern/sector/sector.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
 import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import { hashCombine, hashMix } from 'xxscreeps/utility/utility.js';
@@ -594,7 +595,6 @@ const kMaxGenerateAttempts = 50;
 // forever) after a bounded number of attempts.
 function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions) {
 	const generators = [ ...hooks.map('roomGenerator') ].sort(mappedNumericComparator(generator => generator.order));
-	const { rx, ry } = parseRoomName(roomName);
 	const swampType = options.swampType ??
 		(options.highway ? rollHighwaySwamp() : Math.floor(Math.random() * 14));
 	// Highway terrain is a deterministic function of world position, so a retry would rebuild it
@@ -603,6 +603,7 @@ function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions)
 	for (let attempt = 0; attempt < maxAttempts; ++attempt) {
 		const terrain = gridToTerrain(function() {
 			if (options.highway) {
+				const { rx, ry } = parseRoomName(roomName);
 				return genHighwayTerrain(exits, rx, ry, options.highway, swampType);
 			}
 			const wallType = attempt === 0 ? options.terrainType ?? randomWallType() : randomWallType();
@@ -693,6 +694,33 @@ function buildRoom(
 	return { room, terrain };
 }
 
+// Inserts a freshly built room's record into the terrain map with its authored geometry. Sector
+// meta starts empty -- it can only be stamped correctly once every room of the batch is in the
+// map, so `refreshRoomMeta` owns the stamping.
+function commitRoom(terrainMap: WorldTerrain, roomName: string, terrain: Terrain) {
+	terrainMap.set(roomName, { exits: packExits(terrain), terrain, sectors: [], sectorControl: undefined });
+}
+
+// Sector relationships are stored bidirectionally, so a room landing can extend the records of
+// rooms generated earlier -- an existing member gains this center, a center gains this member.
+// Restamps the geometry of every record within sector range of the given rooms.
+function refreshRoomMeta(terrainMap: WorldTerrain, roomNames: Iterable<string>) {
+	const allNames = new Set(terrainMap.keys());
+	const touched = new Set<string>();
+	for (const roomName of roomNames) {
+		const { rx, ry } = parseSignedRoomName(roomName);
+		for (const [ xx, yy ] of iterateRoomsInRange(rx, ry, 5)) {
+			touched.add(makeSignedRoomName(xx, yy));
+		}
+	}
+	for (const name of touched) {
+		const record = terrainMap.get(name);
+		if (record) {
+			terrainMap.set(name, { ...record, ...computeRoomMeta(name, allNames) });
+		}
+	}
+}
+
 // A freshly-created shard has no world terrain blob; the strict (redis) provider then throws
 // "terrain does not exist" out of loadWorld. Seed an empty terrain map so the first generated room
 // can bootstrap the world. (The local provider tolerates the missing key, masking this.)
@@ -732,18 +760,157 @@ export async function generateRoom(
 
 	const terrainMap = new Map(world.terrain);
 	const { room, terrain } = buildRoom(roomName, options, neighborName => terrainMap.get(neighborName));
-	const roomNames = new Set([ ...terrainMap.keys(), roomName ]);
-	terrainMap.set(roomName, { exits: packExits(terrain), terrain, ...computeRoomMeta(roomName, roomNames) });
-	// Sector relationships are stored bidirectionally, so a room landing can extend the records of
-	// rooms generated earlier -- an existing member gains this center, a center gains this member.
-	for (const [ xx, yy ] of iterateRoomsInRange(rx, ry, 5)) {
-		const neighborName = makeSignedRoomName(xx, yy);
-		const record = terrainMap.get(neighborName);
-		if (record && neighborName !== roomName) {
-			terrainMap.set(neighborName, { ...record, ...computeRoomMeta(neighborName, roomNames) });
-		}
-	}
+	commitRoom(terrainMap, roomName, terrain);
+	refreshRoomMeta(terrainMap, [ roomName ]);
 	await flushRooms(shard, terrainMap, [ room ]);
 
 	return room;
+}
+
+interface SectorOrigin {
+	rx: number;
+	ry: number;
+	// Signed-coordinate direction of increasing printed room numbers, per axis.
+	xStep: number;
+	yStep: number;
+}
+
+// A sector's origin is its outer highway ring corner nearest the world axes, so it sits at printed
+// multiples of 10 on both axes; the sector spans printed coordinates `n..n+10` away from the axes.
+function parseSectorOrigin(name: string): SectorOrigin {
+	const { rx, ry } = parseSignedRoomName(name);
+	if (Number.isNaN(rx) || Number.isNaN(ry)) {
+		throw new Error(`Invalid room name: ${name}`);
+	}
+	const xNum = rx < 0 ? -1 - rx : rx;
+	const yNum = ry < 0 ? -1 - ry : ry;
+	if (xNum % 10 !== 0 || yNum % 10 !== 0) {
+		throw new Error(`Sector origin must be at a multiple of 10: ${name}`);
+	}
+	if (xNum + 10 >= kMaxWorldSize >>> 1 || yNum + 10 >= kMaxWorldSize >>> 1) {
+		throw new Error(`Sector ${name} extends past world bounds`);
+	}
+	return { rx, ry, xStep: rx < 0 ? -1 : 1, yStep: ry < 0 ? -1 : 1 };
+}
+
+// Per-type object loadouts. Highways are object-free open corridors; source-keeper rooms hold
+// three guarded sources and a guarded mineral with no controller; center rooms are the same but
+// keeper-free; normal rooms keep the caller/default loadout (controller + 1-2 sources + mineral).
+const roomTypeTemplates: Record<RoomType, GenerateRoomOptions> = {
+	center: { controller: false, keeperLairs: false, sources: 3 },
+	highway: { controller: false, keeperLairs: false, mineral: false, sources: 0 },
+	normal: {},
+	sourceKeeper: { controller: false, keeperLairs: true, sources: 3 },
+};
+
+interface SectorDir {
+	dxx: number;
+	dyy: number;
+	// The neighbor's border shared with this room, as its `packExits` bit.
+	sharedExitBit: number;
+}
+
+const kSectorDirs: Record<keyof ExitMap, SectorDir> = {
+	top: { dxx: 0, dyy: -1, sharedExitBit: 4 },
+	right: { dxx: 1, dyy: 0, sharedExitBit: 8 },
+	bottom: { dxx: 0, dyy: 1, sharedExitBit: 1 },
+	left: { dxx: -1, dyy: 0, sharedExitBit: 2 },
+};
+
+// The live world walls off some borders where both sides carry a wall mass: a normal room seals
+// about one of its four sides on average, and a highway seals its mass sides at much the same
+// rate. A void border between two sealable sides seals with this probability; the neighbor
+// inherits the seal when it builds.
+const kSealSideProbability = 0.3;
+
+// A highway may seal only its mass sides (the lane must run through); a normal room may seal a
+// side facing another normal or highway room, but never the sector core; source-keeper and center
+// rooms never seal, since walling off the core would strand the sector's guarded rooms.
+function isSealableSide(type: RoomType, dir: keyof ExitMap, roomName: string, neighborName: string, hasController: boolean): boolean {
+	if (type === 'highway') {
+		const orientation = highwayOrientation(roomName);
+		return orientation === 'vertical' ? dir === 'left' || dir === 'right' :
+			orientation === 'horizontal' ? dir === 'top' || dir === 'bottom' :
+			false;
+	} else if (type === 'normal' && hasController) {
+		const neighborType = roomType(neighborName);
+		return neighborType === 'normal' || neighborType === 'highway';
+	}
+	return false;
+}
+
+// Builds every not-yet-existing room of one sector into the shared accumulators -- terrain into
+// `terrainMap`, names into `existing` so later rooms see them as neighbors -- and yields the new
+// rooms. The range is the inclusive 11x11 block from the origin, so the sector is bounded by its
+// full highway ring on all four sides -- the origin-corner rings plus the rings shared with the
+// next sectors. Already-existing rooms are skipped, so the shared rings are idempotent across
+// adjacent sectors and partially-built sectors can be re-entered. No storage I/O; the caller
+// flushes once.
+function *accumulateSector(
+	origin: SectorOrigin,
+	options: GenerateRoomOptions | undefined,
+	terrainMap: WorldTerrain,
+	existing: Set<string>,
+): Iterable<Room> {
+	for (const [ rx, ry ] of iterateRoomsInRange(origin.rx + 5 * origin.xStep, origin.ry + 5 * origin.yStep, 5)) {
+		const roomName = makeSignedRoomName(rx, ry);
+		if (existing.has(roomName)) {
+			continue;
+		}
+		const type = roomType(roomName);
+		const template = roomTypeTemplates[type];
+		const hasController = (template.controller ?? options?.controller) !== false;
+
+		// Roll seals on void borders; sides facing a built room inherit its border instead.
+		const sealed: (keyof ExitMap)[] = [];
+		let openSides = 0;
+		for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
+			const sectorDir = kSectorDirs[dir];
+			const neighborName = makeSignedRoomName(rx + sectorDir.dxx, ry + sectorDir.dyy);
+			const record = terrainMap.get(neighborName);
+			if (record) {
+				if ((record.exits & sectorDir.sharedExitBit) !== 0) {
+					openSides += 1;
+				}
+			} else if (isSealableSide(type, dir, roomName, neighborName, hasController) &&
+				Math.random() < kSealSideProbability) {
+				sealed.push(dir);
+			} else {
+				openSides += 1;
+			}
+		}
+		// Never wall off all four sides -- reopen a rolled seal when no border can carry an exit. A
+		// re-entered hole whose four built neighbors all sealed toward it has nothing to reopen and
+		// still generates a zero-exit room; rare, locally unfixable (the neighbors' terrain is already
+		// authored), and the live world does carry fully sealed rooms.
+		if (openSides === 0 && sealed.length > 0) {
+			sealed.shift();
+		}
+
+		const roomOptions: GenerateRoomOptions = {
+			...type === 'normal' && options,
+			...template,
+			...type === 'highway' && { highway: highwayOrientation(roomName) },
+			exits: Fn.fromEntries(Fn.map(sealed, dir => [ dir, [] ])),
+		};
+		const { room, terrain } = buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
+		commitRoom(terrainMap, roomName, terrain);
+		existing.add(roomName);
+		yield room;
+	}
+}
+
+export async function generateSector(
+	shard: Shard,
+	sectorName: string,
+	options?: GenerateRoomOptions,
+): Promise<Room[]> {
+	const origin = parseSectorOrigin(sectorName);
+	await ensureWorldTerrain(shard);
+	const [ world, existingRooms ] = await Promise.all([ shard.loadWorld(), shard.data.sMembers('rooms') ]);
+	const terrainMap = new Map(world.terrain);
+	const rooms = [ ...accumulateSector(origin, options, terrainMap, new Set(existingRooms)) ];
+	refreshRoomMeta(terrainMap, Fn.map(rooms, room => room.name));
+	await flushRooms(shard, terrainMap, rooms);
+	return rooms;
 }

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,4 +1,4 @@
-import type { ExitMap, GenerateRoomOptions, RoomGeneratorContext } from './symbols.js';
+import type { ExitMap, GenerateRoomOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -13,6 +13,7 @@ import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terr
 import { computeRoomMeta } from 'xxscreeps/mods/modern/sector/sector.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
 import { shuffledSquare } from 'xxscreeps/utility/random.js';
+import { hashCombine, hashMix } from 'xxscreeps/utility/utility.js';
 import { hooks } from './symbols.js';
 import 'xxscreeps:mods/terrain';
 
@@ -237,6 +238,27 @@ function *exitsArray(terrain: Terrain, axis: 'x' | 'y', fixed: number) {
 	}
 }
 
+// Marks the room's exit tiles (and their inner neighbors) as open so terrain generation keeps the
+// border crossings clear.
+function markExits(grid: Grid, exits: ExitMap): void {
+	for (const xx of exits.top) {
+		grid[0]![xx]!.forceOpen = true;
+		grid[1]![xx]!.forceOpen = true;
+	}
+	for (const xx of exits.bottom) {
+		grid[49]![xx]!.forceOpen = true;
+		grid[48]![xx]!.forceOpen = true;
+	}
+	for (const yy of exits.left) {
+		grid[yy]![0]!.forceOpen = true;
+		grid[yy]![1]!.forceOpen = true;
+	}
+	for (const yy of exits.right) {
+		grid[yy]![49]!.forceOpen = true;
+		grid[yy]![48]!.forceOpen = true;
+	}
+}
+
 // Fills the room with cellular-automaton wall (and swamp) noise, rerolling the wall type until the
 // open terrain is fully connected, then smooths swamp the same way.
 function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): Grid {
@@ -245,6 +267,7 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 	let tries = 0;
 	do {
 		grid = makeGrid();
+		markExits(grid, exits);
 		tries++;
 		if (tries > 100) {
 			activeWallType = randomWallType();
@@ -253,24 +276,7 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 
 		for (const [ yy, row ] of grid.entries()) {
 			for (const [ xx, cell ] of row.entries()) {
-				if (yy === 0 && exits.top.includes(xx)) {
-					cell.forceOpen = true;
-					grid[yy + 1]![xx]!.forceOpen = true;
-					continue;
-				}
-				if (yy === 49 && exits.bottom.includes(xx)) {
-					cell.forceOpen = true;
-					grid[yy - 1]![xx]!.forceOpen = true;
-					continue;
-				}
-				if (xx === 0 && exits.left.includes(yy)) {
-					cell.forceOpen = true;
-					row[xx + 1]!.forceOpen = true;
-					continue;
-				}
-				if (xx === 49 && exits.right.includes(yy)) {
-					cell.forceOpen = true;
-					row[xx - 1]!.forceOpen = true;
+				if (cell.forceOpen && isBorder(xx, yy)) {
 					continue;
 				}
 				cell.wall = Math.random() < wallTypes[activeWallType]!.fill;
@@ -291,6 +297,243 @@ function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): 
 		}
 	}
 	return grid;
+}
+
+// Deterministic hash of an integer lattice point to a value in [0, 1).
+function latticeValue(ix: number, iy: number): number {
+	return (hashCombine(hashMix(ix), iy) >>> 0) / 0x100000000;
+}
+
+// Smoothstep-interpolated value noise sampled at world coordinates over a lattice of `cell` tiles.
+// Sampling in world (not per-room) space is what makes wall masses continuous across room borders.
+function valueNoise(wx: number, wy: number, cell: number): number {
+	const gx = wx / cell;
+	const gy = wy / cell;
+	const ix = Math.floor(gx);
+	const iy = Math.floor(gy);
+	const tx = gx - ix;
+	const ty = gy - iy;
+	const sx = tx * tx * (3 - 2 * tx);
+	const sy = ty * ty * (3 - 2 * ty);
+	const top = latticeValue(ix, iy) + (latticeValue(ix + 1, iy) - latticeValue(ix, iy)) * sx;
+	const bottom = latticeValue(ix, iy + 1) + (latticeValue(ix + 1, iy + 1) - latticeValue(ix, iy + 1)) * sx;
+	return top + (bottom - top) * sy;
+}
+
+// Two octaves of world-coordinate value noise drive a border's mass depth: a coarse field sets the
+// depth, a fine field breaks the masses into the detached pieces the live corpus carries (dropping
+// it slabs them together).
+const kHighwayMassCell = 22;
+const kHighwayMassWeight = 0.7;
+const kHighwayDetailCell = 6;
+function edgeNoise(wx: number, wy: number): number {
+	return valueNoise(wx, wy, kHighwayMassCell) * kHighwayMassWeight +
+		valueNoise(wx + 1000, wy + 1000, kHighwayDetailCell) * (1 - kHighwayMassWeight);
+}
+
+// Orthogonal neighbor offsets. The reconnect search runs 4-connected so a carved slot is a
+// contiguous walkable channel, not a diagonal chain.
+const kOrthogonal = [ [ 0, -1 ], [ 0, 1 ], [ -1, 0 ], [ 1, 0 ] ] as const;
+
+// Open tiles reachable from (xx, yy), as a set of packed `yy * 50 + xx` keys.
+function reachableOpen(grid: Grid, xx: number, yy: number): Set<number> {
+	const reached = new Set([ yy * 50 + xx ]);
+	const stack = [ [ xx, yy ] as const ];
+	while (stack.length > 0) {
+		const [ cxx, cyy ] = stack.pop()!;
+		for (const [ dxx, dyy ] of kOrthogonal) {
+			const nxx = cxx + dxx;
+			const nyy = cyy + dyy;
+			const key = nyy * 50 + nxx;
+			if (nxx >= 0 && nyy >= 0 && nxx <= 49 && nyy <= 49 && !grid[nyy]![nxx]!.wall && !reached.has(key)) {
+				reached.add(key);
+				stack.push([ nxx, nyy ]);
+			}
+		}
+	}
+	return reached;
+}
+
+// Breaches the thinnest seal between a cut-off exit throat and the open network: a wall-piercing
+// BFS to the nearest open tile, clearing only its shortest path so the throat opens with a slot,
+// not a bored channel. Carved tiles join `reached` for the next throat.
+function carveToOpen(grid: Grid, sx: number, sy: number, reached: Set<number>): void {
+	const start = sy * 50 + sx;
+	const prev = new Map([ [ start, -1 ] ]);
+	// The queue grows as the search fans out; the array iterator keeps yielding the pushed tiles.
+	const queue: (readonly [ number, number ])[] = [ [ sx, sy ] ];
+	for (const [ cxx, cyy ] of queue) {
+		const key = cyy * 50 + cxx;
+		if (key !== start && reached.has(key)) {
+			for (let step = key; step !== -1; step = prev.get(step) ?? -1) {
+				const pxx = step % 50;
+				const pyy = (step - pxx) / 50;
+				if (!isBorder(pxx, pyy)) {
+					grid[pyy]![pxx]!.wall = false;
+				}
+				reached.add(step);
+			}
+			return;
+		}
+		for (const [ dxx, dyy ] of kOrthogonal) {
+			const nxx = cxx + dxx;
+			const nyy = cyy + dyy;
+			if (nxx >= 0 && nyy >= 0 && nxx <= 49 && nyy <= 49) {
+				const nkey = nyy * 50 + nxx;
+				if (!prev.has(nkey)) {
+					prev.set(nkey, key);
+					queue.push([ nxx, nyy ]);
+				}
+			}
+		}
+	}
+}
+
+// Connects every exit throat to the open lane, breaching only the thin seal where a wall mass or
+// lane blob has cut a throat off -- leaving the open lane (and the blobs studding it) otherwise
+// undisturbed.
+function connectExits(grid: Grid, exits: ExitMap): void {
+	const throats = [
+		...exits.top.map(xx => [ xx, 1 ] as const),
+		...exits.bottom.map(xx => [ xx, 48 ] as const),
+		...exits.left.map(yy => [ 1, yy ] as const),
+		...exits.right.map(yy => [ 48, yy ] as const),
+	];
+	if (throats.length <= 1) {
+		return;
+	}
+	const [ ax, ay ] = throats[0]!;
+	const reached = reachableOpen(grid, ax, ay);
+	for (const [ bx, by ] of throats.slice(1)) {
+		if (!reached.has(by * 50 + bx)) {
+			carveToOpen(grid, bx, by, reached);
+		}
+	}
+}
+
+// Fills and smooths swamp the way buildBaseTerrain does, so highway lanes carry the same organic
+// swamp patches normal rooms do (about half of the live highway rooms have some). swampType 0
+// means none. smoothTerrain copies every cell, so walls and exits are preserved.
+function applySwamp(grid: Grid, swampType: number): Grid {
+	if (!swampType) {
+		return grid;
+	}
+	const params = swampTypes[swampType]!;
+	for (const row of grid.values()) {
+		for (const cell of row.values()) {
+			if (!cell.forceOpen) {
+				cell.swamp = Math.random() < params.fill;
+			}
+		}
+	}
+	let smoothed = grid;
+	for (let ii = 0; ii < params.smooth; ++ii) {
+		smoothed = smoothTerrain(smoothed, params.factor, 'swamp');
+	}
+	return smoothed;
+}
+
+// About half of the live highway rooms carry swamp; the rest are clear. A highway lane is wide
+// open, so a normal-room swamp type would carpet it -- only a mild type (low fill, smoothed back
+// to a patch) lands a vanilla-sized patch. Roll no swamp half the time, else the mild type.
+const kHighwaySwampType = 1;
+function rollHighwaySwamp(): number {
+	return Math.random() < 0.5 ? 0 : kHighwaySwampType;
+}
+
+// Per-border wall-mass shape; lane masses (vertical/horizontal) run deep, crossing-corner masses
+// shallow. Each {base, amp, expo} drives edgeDepth's heavy-tailed wedge, fit to the live corpus.
+interface HighwayMass {
+	base: number;
+	amp: number;
+	expo: number;
+}
+const kHighwayLaneMass: HighwayMass = { base: 0.5, amp: 26, expo: 2.9 };
+const kHighwayCornerMass: HighwayMass = { base: 0.2, amp: 8, expo: 2.5 };
+// A coarse value-noise field thresholded into solid wall blobs that stud the open lane.
+const kHighwayBlobCell = 6;
+const kHighwayBlobThreshold = 0.82;
+
+// Tiles the wall mass intrudes from the border at world position (wx, wy): a heavy-tailed wedge
+// (low base, high exponent), mostly shallow with a rare deep plunge. edgeNoise in [0, 1) bounds it
+// to base + amp.
+function edgeDepth(wx: number, wy: number, mass: HighwayMass): number {
+	return mass.base + mass.amp * edgeNoise(wx, wy) ** mass.expo;
+}
+
+// A [0, 1] multiplier on a border tile's mass depth that recedes the mass near an exit -- 0 over
+// the exit rising to 1 at the radius -- so a throat opens as a natural mouth, not the bored tunnel
+// a reconnect cuts. Concave (sqrt) easing keeps the mass tight to the exit; 2D distance so a mass
+// also parts for a perpendicular lane-side exit.
+const kHighwayExitClearRadius = 3;
+function exitClearance(bx: number, by: number, exitPoints: readonly (readonly [ number, number ])[]): number {
+	const nearest = Math.min(...exitPoints.map(([ ex, ey ]) => Math.max(Math.abs(bx - ex), Math.abs(by - ey))));
+	if (nearest >= kHighwayExitClearRadius) {
+		return 1;
+	}
+	return Math.sqrt(nearest / kHighwayExitClearRadius);
+}
+
+// Highway-room terrain: an open travel lane flanked by the surrounding sector blocks intruding
+// from the sector-facing borders -- left+right for a vertical lane, top+bottom for a horizontal
+// one, all four corners for a crossing. Wall masses (noise-driven wedge depth) + lane blobs + exit
+// recede + a slot-carve reconnect, then swamp. Every piece is tuned to the live highway corpus.
+function genHighwayTerrain(
+	exits: ExitMap,
+	rx: number,
+	ry: number,
+	orientation: HighwayOrientation,
+	swampType: number,
+): Grid {
+	const grid = makeGrid();
+	markExits(grid, exits);
+	// Room origin in world tiles. Each border samples the noise field at its own tiles' world
+	// positions, so the four masses decorrelate and every mass flows continuously across the shared
+	// sector edge.
+	const wox = rx * 50;
+	const woy = ry * 50;
+	const mass = orientation === 'crossing' ? kHighwayCornerMass : kHighwayLaneMass;
+	// Crossing corners sit off the crossed lanes, so they seal nothing and want no clearance (the
+	// exit set stays empty); lane masses span the exits, so they recede for them.
+	const exitPoints = orientation === 'crossing' ? [] : [
+		...exits.top.map(xx => [ xx, 0 ] as const),
+		...exits.bottom.map(xx => [ xx, 49 ] as const),
+		...exits.left.map(yy => [ 0, yy ] as const),
+		...exits.right.map(yy => [ 49, yy ] as const),
+	];
+	// Depth (in tiles) the mass intrudes along one border, indexed by the tile `at(ii)`: the noise
+	// wedge sampled at that tile's world position, receding toward any nearby exit. A border the
+	// lane runs along carries no mass and stays zeroed, so its term never walls a lane tile.
+	const depthAlongBorder = (active: boolean, at: (ii: number) => readonly [ number, number ]) => {
+		if (!active) {
+			return new Array<number>(50).fill(0);
+		}
+		return Fn.pipe(
+			Fn.range(50),
+			$$ => Fn.map($$, ii => {
+				const [ bx, by ] = at(ii);
+				return edgeDepth(wox + bx, woy + by, mass) * exitClearance(bx, by, exitPoints);
+			}),
+			$$ => [ ...$$ ]);
+	};
+	const leftDepth = depthAlongBorder(orientation !== 'horizontal', ii => [ 0, ii ]);
+	const rightDepth = depthAlongBorder(orientation !== 'horizontal', ii => [ 49, ii ]);
+	const topDepth = depthAlongBorder(orientation !== 'vertical', ii => [ ii, 0 ]);
+	const bottomDepth = depthAlongBorder(orientation !== 'vertical', ii => [ ii, 49 ]);
+	for (const [ yy, row ] of grid.entries()) {
+		for (const [ xx, cell ] of row.entries()) {
+			if (cell.forceOpen) {
+				continue;
+			}
+			// Frame every non-exit border tile as wall, the way smoothTerrain does for normal rooms.
+			cell.wall = isBorder(xx, yy) ||
+				xx <= leftDepth[yy]! || 49 - xx <= rightDepth[yy]! ||
+				yy <= topDepth[xx]! || 49 - yy <= bottomDepth[xx]! ||
+				valueNoise(wox + xx, woy + yy, kHighwayBlobCell) > kHighwayBlobThreshold;
+		}
+	}
+	connectExits(grid, exits);
+	return applySwamp(grid, swampType);
 }
 
 const kNoTags: ReadonlySet<string> = new Set();
@@ -329,10 +572,20 @@ const kMaxGenerateAttempts = 50;
 // forever) after a bounded number of attempts.
 function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions) {
 	const generators = [ ...hooks.map('roomGenerator') ].sort(mappedNumericComparator(generator => generator.order));
-	const swampType = options.swampType ?? Math.floor(Math.random() * 14);
-	for (let attempt = 0; attempt < kMaxGenerateAttempts; ++attempt) {
-		const wallType = attempt === 0 ? options.terrainType ?? randomWallType() : randomWallType();
-		const terrain = gridToTerrain(buildBaseTerrain(exits, wallType, swampType));
+	const { rx, ry } = parseRoomName(roomName);
+	const swampType = options.swampType ??
+		(options.highway ? rollHighwaySwamp() : Math.floor(Math.random() * 14));
+	// Highway terrain is a deterministic function of world position, so a retry would rebuild it
+	// identically -- one failed attempt settles the outcome.
+	const maxAttempts = options.highway ? 1 : kMaxGenerateAttempts;
+	for (let attempt = 0; attempt < maxAttempts; ++attempt) {
+		const terrain = gridToTerrain(function() {
+			if (options.highway) {
+				return genHighwayTerrain(exits, rx, ry, options.highway, swampType);
+			}
+			const wallType = attempt === 0 ? options.terrainType ?? randomWallType() : randomWallType();
+			return buildBaseTerrain(exits, wallType, swampType);
+		}());
 		const room = new Room();
 		room.name = roomName;
 		const context = makeGeneratorContext(room, terrain, options);
@@ -340,7 +593,7 @@ function genRoom(roomName: string, exits: ExitMap, options: GenerateRoomOptions)
 			return { room, terrain };
 		}
 	}
-	throw new Error(`Failed to generate room terrain after ${kMaxGenerateAttempts} attempts`);
+	throw new Error(`Failed to generate room terrain after ${maxAttempts} attempt(s)`);
 }
 
 function gridToTerrain(grid: Grid): TerrainWriter {

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -5,7 +5,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
-import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
+import { RoomPosition, iterateArea, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { Room } from 'xxscreeps/game/room/index.js';
 import { makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
@@ -538,6 +538,12 @@ function genHighwayTerrain(
 
 const kNoTags: ReadonlySet<string> = new Set();
 
+// Spread placements keep at least this Chebyshev distance from every anchor; the jitter widens the
+// eligible band below the farthest candidate so results vary naturally instead of always taking
+// the extreme corner.
+const kMinSpreadSpacing = 14;
+const kSpreadJitter = 0.7;
+
 function makeGeneratorContext(room: Room, terrain: Terrain, options: GenerateRoomOptions): RoomGeneratorContext {
 	const tags = new Map<number, Set<string>>();
 	const tagsAt = (position: RoomPosition): ReadonlySet<string> => tags.get(position['#id']) ?? kNoTags;
@@ -550,6 +556,22 @@ function makeGeneratorContext(room: Room, terrain: Terrain, options: GenerateRoo
 			shuffledSquare(min, span),
 			$$ => Fn.map($$, ([ xx, yy ]) => new RoomPosition(xx, yy, room.name)),
 			$$ => Fn.find($$, accept)),
+		findSpreadPosition(min, span, accept, anchors) {
+			const candidates = [ ...Fn.pipe(
+				iterateArea(room.name, min, min, min + span - 1, min + span - 1),
+				$$ => Fn.filter($$, accept),
+				$$ => Fn.map($$, position => ({
+					position,
+					nearest: Math.min(...anchors.map(anchor => position.getRangeTo(anchor))),
+				}))) ];
+			const best = Math.max(...candidates.map(candidate => candidate.nearest), 0);
+			if (best < kMinSpreadSpacing) {
+				return undefined;
+			}
+			const threshold = Math.max(kMinSpreadSpacing, best * kSpreadJitter);
+			const eligible = candidates.filter(candidate => candidate.nearest >= threshold);
+			return eligible[Math.floor(Math.random() * eligible.length)]!.position;
+		},
 		isPlaceable: position => isWall(position) && tagsAt(position).size === 0 &&
 			Fn.some(iterateNeighbors(position), neighbor => !isWall(neighbor)),
 		place(object, ...objectTags) {

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,6 +1,6 @@
 import type { ExitMap, GenerateRoomOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
-import type { RoomType } from 'xxscreeps/mods/modern/sector/sector.js';
+import type { RoomType } from 'xxscreeps/mods/modern/sector/terrain.js';
 import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
@@ -11,7 +11,7 @@ import { Room } from 'xxscreeps/game/room/index.js';
 import { kMaxWorldSize, makeRoomName, makeSignedRoomName, parseRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
-import { computeRoomMeta, highwayOrientation, roomType } from 'xxscreeps/mods/modern/sector/sector.js';
+import { computeRoomMeta, highwayOrientation, roomType } from 'xxscreeps/mods/modern/sector/terrain.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
 import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import { hashCombine, hashMix } from 'xxscreeps/utility/utility.js';

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -7,8 +7,17 @@ import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 type ExitSide = 'top' | 'right' | 'bottom' | 'left';
 export type ExitMap = Record<ExitSide, number[]>;
 
+export type HighwayOrientation = 'vertical' | 'horizontal' | 'crossing';
+
 export interface GenerateRoomOptions {
 	exits?: Partial<ExitMap>;
+	/**
+	 * Generates highway terrain -- an open travel lane flanked by wall masses on the sector-facing
+	 * borders -- instead of cellular-automaton terrain. The orientation names the lane axis:
+	 * `vertical` masses the left+right borders, `horizontal` the top+bottom, and `crossing` only
+	 * the four corners.
+	 */
+	highway?: HighwayOrientation;
 	/** Wall layout 1-28; omit for a random layout. */
 	terrainType?: number;
 	/** Swamp layout 1-14, or 0 for no swamp; omit for a random layout. */

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -36,6 +36,16 @@ export interface RoomGeneratorContext {
 	 */
 	findRandomPosition: (min: number, span: number, accept: (position: RoomPosition) => boolean) =>
 		RoomPosition | undefined;
+	/**
+	 * A position within [min, min + span) on both axes satisfying `accept` that stays far
+	 * (Chebyshev) from every anchor -- chosen with jitter for natural variance, and undefined when
+	 * no candidate keeps the minimum spacing.
+	 */
+	findSpreadPosition: (
+		min: number, span: number,
+		accept: (position: RoomPosition) => boolean,
+		anchors: readonly RoomPosition[],
+	) => RoomPosition | undefined;
 	/** Whether `position` is an untagged wall tile with at least one passable neighbor. */
 	isPlaceable: (position: RoomPosition) => boolean;
 	/** Inserts `object` into the room and tags its position. */

--- a/packages/xxscreeps/xxscreeps.js
+++ b/packages/xxscreeps/xxscreeps.js
@@ -8,6 +8,7 @@ const specifier = process.argv[1];
 // Launch entry command
 const commands = {
 	'generate-room': './dist/scripts/generate-room.js',
+	'generate-sector': './dist/scripts/generate-sector.js',
 	backend: './dist/backend/server.js',
 	cli: './dist/cli/cli.js',
 	eval: './dist/cli/eval.js',


### PR DESCRIPTION
Follow-up to #334 — the sector slice of the room-gen arc.

I'm still not 100% happy with the way highways rooms are being formed, they don't quite match vanilla with funny little "tunnels" being formed, but that can be improved upon separately I think.

Five commits:

- **`room-gen: add highway terrain generation`** — wedge + blob + clearance masses gated by distance from the sector-facing borders, over a world-coordinate noise field; the corridor is selected via `highway: 'vertical' | 'horizontal' | 'crossing'` in `GenerateRoomOptions`.
- **`source: spread the sources of three-source rooms`** — adds `findSpreadPosition` to the generator context (farthest-point placement with corpus-derived spacing) and uses it for every source after the first when a room has 3+.
- **`sector: classify rooms by their template role`** — `roomType` / `highwayOrientation` exported from the sector mod, derived from room coordinates.
- **`room-gen: generate full sectors under the mod-10 template`** — `generateSector` assembles the inclusive 11×11 block (shared highway rings are idempotent across adjacent sectors); border sealing is expressed as explicit empty `exits` lists so `room-gen.ts` itself stays sector-free; `generate-sector` CLI shares `parseRoomOptions` with `generate-room`.
- **`mineral: spread the mineral of three-source rooms`** — real keeper/center rooms spread the mineral like a fourth source (measured over 120 shard3 rooms: nearest source 15–37, median 25), so their four keeper lairs land apart; the mineral hook reuses `findSpreadPosition` against the placed sources.

Two deliberate choices worth flagging:

- The highway noise field is **unseeded world-coordinate noise**: re-entering a partially generated region reproduces continuous terrain across room borders instead of seaming.
- `latticeValue` now composes the existing `hashCombine(hashMix(ix), iy)` instead of the old branch's bespoke mixer — distribution re-validated against the same density targets.

## Validation

- `tsc -b` and eslint clean; full suite 520/520.
- Offline smoke on an isolated local shard: single 121-room sector — room types 72/40/8/1 (normal/highway/keeper/center), object loadouts exact per type, 0 border exit mismatches, 0 exit-disconnected rooms, border seals averaged 1.25 of 4 sides, center room's `sectorControl` stamped edges=40 / members=81.
- Adjacent-sector re-entry: 110 new rooms, shared highway ring idempotent and gains both sectors' membership.
- 5-sector aggregate highway wall density: vertical 18.2% / horizontal 16.9% / crossing 14.9% (shard3 corpus ≈ 21 / 20 / 14 — slightly under, same family).
- Mineral spread: 90 generated three-source rooms measured mineral-to-nearest-source min 14 / median 20 and min lair-pair 10 / median 18, vs the 107-room shard3 keeper sample's 15 / 25 and 11 / 22 — floors match, medians slightly under, same family.
- `generate-sector` CLI end-to-end, including usage, invalid origin, and re-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
