### PR TITLE
powercreep: lose movement ties and die at nuke impact

### DIFF
--- a/.changeset/power-creep-move-nuke.md
+++ b/.changeset/power-creep-move-nuke.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+powercreep: lose movement ties and die at nuke impact

--- a/packages/xxscreeps/mods/mmo/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/processor.ts
@@ -9,7 +9,7 @@ import { appendEventLog } from 'xxscreeps/game/room/event-log.js';
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
 import { checkCarrier } from 'xxscreeps/mods/classic/creep/creep.js';
-import { borderExitPosition, commitMove, flushActionLog, isHostileInSafeMode, kRetainActionsTime, processDrop, processPickup, processSay, processTransfer, processWithdraw, teleportCreep } from 'xxscreeps/mods/classic/creep/processor.js';
+import { borderExitPosition, commitMove, flushActionLog, kRetainActionsTime, processDrop, processPickup, processSay, processTransfer, processWithdraw, teleportCreep } from 'xxscreeps/mods/classic/creep/processor.js';
 import { Tombstone } from 'xxscreeps/mods/classic/creep/tombstone.js';
 import { drop as dropResource } from 'xxscreeps/mods/classic/resource/processor/resource.js';
 import { OpenStore } from 'xxscreeps/mods/classic/resource/store.js';
@@ -38,11 +38,14 @@ function buryPowerCreep(creep: PowerCreep) {
 	};
 	tombstone['#decayTime'] = Game.time + C.TOMBSTONE_DECAY_POWER_CREEP;
 	creep.room['#insertObject'](tombstone);
