### PR TITLE
storage: add `zRank` and honor `rev` in local range reads

### DIFF
--- a/.changeset/keyval-zrank.md
+++ b/.changeset/keyval-zrank.md
@@ -1,0 +1,6 @@
+---
+"xxscreeps": minor
+"@xxscreeps/redis": minor
+---
+
+Add `zRank` to the keyval providers and honor `rev` in local range reads.

--- a/packages/redis/keyval.ts
+++ b/packages/redis/keyval.ts
@@ -386,6 +386,10 @@ export class RedisProvider extends AsyncDisposableResource implements Pr.KeyValP
 		return result.map(({ score, value }) => [ score, value ]);
 	}
 
+	zRank(key: string, member: string, options?: Pr.ZRank) {
+		return options?.rev ? this.keyval.zRevRank(key, member) : this.keyval.zRank(key, member);
+	}
+
 	zRem(key: string, members: string[]) {
 		return this.keyval.zRem(key, members);
 	}

--- a/packages/xxscreeps/engine/db/storage/local/keyval.ts
+++ b/packages/xxscreeps/engine/db/storage/local/keyval.ts
@@ -47,6 +47,19 @@ interface SerializedUint8 {
 	readonly $: string;
 }
 
+/**
+ * `entries` and `entriesByLex` take their direction from the order of their bounds, which is also how
+ * redis reads a score or lex range: `ZRANGE … REV` wants the high bound first. A pair which disagrees
+ * with `rev` answers the whole range here and nothing on redis, so it's rejected rather than
+ * silently divergent.
+ */
+function checkRangeDirection<Type extends number | string>(min: Type, max: Type, options?: Pr.ZRange) {
+	const rev = options?.rev === true;
+	if (rev ? min < max : min > max) {
+		throw new Error(`Invalid range: bounds of a${rev ? ' reversed' : 'n ascending'} range must be given ${rev ? 'high' : 'low'}-first`);
+	}
+}
+
 export class LocalKeyValResponder extends AsyncDisposableResource implements MaybePromises<Pr.KeyValProvider> {
 	readonly blob;
 	private readonly data = new Map<string, InternalValue>();
@@ -629,13 +642,14 @@ export class LocalKeyValResponder extends AsyncDisposableResource implements May
 						};
 						const [ minVal, minInc ] = parse(min satisfies number | string as string);
 						const [ maxVal, maxInc ] = parse(max satisfies number | string as string);
+						checkRangeDirection(minVal, maxVal, options);
 						return set.entriesByLex(minInc, minVal, maxInc, maxVal);
 					}
 					case 'SCORE': {
-						const entries = set.entries(
-							min satisfies number | string as number,
-							max satisfies number | string as number);
-						return Fn.map(entries, entry => entry[1]);
+						const minScore = min satisfies number | string as number;
+						const maxScore = max satisfies number | string as number;
+						checkRangeDirection(minScore, maxScore, options);
+						return Fn.map(set.entries(minScore, maxScore), entry => entry[1]);
 					}
 					case undefined:
 					default: {
@@ -648,6 +662,13 @@ export class LocalKeyValResponder extends AsyncDisposableResource implements May
 						};
 						const from = convert(min satisfies number | string as number);
 						const to = convert(max satisfies number | string as number) + 1;
+						if (options?.rev) {
+							// Index ranges count from the low-score end, or from the high-score end under
+							// `rev`. The score and lex ranges above read their direction from the order of
+							// their bounds, but an index range carries no such signal, so mirror the window
+							// onto the ascending members rather than reversing the whole set.
+							return Fn.reverse([ ...Fn.slice(set.values(), Math.max(0, set.size - to), set.size - from) ]);
+						}
 						return Fn.slice(set.values(), from, to);
 					}
 				}
