### PR TITLE
powercreep: read roster powers off the schema vector, not the game getter

### DIFF
--- a/.changeset/powercreep-roster-powers.md
+++ b/.changeset/powercreep-roster-powers.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix the power creep roster listing throwing for creeps with a learned power.

--- a/packages/xxscreeps/mods/mmo/powercreep/backend.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/backend.ts
@@ -120,7 +120,10 @@ function renderRecord(creep: PowerCreep) {
 		store: {},
 		storeCapacity: 100 * (level + 1),
 		spawnCooldownTime: creep.spawnCooldownTime,
-		powers: creep.powers,
+		// The roster has no tick clock, so cooldowns are always clear here. `creep.powers` would
+		// resolve them against `Game.time`, which the backend has not set up.
+		powers: Object.fromEntries(creep['#powers'].map(({ level, power }) =>
+			[ power, { cooldown: 0, level } ] as const)),
 		...creep.deleteTime !== 0 && { deleteTime: creep.deleteTime },
 	};
 }

--- a/packages/xxscreeps/mods/mmo/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/powercreep.ts
@@ -69,8 +69,8 @@ export class PowerCreep extends withOverlay(RoomObject, powerCreepShape) {
 	 * @see https://docs.screeps.com/api/#PowerCreep.powers
 	 */
 	get powers(): Record<number, PowerType> {
-		// Roster copies are read outside a game context; their cooldowns are always `0`, which
-		// short-circuits before the `Game.time` read.
+		// `cooldown` counts down from the current tick, so this only resolves inside a game context.
+		// Roster copies are read from the backend; those callers take `#powers` directly.
 		return Object.fromEntries(Fn.map(this['#powers'], ({ cooldownTime: time, level, power }) => [ power, { cooldown: cooldownTime(time), level } ]));
 	}
 


### PR DESCRIPTION
`renderRecord` builds the roster listing from schema state — `hits`, `storeCapacity`, `store` are all computed there — except `powers`, which went through the `PowerCreep.powers` getter. That getter resolves cooldowns against `Game.time`, and the backend has no game context, so since #335 the route throws `TypeError: Cannot read properties of undefined (reading 'time')` for any roster creep with a learned power. The sneaky ternary you flagged was papering over exactly this — it was a no-op inside a game context and existed only to dodge the `Game` read, so the fix belongs at the account-scope reader rather than back in the getter.

The roster is account-scoped and has no tick clock at all — that's why `spawnCooldownTime` and `deleteTime` are wall-clock — so `#powers[].cooldownTime` is never written back there and the cooldown is reported clear, restoring the pre-merge wire shape.

Repro on main: create a power creep, allocate one power point, then open the Power tab (`#!/overview/power`) — the list request 500s.

No test — driving the registered route from the harness needs either a fake koa context or a test-only export of `renderRecord`. Happy to add a small backend-route affordance to `test/index.js` if you'd want the coverage.

## Validation

- Probed the registered `/api/game/power-creeps/list` handler directly against a roster holding one learned power: returns `{"ok":1,…"powers":{"1":{"cooldown":0,"level":1}}}`, matching the wire shape from before the merge tweak. The same probe throws on `main`.
- 534/534 tests, zero new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
