### PR TITLE
room-gen: add `--seed` for reproducible generation

### DIFF
--- a/.changeset/room-gen-seed.md
+++ b/.changeset/room-gen-seed.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Added `--seed` to `generate-room` and `generate-sector`, making a generated world reproducible.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ await using shard = await Shard.connect(db, 'shard0');
 await generateRoom(shard, 'W12N5');
 await generateRoom(shard, 'W11N5', { terrainType: 3, swampType: 2 });
 await generateRoom(shard, 'W10N5', { sources: 1, mineral: 'H' });
-await generateSector(shard, 'W20N20');
+await generateSector(shard, 'W20N20', { seed: 1234 });
 await Promise.all([ db.save(), shard.save() ]);
 ```
 
@@ -194,6 +194,17 @@ live world's. Rooms that already exist are skipped, so adjacent sectors share
 their boundary rings and a partially built sector can be re-entered. The same
 options apply to the sector's normal rooms. Also available as
 `npx xxscreeps generate-sector W20N20`.
+
+`seed` fixes every random value a room draws, so the same seed rebuilds the same
+terrain, objects, and object ids. Each room draws from its own stream, keyed by
+the seed together with the room's coordinates, so what a room rolls for itself
+doesn't depend on how many rooms preceded it — sharing one stream across a run
+would instead give two rooms at the same offset into it identical contents, ids
+included. Shared borders are still authored by whichever side is generated
+first, so generating the same rooms in a different order still yields a
+different world. Highway wall masses are sampled from world coordinates rather
+than the seed, so they repeat across worlds; their exits and swamp follow the
+seed like any other room's.
 
 ## Docker
 

--- a/packages/xxscreeps/mods/modern/deposit/test.ts
+++ b/packages/xxscreeps/mods/modern/deposit/test.ts
@@ -9,9 +9,9 @@ import { createRoomObject } from 'xxscreeps/game/object.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
 import { makeSectorRadiusPredicate } from 'xxscreeps/mods/modern/sector/sector.js';
-import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
 import { testWorld } from 'xxscreeps/test/import.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { deterministicRandom } from 'xxscreeps/utility/random.js';
 import * as C from 'xxscreeps:mods/constants';
 import { Deposit } from './deposit.js';
 import { depositTypeForRoom, loadSectorDeposits, setDepositBootstrapScatterForTesting } from './main.js';
@@ -122,7 +122,7 @@ describe('mods/modern/deposit', () => {
 	// W5N5 comes due the moment it's seeded), scoped to the test and restored on disposal.
 	function withFixedPlacement(seed = 1): Disposable {
 		const stack = new DisposableStack();
-		stack.use(deterministicRandomForTesting(seed));
+		stack.use(deterministicRandom(seed));
 		stack.use(setDepositBootstrapScatterForTesting(() => 0));
 		return stack;
 	}
@@ -218,7 +218,7 @@ describe('mods/modern/deposit', () => {
 				room['#insertObject'](createCreep(new RoomPosition(20, 21, 'W0N0'), [ C.MOVE ], 'parker', '100'));
 			},
 		})(async ({ shard, tick }) => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			// No bootstrap: the decay path is the sole scheduler of W5N5. Decay fires this tick and marks
 			// W5N5 due immediately (score 0); the shard processor drains it the same tick, tallies the
 			// sector without the corpse, and pushes a refill intent.

--- a/packages/xxscreeps/mods/modern/powerbank/test.ts
+++ b/packages/xxscreeps/mods/modern/powerbank/test.ts
@@ -8,8 +8,8 @@ import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
 import { lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
 import { iterateSectors } from 'xxscreeps/mods/modern/sector/sector.js';
-import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import { deterministicRandom } from 'xxscreeps/utility/random.js';
 import * as C from 'xxscreeps:mods/constants';
 import { inspectDuePowerBankRoomsForTest, scheduleRoom } from './model.js';
 import { StructurePowerBank, create as createPowerBank } from './powerbank.js';
@@ -132,7 +132,7 @@ describe('mods/modern/powerbank', () => {
 	// Scripted values for the first calls, then the LCG — steers the base/crit rolls while leaving
 	// placement free to vary.
 	function makeRngWithPrefix(prefix: number[], seed = 1) {
-		const disposable = deterministicRandomForTesting(seed);
+		const disposable = deterministicRandom(seed);
 		const { random } = Math;
 		let index = 0;
 		Math.random = () => index < prefix.length ? prefix[index++]! : random();
@@ -148,7 +148,7 @@ describe('mods/modern/powerbank', () => {
 
 	describe('placement', () => {
 		test('bootstrap seeds every highway room without placing', () => emptyWorld(async ({ shard }) => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			const seededAt = shard.time;
 			await runShardInitializers(shard);
 			const due = await inspectDuePowerBankRoomsForTest(shard);
@@ -167,7 +167,7 @@ describe('mods/modern/powerbank', () => {
 		}));
 
 		test('a due highway room places one valid power bank', () => emptyWorld(async ({ shard, tick }) => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			const scheduledAt = shard.time;
 			await scheduleRoom(shard, 'W0N0', 0);
 			// Tick 1: the shard processor pushes a placement intent and reschedules. Tick 2: the room
@@ -198,7 +198,7 @@ describe('mods/modern/powerbank', () => {
 		}));
 
 		test('non-highway rooms are never seeded', () => emptyWorld(async ({ shard }) => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			await runShardInitializers(shard);
 			const seeded = new Set((await inspectDuePowerBankRoomsForTest(shard)).map(([ , roomName ]) => roomName));
 			assert.ok(!seeded.has('W5N5'), 'sector center is not seeded');
@@ -221,7 +221,7 @@ describe('mods/modern/powerbank', () => {
 			// a match proves the schedule was repopulated from the room rather than rolled from scratch.
 			W0N0: room => { room['#nextPowerBankTime'] = 12345; },
 		})(async ({ shard }) => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			await runShardInitializers(shard);
 			const due = await inspectDuePowerBankRoomsForTest(shard);
 			const entry = due.find(([ , roomName ]) => roomName === 'W0N0');

--- a/packages/xxscreeps/scripts/generate-room.ts
+++ b/packages/xxscreeps/scripts/generate-room.ts
@@ -31,6 +31,11 @@ function parseMineralType(value: string | undefined) {
 // The room-shape flags shared between `generate-room` and `generate-sector`.
 export const roomOptionArguments = [ 'terrain-type', 'swamp-type', 'sources', 'mineral' ] as const;
 
+// Every random value generation draws comes from the seed, so the same seed rebuilds the same rooms.
+export function parseSeed(value: string | undefined) {
+	return parseOptionalInteger(value, 'seed', 0, 0xffffffff);
+}
+
 export function parseRoomOptions(argv: Partial<Record<typeof roomOptionArguments[number], string>>): GenerateRoomOptions {
 	const terrainType = parseOptionalInteger(argv['terrain-type'], 'terrain-type', 1, 28);
 	const swampType = parseOptionalInteger(argv['swamp-type'], 'swamp-type', 0, 14);
@@ -47,16 +52,17 @@ export function parseRoomOptions(argv: Partial<Record<typeof roomOptionArguments
 async function main() {
 	const argv = checkArguments({
 		argv: true,
-		string: [ 'shard', ...roomOptionArguments ] as const,
+		string: [ 'shard', 'seed', ...roomOptionArguments ] as const,
 	});
 	const roomName = argv.argv[0];
 	if (roomName === undefined) {
-		console.log('Usage: xxscreeps generate-room <room> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
+		console.log('Usage: xxscreeps generate-room <room> [--shard shard] [--seed 0-4294967295] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
 		process.exitCode = 1;
 		return;
 	}
 
-	const options = parseRoomOptions(argv);
+	const seed = parseSeed(argv.seed);
+	const options = { ...parseRoomOptions(argv), ...seed !== undefined && { seed } };
 	await using db = await Database.connect();
 	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
 	const room = await generateRoom(shard, roomName, options);

--- a/packages/xxscreeps/scripts/generate-sector.ts
+++ b/packages/xxscreeps/scripts/generate-sector.ts
@@ -1,7 +1,7 @@
 import { checkArguments } from 'xxscreeps/config/arguments.js';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
-import { parseRoomOptions, roomOptionArguments } from 'xxscreeps/scripts/generate-room.js';
+import { parseRoomOptions, parseSeed, roomOptionArguments } from 'xxscreeps/scripts/generate-room.js';
 import { generateSector } from 'xxscreeps/scripts/room-gen.js';
 
 // Generates a full sector from an origin room -- the 11x11 = 121-room block including the highway
@@ -11,16 +11,17 @@ import { generateSector } from 'xxscreeps/scripts/room-gen.js';
 async function main() {
 	const argv = checkArguments({
 		argv: true,
-		string: [ 'shard', ...roomOptionArguments ] as const,
+		string: [ 'shard', 'seed', ...roomOptionArguments ] as const,
 	});
 	const origin = argv.argv[0];
 	if (origin === undefined) {
-		console.log('Usage: xxscreeps generate-sector <origin> [--shard shard] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
+		console.log('Usage: xxscreeps generate-sector <origin> [--shard shard] [--seed 0-4294967295] [--terrain-type 1-28] [--swamp-type 0-14] [--sources 1-4] [--mineral H|O|Z|K|U|L|X]');
 		process.exitCode = 1;
 		return;
 	}
 
-	const options = parseRoomOptions(argv);
+	const seed = parseSeed(argv.seed);
+	const options = { ...parseRoomOptions(argv), ...seed !== undefined && { seed } };
 	await using db = await Database.connect();
 	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
 	const rooms = await generateSector(shard, origin, options);

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -260,17 +260,26 @@ function markExits(grid: Grid, exits: ExitMap): void {
 	}
 }
 
+const kTriesPerWallType = 100;
+const kMaxTerrainAttempts = kTriesPerWallType * 10;
+
 // Fills the room with cellular-automaton wall (and swamp) noise, rerolling the wall type until the
-// open terrain is fully connected, then smooths swamp the same way.
+// open terrain is fully connected, then smooths swamp the same way. A seeded room draws from a
+// stream fixed by its coordinates, so a layout that never connects never connects on a rerun
+// either -- the reroll is bounded to fail rather than hang.
 function buildBaseTerrain(exits: ExitMap, wallType: number, swampType: number): Grid {
 	let grid: Grid;
 	let activeWallType = wallType;
 	let tries = 0;
+	let attempts = 0;
 	do {
+		if (++attempts > kMaxTerrainAttempts) {
+			throw new Error(`Failed to connect room terrain after ${kMaxTerrainAttempts} attempts`);
+		}
 		grid = makeGrid();
 		markExits(grid, exits);
 		tries++;
-		if (tries > 100) {
+		if (tries > kTriesPerWallType) {
 			activeWallType = randomWallType();
 			tries = 0;
 		}

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,4 +1,4 @@
-import type { ExitMap, GenerateRoomOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
+import type { ExitMap, GenerateRoomOptions, GenerationOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { RoomType } from 'xxscreeps/mods/modern/sector/terrain.js';
 import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
@@ -13,12 +13,12 @@ import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { Terrain, TerrainWriter, isBorder, packExits } from 'xxscreeps/game/terrain.js';
 import { computeRoomMeta, highwayOrientation, roomType } from 'xxscreeps/mods/modern/sector/terrain.js';
 import { makeWriter } from 'xxscreeps/schema/write.js';
-import { shuffledSquare } from 'xxscreeps/utility/random.js';
+import { deterministicRandom, shuffledSquare } from 'xxscreeps/utility/random.js';
 import { hashCombine, hashMix } from 'xxscreeps/utility/utility.js';
 import { hooks } from './symbols.js';
 import 'xxscreeps:mods/terrain';
 
-export type { GenerateRoomOptions } from './symbols.js';
+export type { GenerateRoomOptions, GenerationOptions } from './symbols.js';
 
 // The world's per-room terrain map, as returned by `shard.loadWorld()`. The generation entry points
 // accumulate freshly built rooms into one of these and serialize it once, rather than once per room.
@@ -742,10 +742,21 @@ async function flushRooms(shard: Shard, terrainMap: WorldTerrain, rooms: Room[])
 	]);
 }
 
+// Generation draws every random value from `Math.random`, so a seeded run swaps in a stream keyed by
+// the seed and the room's position -- terrain, object placement, and the ids those objects get all
+// replay. The key is per room rather than per run so that what a room rolls for itself doesn't shift
+// with the number of rooms built before it: one stream for a whole run hands two rooms that start at
+// the same offset into it identical contents, ids included, since `generateId` draws from
+// `Math.random` as well. Shared borders are still authored by whichever side is built first, so the
+// order rooms arrive in does still shape the world.
+function seedRoom(seed: number | undefined, rx: number, ry: number) {
+	return seed === undefined ? undefined : deterministicRandom(hashCombine(hashCombine(seed, rx), ry));
+}
+
 export async function generateRoom(
 	shard: Shard,
 	roomName: string,
-	options?: GenerateRoomOptions,
+	options?: GenerationOptions,
 ): Promise<Room> {
 	const { rx, ry } = parseSignedRoomName(roomName);
 	if (Number.isNaN(rx) || Number.isNaN(ry)) {
@@ -758,8 +769,12 @@ export async function generateRoom(
 		throw new Error(`Room already exists: ${roomName}`);
 	}
 
+	const { seed, ...roomOptions } = options ?? {};
 	const terrainMap = new Map(world.terrain);
-	const { room, terrain } = buildRoom(roomName, options, neighborName => terrainMap.get(neighborName));
+	const { room, terrain } = function() {
+		using random = seedRoom(seed, rx, ry);
+		return buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
+	}();
 	commitRoom(terrainMap, roomName, terrain);
 	refreshRoomMeta(terrainMap, [ roomName ]);
 	await flushRooms(shard, terrainMap, [ room ]);
@@ -849,6 +864,7 @@ function isSealableSide(type: RoomType, dir: keyof ExitMap, roomName: string, ne
 function *accumulateSector(
 	origin: SectorOrigin,
 	options: GenerateRoomOptions | undefined,
+	seed: number | undefined,
 	terrainMap: WorldTerrain,
 	existing: Set<string>,
 ): Iterable<Room> {
@@ -857,59 +873,74 @@ function *accumulateSector(
 		if (existing.has(roomName)) {
 			continue;
 		}
-		const type = roomType(roomName);
-		const template = roomTypeTemplates[type];
-		const hasController = (template.controller ?? options?.controller) !== false;
-
-		// Roll seals on void borders; sides facing a built room inherit its border instead.
-		const sealed: (keyof ExitMap)[] = [];
-		let openSides = 0;
-		for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
-			const sectorDir = kSectorDirs[dir];
-			const neighborName = makeSignedRoomName(rx + sectorDir.dxx, ry + sectorDir.dyy);
-			const record = terrainMap.get(neighborName);
-			if (record) {
-				if ((record.exits & sectorDir.sharedExitBit) !== 0) {
-					openSides += 1;
-				}
-			} else if (isSealableSide(type, dir, roomName, neighborName, hasController) &&
-				Math.random() < kSealSideProbability) {
-				sealed.push(dir);
-			} else {
-				openSides += 1;
-			}
-		}
-		// Never wall off all four sides -- reopen a rolled seal when no border can carry an exit. A
-		// re-entered hole whose four built neighbors all sealed toward it has nothing to reopen and
-		// still generates a zero-exit room; rare, locally unfixable (the neighbors' terrain is already
-		// authored), and the live world does carry fully sealed rooms.
-		if (openSides === 0 && sealed.length > 0) {
-			sealed.shift();
-		}
-
-		const roomOptions: GenerateRoomOptions = {
-			...type === 'normal' && options,
-			...template,
-			...type === 'highway' && { highway: highwayOrientation(roomName) },
-			exits: Fn.fromEntries(Fn.map(sealed, dir => [ dir, [] ])),
-		};
-		const { room, terrain } = buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
+		const { room, terrain } = buildSectorRoom(roomName, options, seed, terrainMap);
 		commitRoom(terrainMap, roomName, terrain);
 		existing.add(roomName);
 		yield room;
 	}
 }
 
+// Builds one room of a sector under its room type's template: rolls the seals the template leaves to
+// chance, then defers to the shared builder. Holds the room's random stream, so every decision the
+// room makes -- seals included -- comes from one seeded sequence in a fixed order.
+function buildSectorRoom(
+	roomName: string,
+	options: GenerateRoomOptions | undefined,
+	seed: number | undefined,
+	terrainMap: WorldTerrain,
+) {
+	const { rx, ry } = parseSignedRoomName(roomName);
+	using random = seedRoom(seed, rx, ry);
+	const type = roomType(roomName);
+	const template = roomTypeTemplates[type];
+	const hasController = (template.controller ?? options?.controller) !== false;
+
+	// Roll seals on void borders; sides facing a built room inherit its border instead.
+	const sealed: (keyof ExitMap)[] = [];
+	let openSides = 0;
+	for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
+		const sectorDir = kSectorDirs[dir];
+		const neighborName = makeSignedRoomName(rx + sectorDir.dxx, ry + sectorDir.dyy);
+		const record = terrainMap.get(neighborName);
+		if (record) {
+			if ((record.exits & sectorDir.sharedExitBit) !== 0) {
+				openSides += 1;
+			}
+		} else if (isSealableSide(type, dir, roomName, neighborName, hasController) &&
+			Math.random() < kSealSideProbability) {
+			sealed.push(dir);
+		} else {
+			openSides += 1;
+		}
+	}
+	// Never wall off all four sides -- reopen a rolled seal when no border can carry an exit. A
+	// re-entered hole whose four built neighbors all sealed toward it has nothing to reopen and
+	// still generates a zero-exit room; rare, locally unfixable (the neighbors' terrain is already
+	// authored), and the live world does carry fully sealed rooms.
+	if (openSides === 0 && sealed.length > 0) {
+		sealed.shift();
+	}
+
+	const roomOptions: GenerateRoomOptions = {
+		...type === 'normal' && options,
+		...template,
+		...type === 'highway' && { highway: highwayOrientation(roomName) },
+		exits: Fn.fromEntries(Fn.map(sealed, dir => [ dir, [] ])),
+	};
+	return buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
+}
+
 export async function generateSector(
 	shard: Shard,
 	sectorName: string,
-	options?: GenerateRoomOptions,
+	options?: GenerationOptions,
 ): Promise<Room[]> {
 	const origin = parseSectorOrigin(sectorName);
 	await ensureWorldTerrain(shard);
 	const [ world, existingRooms ] = await Promise.all([ shard.loadWorld(), shard.data.sMembers('rooms') ]);
+	const { seed, ...roomOptions } = options ?? {};
 	const terrainMap = new Map(world.terrain);
-	const rooms = [ ...accumulateSector(origin, options, terrainMap, new Set(existingRooms)) ];
+	const rooms = [ ...accumulateSector(origin, roomOptions, seed, terrainMap, new Set(existingRooms)) ];
 	refreshRoomMeta(terrainMap, Fn.map(rooms, room => room.name));
 	await flushRooms(shard, terrainMap, rooms);
 	return rooms;

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -24,6 +24,16 @@ export interface GenerateRoomOptions {
 	swampType?: number;
 }
 
+export interface GenerationOptions extends GenerateRoomOptions {
+	/**
+	 * Seeds every random value the generation draws, so the same seed rebuilds the same rooms --
+	 * terrain, objects, and their ids. Accepts 0 to 0xffffffff; omit to generate at random. Unlike
+	 * the room-shape flags this belongs to the generation, not the room, so it never reaches a
+	 * `roomGenerator` hook's `options`.
+	 */
+	seed?: number;
+}
+
 export interface RoomGeneratorContext {
 	options: GenerateRoomOptions;
 	/** The room being generated. Insert objects through `place` so their positions are tagged. */

--- a/packages/xxscreeps/test/fixtures.ts
+++ b/packages/xxscreeps/test/fixtures.ts
@@ -1,5 +1,3 @@
-import { hashMix } from 'xxscreeps/utility/utility.js';
-
 export class DeterministicClockForTesting {
 	readonly #now = Date.now;
 	#ts: number;
@@ -24,13 +22,4 @@ export class DeterministicClockForTesting {
 	set(value: number) {
 		this.#ts = value;
 	}
-}
-
-export function deterministicRandomForTesting(seed = 1) {
-	const disposable = new DisposableStack();
-	const { random } = Math;
-	disposable.defer(() => Math.random = random);
-	let state = hashMix(seed);
-	Math.random = () => (state = hashMix(state)) / 0xffffffff + 0.5;
-	return disposable;
 }

--- a/packages/xxscreeps/utility/random.ts
+++ b/packages/xxscreeps/utility/random.ts
@@ -1,5 +1,23 @@
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { hashCombine } from './utility.js';
+import { hashCombine, hashMix } from './utility.js';
+
+/**
+ * Replaces `Math.random` with a stream determined entirely by `seed`, restored on disposal, so every
+ * random value the scope draws replays on the next run with the same seed. Hashing a counter rather
+ * than chaining the hash into itself keeps every seed on a full-period stream: `hashMix` fixes zero,
+ * and a chained state seeded there would return zero forever. The seed is mixed before it keys the
+ * counter because `hashCombine` adds its arguments -- keyed on the raw seed, each seed's stream is
+ * the next seed's shifted by one draw.
+ */
+export function deterministicRandom(seed = 1) {
+	const disposable = new DisposableStack();
+	const { random } = Math;
+	disposable.defer(() => Math.random = random);
+	const key = hashMix(seed);
+	let index = 0;
+	Math.random = () => (hashCombine(key, index++) >>> 0) / 0x100000000;
+	return disposable;
+}
 
 /**
  * Yields every integer in `[0, count)` exactly once, in a pseudo-random order drawn from

--- a/packages/xxscreeps/utility/test.ts
+++ b/packages/xxscreeps/utility/test.ts
@@ -1,21 +1,37 @@
 import * as assert from 'node:assert';
 import { numericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
 import { describe, test } from 'xxscreeps/test/index.js';
-import { shuffle, shuffledRange, shuffledSquare } from './random.js';
+import { deterministicRandom, shuffle, shuffledRange, shuffledSquare } from './random.js';
 
 describe('utility', () => {
 	describe('random', () => {
+		test('deterministicRandom replays its stream and restores Math.random', () => {
+			const { random } = Math;
+			const draw = (seed: number) => {
+				using rng = deterministicRandom(seed);
+				return [ ...Fn.map(Fn.range(1000), () => Math.random()) ];
+			};
+			// Zero is the interesting seed: `hashMix` fixes it, so a stream chaining the hash into its
+			// own state returns zero forever from there.
+			const first = draw(0);
+			assert.deepStrictEqual(draw(0), first, 'the same seed replays');
+			assert.notDeepStrictEqual(draw(1), first, 'a different seed diverges');
+			assert.notStrictEqual(draw(1)[0], first[1], 'an adjacent seed is not the same stream shifted');
+			assert.ok(first.every(value => value >= 0 && value < 1), 'every draw lands in [0, 1)');
+			assert.strictEqual(new Set(first).size, first.length, 'no draw repeats');
+			assert.strictEqual(Math.random, random, 'the original is restored');
+		});
+
 		test('shuffledRange yields each index exactly once', () => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			for (const count of [ 0, 1, 2, 3, 4, 15, 16, 17, 100, 1000 ]) {
 				assert.deepStrictEqual([ ...shuffledRange(count) ].sort(numericComparator), [ ...Fn.range(count) ]);
 			}
 		});
 
 		test('shuffledSquare visits every position exactly once', () => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			const visited = Fn.pipe(
 				shuffledSquare(5, 40),
 				$$ => Fn.map($$, ([ xx, yy ]) => yy * 50 + xx),
@@ -26,13 +42,13 @@ describe('utility', () => {
 		});
 
 		test('shuffle yields each element exactly once', () => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			const list = [ ...Fn.range(26) ];
 			assert.deepStrictEqual([ ...shuffle(list) ].sort(numericComparator), list);
 		});
 
 		test('first yielded index is roughly uniform', () => {
-			using rng = deterministicRandomForTesting();
+			using rng = deterministicRandom();
 			const trials = 10000;
 			const counts = [ ...Fn.map(Fn.range(10), () => 0) ];
 			for (let ii = 0; ii < trials; ++ii) {


### PR DESCRIPTION
Resolves #343.

`generate-room` and `generate-sector` take `--seed`; the same seed rebuilds the same terrain, objects, and object ids.

The seed applies by swapping `Math.random` for the duration of a room's synchronous build rather than threading a generator through every draw site — #262 deleted the injectable-rng shape for the same reason, and going through the global is also what makes `generateId` replay, so a seeded room's blob comes out byte-identical rather than merely similarly shaped. Each room's stream is keyed on `(seed, rx, ry)` rather than on the run: one stream per run hands two rooms that start at the same offset into it identical contents, ids included, which duplicates ids within a shard.

The first commit stands alone — it promotes `deterministicRandomForTesting` to `utility/random.ts` and fixes two things that only start to matter once production draws from it. `hashMix` fixes zero, so the chained state returned zero forever from `--seed 0`, which `buildBaseTerrain`'s unbounded `checkFlood` retry never escapes; and the old `[0, 1)` mapping went slightly negative for one state in 2^32, flooring a `Math.random() * n` index to `-1`.

Deliberate limits: shared borders are authored by whichever side builds first, so re-ordering the same generate calls still changes the world; highway wall masses come from unseeded world-position noise, so that field repeats across worlds, though their exits and swamp follow the seed; and a seed only holds for a given build, since the generator is still being tuned.

## Validation

- Generated 3 sectors (341 rooms) twice with `--seed 7`: byte-identical shard; `--seed 8` diverged in 244 files. Same for a single `generate-room`.
- Swept object ids across that world: 993 objects, 993 distinct. Before the per-room keying, two same-seed sectors gave 648 objects sharing 324 ids.
- `--seed 0` completes in 24s; it hung indefinitely on the chained stream.
- Stream uniformity over 2M draws: χ²(19df) 9.2 and 9.8, against 17.9 for `Math.random`; no draw outside `[0, 1)` in 20M.
- Terrain density held against unseeded output: normal rooms 32.7–34.8% wall, highway 21.6–23.1%.
- 537 tests, `tsc -b`, and `eslint --max-warnings 0` clean. The new `utility/test.ts` case fails when the production change is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