@@ -696,7 +717,9 @@ export class LocalKeyValResponder extends AsyncDisposableResource implements May
 		if (set) {
 			switch (options?.by) {
 				case 'LEX': throw new Error('Invalid request');
-				case 'SCORE': return [ ...set.entries(min, max) ];
+				case 'SCORE':
+					checkRangeDirection(min, max, options);
+					return [ ...set.entries(min, max) ];
 				case undefined:
 				default: {
 					const values = this.zRange(key, min, max, options);
@@ -706,6 +729,17 @@ export class LocalKeyValResponder extends AsyncDisposableResource implements May
 		} else {
 			return [];
 		}
+	}
+
+	zRank(key: string, member: string, options?: Pr.ZRank) {
+		const set = this.lookupObject(key, SortedSet);
+		if (set) {
+			const rank = set.rank(member);
+			if (rank !== undefined) {
+				return options?.rev ? set.size - 1 - rank : rank;
+			}
+		}
+		return null;
 	}
 
 	zRem(key: string, members: string[]) {

--- a/packages/xxscreeps/engine/db/storage/local/sorted-set.ts
+++ b/packages/xxscreeps/engine/db/storage/local/sorted-set.ts
@@ -93,6 +93,12 @@ export class SortedSet {
 		return count;
 	}
 
+	rank(member: string) {
+		if (this.#scores.has(member)) {
+			return this.#members.indexOf(member);
+		}
+	}
+
 	score(member: string) {
 		return this.#scores.get(member);
 	}

--- a/packages/xxscreeps/engine/db/storage/local/test.ts
+++ b/packages/xxscreeps/engine/db/storage/local/test.ts
@@ -14,6 +14,34 @@ describe('engine/db/storage/local', () => {
 		assert.strictEqual(await scratch.zScore('out', 'only-b'), 21);
 	});
 
+	test('index ranges and ranks count from the high-score end under REV', async () => {
+		await using testShard = await instantiateTestShard();
+		const { scratch } = testShard.shard;
+		await scratch.zAdd('ranked', [ [ 1, 'low' ], [ 3, 'high' ], [ 2, 'mid' ] ]);
+		assert.deepStrictEqual(await scratch.zRange('ranked', 0, 1), [ 'low', 'mid' ]);
+		assert.deepStrictEqual(await scratch.zRange('ranked', 0, 1, { rev: true }), [ 'high', 'mid' ]);
+		assert.deepStrictEqual(
+			await scratch.zRangeWithScores('ranked', 1, 2, { rev: true }),
+			[ [ 2, 'mid' ], [ 1, 'low' ] ]);
+		assert.strictEqual(await scratch.zRank('ranked', 'high'), 2);
+		assert.strictEqual(await scratch.zRank('ranked', 'high', { rev: true }), 0);
+		assert.strictEqual(await scratch.zRank('ranked', 'absent'), null);
+		assert.strictEqual(await scratch.zRank('missing-key', 'high'), null);
+	});
+
+	test('a score range whose bounds contradict REV is rejected', async () => {
+		await using testShard = await instantiateTestShard();
+		const { scratch } = testShard.shard;
+		await scratch.zAdd('ranked', [ [ 1, 'low' ], [ 3, 'high' ] ]);
+		// Redis answers these with an empty range, so accepting them here would hide the divergence
+		await assert.rejects(async () => scratch.zRange('ranked', 0, Infinity, { by: 'SCORE', rev: true }));
+		await assert.rejects(async () => scratch.zRangeWithScores('ranked', 0, Infinity, { by: 'SCORE', rev: true }));
+		await assert.rejects(async () => scratch.zRange('ranked', Infinity, 0, { by: 'SCORE' }));
+		// Bounds given the way redis wants them, and a degenerate range, are fine either way
+		assert.deepStrictEqual(await scratch.zRange('ranked', Infinity, 0, { by: 'SCORE', rev: true }), [ 'high', 'low' ]);
+		assert.deepStrictEqual(await scratch.zRange('ranked', 3, 3, { by: 'SCORE', rev: true }), [ 'high' ]);
+	});
+
 	test('blob set honors compare-and-swap conditions', async () => {
 		await using testShard = await instantiateTestShard();
 		const { data } = testShard.shard;

--- a/packages/xxscreeps/engine/db/storage/provider.ts
+++ b/packages/xxscreeps/engine/db/storage/provider.ts
@@ -56,6 +56,9 @@ export interface ZRange {
 	limit?: [ number, number ];
 	rev?: boolean;
 }
+export interface ZRank {
+	rev?: boolean;
+}
 
 export type Value = number | string | Readonly<Uint8Array>;
 export interface KeyValProvider {
@@ -124,6 +127,9 @@ export interface KeyValProvider {
 	zRange(key: string, min: number, max: number, options?: ZRange): Promise<string[]>;
 	zRangeStore(into: string, from: string, min: number, max: number, options?: ZRange): Promise<number>;
 	zRangeWithScores(key: string, min: number, max: number, options?: ZRange): Promise<[ number, string ][]>;
+	// Index of `member` within the set, or `null` when it isn't a member. Ordered by score, ties
+	// broken lexicographically; `rev` counts from the high-score end.
+	zRank(key: string, member: string, options?: ZRank): Promise<number | null>;
 	zRem(key: string, members: string[]): Promise<number>;
 	zRemRange(key: string, min: number, max: number): Promise<number>;
 	zScore(key: string, member: string): Promise<number | null>;


### PR DESCRIPTION
`zRank` was the one sorted-set read the providers didn't expose, and it's needed to answer "where do I place?" without pulling the whole set into memory.

Adding it surfaced an asymmetry in the local provider: `entries` and `entriesByLex` pick their direction from the order of their bounds, which is how redis reads a `BYSCORE`/`BYLEX` range too, but an index range carries no such signal — `zRange(key, 0, 9, { rev: true })` counted from the low-score end locally and the high-score end on redis. Index ranges now mirror the window onto the ascending members. The score and lex branches keep taking their direction from the bounds, but a pair that contradicts `rev` now throws instead of quietly answering the whole range where redis would answer nothing.

## Validation

`tsc -b` and `eslint --max-warnings 0` clean; 530/530 tests pass. New cases in `engine/db/storage/local/test.ts` cover forward and reversed index ranges, `zRank` in both directions plus its `null` results, and the rejected bound/`rev` combinations.
