### PR TITLE
driver: decode the runtime source map with trace-mapping

### DIFF
--- a/.changeset/runtime-source-map-decoder.md
+++ b/.changeset/runtime-source-map-decoder.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Decode the runtime source map with `@jridgewell/trace-mapping` instead of `source-map@0.6`

--- a/packages/xxscreeps/driver/runtime/source-map-consumer.ts
+++ b/packages/xxscreeps/driver/runtime/source-map-consumer.ts
@@ -1,0 +1,26 @@
+import type { Needle, SourceMapInput } from '@jridgewell/trace-mapping';
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+
+// `source-map-support` resolves `source-map@0.6`, whose consumer materializes and sorts an object
+// per mapping before it can answer the first query. For the runtime bundle that is most of a
+// player's CPU limit, charged to whichever tick first reads `error.stack`. Webpack aliases
+// `source-map` here instead, onto the decoder webpack already uses to build the bundle.
+export class SourceMapConsumer {
+	private readonly tracer;
+
+	constructor(map: SourceMapInput) {
+		this.tracer = new TraceMap(map);
+	}
+
+	get sources() {
+		return this.tracer.resolvedSources;
+	}
+
+	get sourcesContent() {
+		return this.tracer.sourcesContent;
+	}
+
+	originalPositionFor(needle: Needle) {
+		return originalPositionFor(this.tracer, needle);
+	}
+}

--- a/packages/xxscreeps/driver/sandbox/isolated/index.ts
+++ b/packages/xxscreeps/driver/sandbox/isolated/index.ts
@@ -27,6 +27,7 @@ const getRuntimeSource = runOnce(() => {
 		babel: [ Privates ],
 		alias: {
 			process: 'xxscreeps/driver/sandbox/isolated/process.js',
+			'source-map$': 'xxscreeps/driver/runtime/source-map-consumer.js',
 			'/xxscreeps:private-symbol': 'xxscreeps/driver/private/symbol/isolated-vm.js',
 			'xxscreeps/engine/schema/build/index.js': 'xxscreeps/engine/schema/build/runtime.js',
 			'xxscreeps/game/constants/index.js': import.meta.resolve('xxscreeps/game/constants/index.js'),

--- a/packages/xxscreeps/package.json
+++ b/packages/xxscreeps/package.json
@@ -23,6 +23,7 @@
     "@babel/core": "~7.29.7",
     "@babel/types": "^7.29.7",
     "@isolated-vm/experimental": "^0.0.10",
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@loaderkit/resolve": "^1.0.6",
     "@screeps/launcher": "4.1.0",
     "@types/convert-source-map": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@isolated-vm/experimental':
         specifier: ^0.0.10
         version: 0.0.10
+      '@jridgewell/trace-mapping':
+        specifier: ^0.3.31
+        version: 0.3.31
       '@loaderkit/resolve':
         specifier: ^1.0.6
         version: 1.0.6


### PR DESCRIPTION
`source-map-support` decodes the runtime bundle's map the first time it translates a frame from it, inside the isolate, charged to whichever player tick first reads `error.stack` — 38-41ms on current main against a bucket that refills at `kCPU: 100` per tick. And because `tickLimit` is `Math.min(config.runner.cpu.tickLimit, bucket)`, a player whose bucket has drained below the decode cost times out instead of paying it, is marked stale, and the recreated sandbox decodes again on its first stack.

The cost is the decoder, not the map. `source-map-support@0.5.21` resolves `source-map@0.6`, whose consumer materializes and sorts an object per mapping before it can answer the first query. This PR aliases `source-map` in the runtime bundle onto a small shim over `@jridgewell/trace-mapping` — the decoder webpack itself uses to build this bundle, deduped onto the copy already in the lockfile. `source-map-support` touches four members of the consumer — `new SourceMapConsumer`, `.sources`, `.sourcesContent`, `.originalPositionFor` — and duck-types the last, so the shim is exactly those four.

Measured in a real isolate via `isolate.cpuTime`, the clock `IsolatedSandbox.run` bills against `tickLimit`, on the bundle current main produces:

|  | initialize | first `error.stack` | heap at init | heap after decode |
|---|---|---|---|---|
| main | 13.8-14.3ms | 37.6-40.9ms | 5.3-5.4 MiB | 17.7-17.8 MiB |
| this PR | 13.2-14.7ms | 6.8-9.9ms | 5.2-5.3 MiB | 10.3-11.1 MiB |

Initialization and per-tick cost are unchanged; `source-map@0.6` also drops out of the bundle.

## Validation

- `npx xxscreeps test` — 645 passed; `eslint --max-warnings 0` clean on the changed files
- The two decoders agree on all 155,403 generated positions in the current bundle — every mapped segment, the columns either side of it, line starts, past end-of-line, and past end-of-file. Translated stacks are identical.
- Not covered by an in-repo test: `test/simulate.ts` pins `sandbox: 'unsafe'`, which never loads this module, so no in-repo test exercises the changed path.