-	creep['#destroy']();
 }
 
 // The roster lives in account keyspace, so the death writeback rides `context.task`.
 function killPowerCreep(creep: PowerCreep, context: ProcessorContext) {
+	// A nuke's sweep and blast can each kill the same creep in one tick pass; only the first buries.
+	if (!creep['#destroy']()) {
+		return;
+	}
 	const user = creep['#user'];
 	const id = creep.id;
 	buryPowerCreep(creep);
@@ -76,8 +79,8 @@ const intents = [
 
 	registerIntentProcessor(PowerCreep, 'move', {}, (creep, context, direction: Direction) => {
 		if (checkCarrier(creep) === C.OK) {
-			const priority = 1 + (isHostileInSafeMode(creep) ? -500 : 0);
-			Movement.announce(creep, direction, commit => commit(priority, pos => {
+			// No MOVE parts to rank on; any creep that can move takes a contested tile first.
+			Movement.announce(creep, direction, commit => commit(-Infinity, pos => {
 				commitMove(creep, pos, C.ROAD_WEAROUT_POWER_CREEP);
 				context.didUpdate();
 			}));
@@ -162,6 +165,10 @@ registerObjectPreTickProcessor(PowerCreep, (creep, context) => {
 		}
 	}
 });
+
+PowerCreep.prototype['#applyNukeImpact'] = function(this: PowerCreep, _nuke: RoomObject, context: ProcessorContext) {
+	killPowerCreep(this, context);
+};
 
 registerObjectTickProcessor(PowerCreep, (creep, context) => {
 	// Settle damage deferred by `#applyDamage`

--- a/packages/xxscreeps/mods/mmo/powercreep/test.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/test.ts
@@ -4,8 +4,10 @@ import * as User from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { RoomPosition, getPositionInDirection } from 'xxscreeps/game/position.js';
 import { create as createConstructionSite } from 'xxscreeps/mods/classic/construction/construction-site.js';
+import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
 import { create as createRoad } from 'xxscreeps/mods/classic/road/road.js';
 import { lookForStructureAt, lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
+import { create as createNuke } from 'xxscreeps/mods/modern/nuker/nuke.js';
 import { create as createPowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
@@ -225,6 +227,46 @@ describe('mods/mmo/powercreep', () => {
 		});
 	}));
 
+	// A power creep and two creeps — one bare, one weighed down by a WORK part — around the open
+	// tile at (25, 24).
+	const moveTieSim = simulate({
+		W1N1: room => {
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = owner;
+			const alice = createSpawnedPowerCreep(
+				new RoomPosition(25, 23, 'W1N1'),
+				createPowerCreep('pc1', 'Alice', C.POWER_CLASS.OPERATOR, owner));
+			alice['#ageTime'] = 1000;
+			room['#insertObject'](alice);
+			room['#insertObject'](createCreep(new RoomPosition(25, 25, 'W1N1'), [ C.MOVE ], 'bare', owner));
+			room['#insertObject'](createCreep(new RoomPosition(26, 24, 'W1N1'), [ C.WORK, C.MOVE ], 'laden', owner));
+		},
+	});
+
+	test('a power creep loses a movement tie to a bare creep', () => moveTieSim(async ({ player, tick }) => {
+		await player(owner, Game => {
+			assert.strictEqual(Game.creeps.bare?.move(C.TOP), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.move(C.BOTTOM), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.creeps.bare?.pos.isEqualTo(25, 24), true);
+			assert.strictEqual(Game.powerCreeps.Alice?.pos.isEqualTo(25, 23), true);
+		});
+	}));
+
+	test('a power creep loses a movement tie to a laden creep', () => moveTieSim(async ({ player, tick }) => {
+		await player(owner, Game => {
+			assert.strictEqual(Game.creeps.laden?.move(C.LEFT), C.OK);
+			assert.strictEqual(Game.powerCreeps.Alice?.move(C.BOTTOM), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			assert.strictEqual(Game.creeps.laden?.pos.isEqualTo(25, 24), true);
+			assert.strictEqual(Game.powerCreeps.Alice?.pos.isEqualTo(25, 23), true);
+		});
+	}));
+
 	test('a spawned power creep crosses a room border', () => creepSim(async ({ player, poke, peekRoom, tick, shard }) => {
 		const id = await createAlice(shard.db);
 		await player(owner, Game => {
@@ -410,6 +452,51 @@ describe('mods/mmo/powercreep', () => {
 		});
 		const [ entry ] = await Model.loadRoster(shard.db, owner);
 		assert.ok(entry!.spawnCooldownTime > Date.now());
+	}));
+
+	test('a nuke impact routes death through the tombstone + respawn cooldown', () => creepSim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		// Land outside blast range of the creep: the room-wide sweep is what kills it.
+		await poke('W1N1', owner, (Game, room) => {
+			room['#insertObject'](createNuke(new RoomPosition(40, 40, 'W1N1'), 'W2N1', Game.time + 2));
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			// Still alive on the approach tick; death lands exactly at impact.
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 1);
+		});
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_TOMBSTONES).length, 1);
+		});
+		const [ entry ] = await Model.loadRoster(shard.db, owner);
+		assert.ok(entry!.spawnCooldownTime > Date.now());
+	}));
+
+	test('a nuke impact in blast range buries the creep exactly once', () => creepSim(async ({ player, poke, peekRoom, tick, shard }) => {
+		const id = await createAlice(shard.db);
+		// The nuke predates the creep so it ticks first at impact: the sweep kill and the blast
+		// damage dealt to the same creep settle in one pass, which must not bury it twice.
+		await poke('W1N1', owner, (Game, room) => {
+			room['#insertObject'](createNuke(new RoomPosition(25, 25, 'W1N1'), 'W2N1', Game.time + 3));
+		});
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+		});
+		await tick();
+		await tick();
+		await tick();
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room['#lookFor'](C.LOOK_POWER_CREEPS).length, 0);
+			assert.strictEqual(room['#lookFor'](C.LOOK_TOMBSTONES).length, 1);
+		});
 	}));
 
 	test('spawning a creep you do not own is rejected', () => creepSim(async ({ player }) => {

--- a/packages/xxscreeps/mods/modern/nuker/processor.ts
+++ b/packages/xxscreeps/mods/modern/nuker/processor.ts
@@ -1,3 +1,4 @@
+import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import { hooks, registerIntentProcessor, registerObjectTickProcessor } from 'xxscreeps/engine/processor/index.js';
 import { invertedNumericComparator, mappedComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -14,7 +15,7 @@ import { StructureNuker, checkLaunchNuke } from './nuker.js';
 declare module 'xxscreeps/game/object.js' {
 	interface RoomObject {
 		// eslint-disable-next-line @typescript-eslint/method-signature-style
-		'#applyNukeImpact'(nuke: RoomObject): void;
+		'#applyNukeImpact'(nuke: RoomObject, context: ProcessorContext): void;
 	}
 }
 
@@ -63,7 +64,7 @@ registerObjectTickProcessor(Nuke, (nuke, context) => {
 	if (timeToLand > 0) {
 		context.wakeAt(nuke['#landTime']);
 	} else if (timeToLand === 0) {
-		applyNukeImpact(nuke);
+		applyNukeImpact(nuke, context);
 		context.setActive();
 	} else if (timeToLand === -1) {
 		nuke.room['#removeObject'](nuke);
@@ -71,12 +72,13 @@ registerObjectTickProcessor(Nuke, (nuke, context) => {
 	}
 });
 
-function applyNukeImpact(nuke: Nuke) {
+function applyNukeImpact(nuke: Nuke, context: ProcessorContext) {
 	const { room } = nuke;
 
-	// Apply immediate destruction of creeps, resources, and others
-	for (const object of room['#immediateObjects']()) {
-		object['#applyNukeImpact'](nuke);
+	// Apply immediate destruction of creeps, resources, and others. Materialized first so the sweep
+	// skips objects the impact itself inserts, like a killed power creep's tombstone.
+	for (const object of [ ...room['#immediateObjects']() ]) {
+		object['#applyNukeImpact'](nuke, context);
 	}
 
 	// 5x5 blast: rampart on tile absorbs first, residual hits non-rampart structures.


### PR DESCRIPTION
Two power creep gaps:

- **Movement ties.** With no MOVE parts to rank on, a power creep now loses a contested tile to any creep that can move (priority `-Infinity`; the previous flat `1` beat weighed-down creeps).
- **Nuke impact.** Power creeps now die when a nuke lands, through the same death path as suicide and old age — tombstone plus account respawn cooldown. `'#applyNukeImpact'` gains a `ProcessorContext` parameter because the roster writeback rides `context.task`. The impact sweep materializes its object list first so it skips objects the impact itself inserts (the killed creep's tombstone), and `killPowerCreep` bails when the creep is already destroyed: the room-wide sweep and the creep's settled blast damage can each kill the same creep in one tick pass, which must not bury it twice.

## Validation

- `mods/mmo/powercreep` tests: movement ties against a bare and a laden creep; nuke death out of blast range (sweep path — tombstone + respawn cooldown) and in blast range (buried exactly once — fails `2 !== 1` without the `killPowerCreep` guard). Full mod suite 35/35, nuker 9/9.
- screeps-ok: `MOVE-POWER-001` (power creep loses a movement collision tie to a regular creep) and `NUKE-IMPACT-008:powerCreepRoomwideRemoved` (object-type outcome at nuke impact matches the matrix) — both fail on the base commit and pass with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
