### PR TITLE
sector: drop the duplicated `iterateSectors`

### DIFF
--- a/packages/xxscreeps/mods/modern/sector/terrain.ts
+++ b/packages/xxscreeps/mods/modern/sector/terrain.ts
@@ -1,5 +1,3 @@
-import type { SectorControl } from './schema.js';
-import type { World } from 'xxscreeps/game/map.js';
 import type { HighwayOrientation } from 'xxscreeps/scripts/symbols.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { makeAbstractIterateWithRangeTo, makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
@@ -7,16 +5,6 @@ import { makeSignedRoomName, parseSignedRoomName } from 'xxscreeps/game/room/nam
 
 const iterateRoomRing = makeAbstractIterateWithRangeTo(-Infinity, Infinity);
 const iterateRoomArea = makeLocalIterateInRangeTo(-Infinity, Infinity);
-
-// Iterates the sector-control records stamped on the world's center rooms.
-export function *iterateSectors(world: World): IterableIterator<[ center: string, sector: SectorControl ]> {
-	for (const [ roomName, entry ] of world.terrain) {
-		const { sectorControl } = entry;
-		if (sectorControl) {
-			yield [ roomName, sectorControl ];
-		}
-	}
-}
 
 // Sector centers are the rooms numbered `{..}5` on each axis; the highway ring sits on the `{..}0`
 // boundary rooms +-5 away. Keyed off the sign of the signed coordinate (W/N use the negative

--- a/packages/xxscreeps/mods/modern/sector/test.ts
+++ b/packages/xxscreeps/mods/modern/sector/test.ts
@@ -3,8 +3,8 @@ import * as assert from 'node:assert';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { testWorld } from 'xxscreeps/test/import.js';
 import { describe, test } from 'xxscreeps/test/index.js';
-import { makeSectorRadiusPredicate } from './sector.js';
-import { computeRoomMeta, iterateSectors } from './terrain.js';
+import { iterateSectors, makeSectorRadiusPredicate } from './sector.js';
+import { computeRoomMeta } from './terrain.js';
 
 // Every room in the W/N quadrant corner of the given size — e.g. 21 spans W0..W20 x N0..N20.
 function roomQuadrant(size: number): ReadonlySet<string> {


### PR DESCRIPTION
The `sector/terrain.ts` split in #336 copied `iterateSectors` instead of moving it, so it's defined identically in both `sector.ts` and `terrain.ts`. `22ba85fd` then pointed `sector/test.ts` at the `terrain.ts` copy, leaving both definitions with live callers.

Dropped the `terrain.ts` copy and moved the test's import back. `iterateSectors` reads persisted `sectorControl` at runtime for `deposit/main.ts` and `powerbank/main.ts`, which both already resolve to `sector.ts`.

No changeset — internal, no behavior change.

## Validation

- `tsc -b` and eslint clean; full suite 536/536.
- Package-wide `iterateSectors` grep: one definition, four call sites, all resolving to `sector.ts`.
- Verified the two copies were byte-for-byte identical before removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
