### PR TITLE
Reorder checkSend validation precedence

### DIFF
--- a/.changeset/terminal-send-validation-precedence.md
+++ b/.changeset/terminal-send-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Reorder `StructureTerminal.send` validation so destination and cooldown precede the energy cost and description.

--- a/packages/xxscreeps/mods/classic/brokerage/terminal.ts
+++ b/packages/xxscreeps/mods/classic/brokerage/terminal.ts
@@ -83,25 +83,27 @@ export class StructureTerminal extends withOverlay(OwnedStructure, terminalShape
 
 //
 // Intent checks
+// Divergence from Screeps, which accepts a send to the terminal's own room
+function checkDestination(range: number) {
+	return range < Infinity && range !== 0 ? C.OK : C.ERR_INVALID_ARGS;
+}
+
+function checkCooldown(terminal: StructureTerminal) {
+	return terminal.cooldown === 0 ? C.OK : C.ERR_TIRED;
+}
+
 export function checkSend(terminal: StructureTerminal, resourceType: ResourceType, amount: number, destination: string, description: string | null | undefined) {
 	const range = Game.map.getRoomLinearDistance(terminal.room.name, destination);
 	const energyCost = calculateEnergyCost(amount, range);
+	const energyRequired = resourceType === C.RESOURCE_ENERGY ? amount + energyCost : energyCost;
 	return chainIntentChecks(
 		() => checkMyStructure(terminal, StructureTerminal),
 		() => checkIsActive(terminal),
-		resourceType === C.RESOURCE_ENERGY
-			? () => checkHasResource(terminal, C.RESOURCE_ENERGY, amount + energyCost) :
-			() => chainIntentChecks(
-				() => checkHasResource(terminal, C.RESOURCE_ENERGY, energyCost),
-				() => checkHasResource(terminal, resourceType, amount)),
+		() => checkDestination(range),
+		() => checkHasResource(terminal, resourceType, amount),
+		() => checkCooldown(terminal),
+		() => checkHasResource(terminal, C.RESOURCE_ENERGY, energyRequired),
 		() => description == null ? C.OK : checkString(description, 100),
-		() => {
-			if (!(range < Infinity) || range === 0) {
-				return C.ERR_INVALID_ARGS;
-			} else if (terminal.cooldown) {
-				return C.ERR_TIRED;
-			}
-		},
 	);
 }
 

--- a/packages/xxscreeps/mods/classic/brokerage/test.ts
+++ b/packages/xxscreeps/mods/classic/brokerage/test.ts
@@ -209,4 +209,25 @@ describe('mods/classic/brokerage', () => {
 			assert.strictEqual(terminal?.send(C.RESOURCE_ENERGY, 1000, 'W2N1'), C.ERR_TIRED);
 		});
 	}));
+
+	test('an unparseable destination returns ERR_INVALID_ARGS', () => sendSim(async ({ player }) => {
+		await player('100', Game => {
+			const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+			assert.strictEqual(terminal?.send(C.RESOURCE_ENERGY, 1000, 'nowhere'), C.ERR_INVALID_ARGS);
+		});
+	}));
+
+	test('cooldown outranks the transfer cost and the description', () => sendSim(async ({ player, tick }) => {
+		await player('100', Game => {
+			const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+			terminal?.send(C.RESOURCE_ENERGY, 1000, 'W2N1');
+		});
+		await tick();
+		await player('100', Game => {
+			const terminal = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_TERMINAL)[0];
+			// The store holds the whole amount, but not the amount plus its transfer cost.
+			assert.strictEqual(terminal?.send(C.RESOURCE_ENERGY, terminal.store.energy, 'W2N1'), C.ERR_TIRED);
+			assert.strictEqual(terminal.send(C.RESOURCE_ENERGY, 1000, 'W2N1', 'x'.repeat(101)), C.ERR_TIRED);
+		});
+	}));
 });


### PR DESCRIPTION
`checkSend` computed the transfer energy cost before running any check, so an unparseable
destination produced a `NaN` range and a `NaN` cost, and that cost failed the resource check — an
invalid room name reported `ERR_NOT_ENOUGH_RESOURCES`. The cooldown check ran last, so an
on-cooldown terminal reported the energy-cost or description failure instead of `ERR_TIRED`.

The chain now follows `StructureTerminal.prototype.send`: owner, active, destination, resource
amount, cooldown, energy cost, description.

Beyond the return codes, one accepted input changes: an energy send with a non-numeric `amount`
(`true`, `false`, `null`) passed, because `amount + energyCost` coerced it past `checkResourceArgs` —
the unconditional amount check now rejects it, as the non-energy path already did.

A same-room send still returns `ERR_INVALID_ARGS` where Screeps accepts it; the check moved but its
behavior didn't, and the divergence is now marked at the site.

Not addressed here: `checkSend` and the send processor call `getRoomLinearDistance` without
`continuous`, where vanilla passes it, so the cost differs on a wrapping world.

## Validation

`npm test` (538 passed) and `npm run lint` (0 warnings). The two tests added to
`mods/classic/brokerage/test.ts` cover the invalid destination and cooldown precedence; both failed
before the reorder, returning `ERR_NOT_ENOUGH_RESOURCES` and `ERR_INVALID_ARGS`.

screeps-ok's terminal suite passed against both engines, clearing the
`terminal-send-check-order-diverges` gap — 9 rows flipped: `TERMINAL-SEND-005` (invalid
`resourceType` / room name / description return `ERR_INVALID_ARGS`), and `TERMINAL-SEND-013`'s
`invalidRoom`, `invalidRoomBeforeInvalidResource`, `invalidRoomBeforeNotEnoughAmount`,
`invalidRoomBeforeCooldown`, `invalidRoomBeforeNotEnoughEnergyCost`,
`invalidRoomBeforeInvalidDescription`, `cooldownBeforeNotEnoughEnergyCost`,
`cooldownBeforeInvalidDescription`.
