### PR TITLE
room-gen: fix the connectivity check flooding from a transposed cell

### DIFF
--- a/.changeset/room-gen-flood-orientation.md
+++ b/.changeset/room-gen-flood-orientation.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fixed the room terrain connectivity check flooding from a transposed start cell, which rejected valid layouts.

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -147,8 +147,8 @@ function checkFlood(grid: Grid): boolean {
 	let startXx = -1;
 	let startYy = -1;
 
-	outer: for (const [ xx, row ] of grid.entries()) {
-		for (const [ yy, cell ] of row.entries()) {
+	outer: for (const [ yy, row ] of grid.entries()) {
+		for (const [ xx, cell ] of row.entries()) {
 			if (!cell.wall) {
 				startXx = xx;
 				startYy = yy;


### PR DESCRIPTION
`checkFlood` picks a starting cell by scanning for the first non-wall tile, but the outer loop binds the row index to `xx` while the grid is addressed `grid[yy][xx]` everywhere else in the file, so the flood starts at the start cell's mirror. When that mirror lands inside a wall mass with no open neighbour the flood visits nothing and the check fails a room that is in fact connected.

The check stays sound either way — it never accepts a disconnected room, so no broken terrain has shipped — but it isn't complete, and the layouts it wrongly rejects aren't a random sample: they're the ones walled near the mirrored cell. Generation just retries until something passes, so the surviving terrain skews toward whatever happens to be open there, and the reroll runs about 1.5x the attempts it needs.

## Validation

- Replayed `buildBaseTerrain`'s fill and smooth over 30,000 layouts with the real `wallTypes` table and real `genExit` exits, checking each candidate under both orientations: 12,654 layouts were connected and the shipped check accepted 8,462 of them, rejecting 33%. Nothing was accepted by the shipped check that the corrected one rejected, which is what keeps the bug invisible in output.
- Rejections concentrated in the low-fill cave types, worst at 2, 3 and 13.
- Two hand-built connected grids — one open row, one open column — were rejected before the change and accepted after.
- 536 tests, `tsc -b`, and `eslint --max-warnings 0` clean.

Terrain changes for a given sequence of draws, so this is better landed before #346 gives anyone a reason to pin a seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
