### PR TITLE
docs: document the terrain encoding and the generate-room command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ server before running it so cached world state in the backend, processor, and
 runner workers doesn't go stale. Exits are read from any already-generated
 neighbor, so adjacent generated rooms connect.
 
+Also available as `npx xxscreeps generate-room W12N5`, which takes the room
+shape as flags — `--shard`, `--terrain-type 1-28`, `--swamp-type 0-14`,
+`--sources 1-4`, `--mineral H|O|Z|K|U|L|X` — and prints its usage line when
+run without a room name. `controller` and `keeperLairs` have no flags, so
+source-keeper and center rooms are script-only.
+
 `generateSector` builds the full 11×11 room block from an origin corner (a
 room at printed multiples of 10 on both axes) under the vanilla mod-10 sector
 template: highway rooms on the boundary rings, the central room and its 3×3
@@ -193,7 +199,8 @@ and some borders between normal and highway rooms seal at random, like the
 live world's. Rooms that already exist are skipped, so adjacent sectors share
 their boundary rings and a partially built sector can be re-entered. The same
 options apply to the sector's normal rooms. Also available as
-`npx xxscreeps generate-sector W20N20`.
+`npx xxscreeps generate-sector W20N20`, taking the same flags as
+`generate-room`.
 
 ## Docker
 

--- a/packages/xxscreeps/game/terrain.ts
+++ b/packages/xxscreeps/game/terrain.ts
@@ -19,6 +19,8 @@ export const terrainMaskToString = [ 'plain', 'wall', 'swamp', 'wall' ] as const
  * @see https://docs.screeps.com/api/#Room-Terrain
  */
 export class Terrain {
+	// The room's 2500 tiles packed into 625 bytes: two bits per tile, four tiles per byte from the
+	// low end, indexed row-major as `yy * 50 + xx`. Each pair holds the value `get` returns.
 	readonly #buffer: Uint8Array;
 
 	/**
@@ -127,10 +129,15 @@ export function isBorder(xx: number, yy: number) {
 	return xx === 0 || xx === 49 || yy === 0 || yy === 49;
 }
 
+// The two-tile band along any edge -- 0, 1, 48, or 49 on either axis. The modulo wraps the high end
+// onto the low one so both ends fall out of a single comparison.
 export function isNearBorder(xx: number, yy: number) {
 	return (xx + 2) % 50 < 4 || (yy + 2) % 50 < 4;
 }
 
+// Which sides the room can be walked out of, as the bitfield `World` stores and `describeExits`
+// reads: 1 top, 2 right, 4 bottom, 8 left. A side counts when any of its tiles is passable; the
+// corners are skipped because an exit never occupies one.
 export function packExits(terrain: Terrain) {
 	const checkExit = (fn: (ii: number) => [ number, number ]) =>
 		Fn.some(Fn.range(1, 49), ii => terrain.get(...fn(ii)) !== C.TERRAIN_MASK_WALL);


### PR DESCRIPTION
Two gaps in the terrain/room-gen surface.

`Terrain`'s packed buffer layout was only implicit in the bit math at four sites
(`get`, `set`, `getRawBuffer`, `format`). It's now stated once on the private
field rather than in the class docblock, which is `@public` and gets emitted
verbatim into the player-facing `screeps.d.ts`. `packExits` returned an
undocumented bitfield, so the bits are named along with why the corners are
skipped, and `isNearBorder`'s modulo — which folds both ends of an axis into one
comparison — is spelled out.

`generate-room` is registered in `xxscreeps.js` but appeared nowhere in the
README; only `generate-sector` had a mention. Its flags now sit with the
`generateRoom` script example, noting that `controller` and `keeperLairs` have no
flags, so source-keeper and center rooms stay script-only.

No changeset — comments and README only, no behavior change.

## Validation

- `tsc -b` and eslint clean.
- Exit bit order checked against both consumers: `describeExits` in `game/map.ts`
  (`2 ** ((direction - 1) >>> 1)`) and `kSectorDirs.sharedExitBit` in
  `scripts/room-gen.ts`.
- Flag list transcribed from `generate-room`'s `checkArguments` call and usage
  string, not from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
