### PR TITLE
scripts: move payload import/export onto per-mod codecs

### DIFF
--- a/.changeset/payload-codec.md
+++ b/.changeset/payload-codec.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Moved payload import/export onto per-mod codecs registered through the terrain slot.

--- a/packages/xxscreeps/mods/classic/controller/terrain.ts
+++ b/packages/xxscreeps/mods/classic/controller/terrain.ts
@@ -21,6 +21,15 @@ hooks.register('roomGenerator', {
 	},
 });
 
+hooks.register('payload', {
+	marker: '@',
+	encode: object => object instanceof StructureController ? {} : undefined,
+	decode(meta, room) {
+		room['#user'] = null;
+		return new StructureController();
+	},
+});
+
 declare module 'xxscreeps/scripts/symbols.js' {
 	interface GenerateRoomOptions {
 		/**

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -69,9 +69,31 @@ hooks.register('roomGenerator', {
 	},
 });
 
+hooks.register('payload', {
+	marker: 'M',
+	encode: object => object instanceof Mineral ? {
+		density: object.density,
+		mineral: object.mineralType,
+	} : undefined,
+	decode(meta) {
+		const mineral = new Mineral();
+		mineral.density = meta.density!;
+		mineral.mineralType = meta.mineral!;
+		mineral.mineralAmount = C.MINERAL_DENSITY[mineral.density]!;
+		return mineral;
+	},
+});
+
 declare module 'xxscreeps/scripts/symbols.js' {
 	interface GenerateRoomOptions {
 		/** Mineral type, or `false` for no mineral; omit for a random type. */
 		mineral?: ResourceType | false;
+	}
+
+	interface PayloadObject {
+		/** Mineral density, one of the `DENSITY_*` levels. */
+		density?: number;
+		/** The type of mineral deposited. */
+		mineral?: ResourceType;
 	}
 }

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -91,11 +91,33 @@ hooks.register('roomGenerator', {
 	},
 });
 
+// A payload records ownership only as the presence of a controller, so a source reads back at
+// keeper or neutral capacity and never at an owner's. Which of the two can't be told from the tile
+// either -- the controller's marker may come after this one -- so it rides the metadata.
+hooks.register('payload', {
+	marker: 'E',
+	encode: object => object instanceof Source ? {
+		...object.energyCapacity === C.SOURCE_ENERGY_KEEPER_CAPACITY && { keeper: true },
+	} : undefined,
+	decode(meta) {
+		const source = new Source();
+		source.energy = source.energyCapacity = meta.keeper === true
+			? C.SOURCE_ENERGY_KEEPER_CAPACITY
+			: C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
+		return source;
+	},
+});
+
 declare module 'xxscreeps/scripts/symbols.js' {
 	interface GenerateRoomOptions {
 		/** Number of sources; omit for a random 1 or 2. */
 		sources?: number;
 		/** Whether keeper lairs guard each source and the mineral. Default is false. */
 		keeperLairs?: boolean;
+	}
+
+	interface PayloadObject {
+		/** Whether the source holds a controller-less room's larger energy capacity. */
+		keeper?: boolean;
 	}
 }

--- a/packages/xxscreeps/scripts/payload.ts
+++ b/packages/xxscreeps/scripts/payload.ts
@@ -73,10 +73,11 @@ async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Pro
 		return { marker: object?.marker ?? terrainMask[terrain.get(xx, yy)], meta: object?.meta };
 	}) ]) ];
 	const layout = cells.map(row => row.map(cell => cell.marker).join(''));
-	const metadata = [ ...Fn.pipe(
+	const metadata = Fn.pipe(
 		cells,
 		$$ => Fn.transform($$, row => Fn.map(row, cell => cell.meta)),
-		$$ => Fn.filter($$)) ];
+		$$ => Fn.filter($$),
+		$$ => [ ...$$ ]);
 	return { layout, ...metadata.length > 0 && { objects: metadata } };
 }
 

--- a/packages/xxscreeps/scripts/payload.ts
+++ b/packages/xxscreeps/scripts/payload.ts
@@ -1,0 +1,150 @@
+import type { PayloadCodec, PayloadObject } from './symbols.js';
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { Terrain } from 'xxscreeps/game/terrain.js';
+import { compositeComparator, mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import * as MapSchema from 'xxscreeps/game/map.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { Room } from 'xxscreeps/game/room/index.js';
+import { parseRoomName } from 'xxscreeps/game/room/name.js';
+import { TerrainWriter, packExits } from 'xxscreeps/game/terrain.js';
+import { computeRoomMeta } from 'xxscreeps/mods/modern/sector/terrain.js';
+import { makeWriter } from 'xxscreeps/schema/write.js';
+import { hooks } from './symbols.js';
+import 'xxscreeps:mods/game';
+import 'xxscreeps:mods/terrain';
+
+/** One room of a payload: 50 lines of 50 characters, plus metadata for the markers among them. */
+export interface PayloadRoom {
+	layout: string[];
+	objects?: PayloadObject[];
+}
+
+/** An authored world: every room's terrain and objects, by room name. */
+export type Payload = Record<string, PayloadRoom>;
+
+// Index 3 is wall+swamp, which reads back as wall: `Terrain.get` documents three values, and
+// `packExits` would read anything else as a border opening.
+const terrainMask = [ ' ', '#', ',', '?' ];
+const terrainValues = [ 0, C.TERRAIN_MASK_WALL, C.TERRAIN_MASK_SWAMP, C.TERRAIN_MASK_WALL ];
+
+// Codecs by the character they own. A marker colliding with terrain or with another mod's would
+// silently take over that character's tiles on import, so it fails here instead.
+const codecs = function() {
+	const byMarker = new Map<string, PayloadCodec>();
+	for (const codec of hooks.map('payload')) {
+		if (codec.marker.length !== 1) {
+			throw new Error(`Payload marker '${codec.marker}' must be one character`);
+		} else if (terrainMask.includes(codec.marker)) {
+			throw new Error(`Payload marker '${codec.marker}' is reserved for terrain`);
+		} else if (byMarker.has(codec.marker)) {
+			throw new Error(`Payload marker '${codec.marker}' is registered twice`);
+		}
+		byMarker.set(codec.marker, codec);
+	}
+	return byMarker;
+}();
+
+// Objects no codec claims -- creeps, roads, anything a payload doesn't carry -- yield undefined and
+// leave their tile's terrain showing.
+function encodeObject(object: RoomObject) {
+	return Fn.find(Fn.map(codecs.values(), codec => {
+		const fields = codec.encode(object);
+		return fields === undefined ? undefined : { marker: codec.marker, meta: { id: object.id, ...fields } };
+	}), nonNullPredicate);
+}
+
+async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Promise<PayloadRoom> {
+	const room = await shard.loadRoom(roomName);
+	const objects = Fn.pipe(
+		room['#objects'],
+		$$ => Fn.map($$, object => {
+			const encoded = encodeObject(object);
+			return encoded === undefined ? undefined : [ `${object.pos.x},${object.pos.y}`, encoded ] as const;
+		}),
+		$$ => Fn.filter($$),
+		$$ => new Map($$));
+	// Metadata rides the layout's scan order and nothing else, so both come off one resolved array.
+	const cells = [ ...Fn.map(Fn.range(50), yy => [ ...Fn.map(Fn.range(50), xx => {
+		const object = objects.get(`${xx},${yy}`);
+		return { marker: object?.marker ?? terrainMask[terrain.get(xx, yy)], meta: object?.meta };
+	}) ]) ];
+	const layout = cells.map(row => row.map(cell => cell.marker).join(''));
+	const metadata = [ ...Fn.pipe(
+		cells,
+		$$ => Fn.transform($$, row => Fn.map(row, cell => cell.meta)),
+		$$ => Fn.filter($$)) ];
+	return { layout, ...metadata.length > 0 && { objects: metadata } };
+}
+
+/**
+ * Renders every room of `shard` as a terrain layout, with each object a registered codec claims
+ * folded in as that codec's character plus an entry in the room's metadata.
+ */
+export async function exportPayload(shard: Shard): Promise<Payload> {
+	const world = await shard.loadWorld();
+	// Sort map so that rooms will be continuous in the JSON top to bottom, left to right.
+	const rooms = [ ...world.entries() ].sort(compositeComparator<readonly [ string, Terrain ]>([
+		mappedNumericComparator(([ roomName ]) => parseRoomName(roomName).rx),
+		mappedNumericComparator(([ roomName ]) => parseRoomName(roomName).ry),
+	]));
+	return Fn.fromEntries(await Fn.mapAwait(rooms, async ([ roomName, terrain ]) => [
+		roomName,
+		await exportRoom(shard, roomName, terrain),
+	] as const));
+}
+
+function importRoom(roomName: string, info: PayloadRoom) {
+	const terrain = new TerrainWriter();
+	const room = new Room();
+	room.name = roomName;
+	const metadata = (info.objects ?? []).values();
+	for (const [ yy, line ] of info.layout.entries()) {
+		for (const [ xx, character ] of [ ...line as Iterable<string> ].entries()) {
+			const value = terrainValues[terrainMask.indexOf(character)];
+			if (value !== undefined) {
+				terrain.set(xx, yy, value);
+				continue;
+			}
+			const codec = codecs.get(character);
+			if (codec === undefined) {
+				throw new Error(`Room ${roomName} holds unregistered character '${character}'`);
+			}
+			const meta = metadata.next().value;
+			if (meta === undefined) {
+				throw new Error(`Room ${roomName} holds more markers than metadata`);
+			}
+			terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
+			const object = codec.decode(meta, room);
+			object.id = meta.id;
+			object.pos = new RoomPosition(xx, yy, roomName);
+			object['#posId'] = object.pos['#id'];
+			room['#insertObject'](object);
+		}
+	}
+	room['#flushObjects'](null);
+	return { room, terrain };
+}
+
+/**
+ * Rebuilds every room a payload describes, along with the world terrain blob a shard's `terrain`
+ * key holds. Performs no storage I/O; the caller saves what it needs.
+ */
+export function importPayload(payload: Payload) {
+	const parsedRooms = Object.entries(payload).map(([ roomName, info ]) => importRoom(roomName, info));
+	const roomNames = new Set(Fn.map(parsedRooms, ({ room }) => room.name));
+	const terrainMap = new Map(Fn.map(parsedRooms, ({ room, terrain }) => [
+		room.name, {
+			exits: packExits(terrain),
+			terrain,
+			...computeRoomMeta(room.name, roomNames),
+		},
+	]));
+	return {
+		rooms: parsedRooms.map(({ room }) => room),
+		terrain: makeWriter(MapSchema.schema)(terrainMap),
+	};
+}

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -54,6 +54,33 @@ export interface RoomGeneratorContext {
 	tagsAt: (position: RoomPosition) => ReadonlySet<string>;
 }
 
+/**
+ * One entry of a room's `objects` array in a payload. The engine owns `id`; each codec augments
+ * this interface with the fields it encodes.
+ */
+export interface PayloadObject {
+	id: string;
+}
+
+/**
+ * Reads and writes the objects of one type in a payload's room layouts. Registered from the mod's
+ * `terrain.ts`, the slot `scripts/payload.js` resolves its codecs from.
+ */
+export interface PayloadCodec {
+	/**
+	 * The layout character this codec owns, standing in for the terrain character of the tile its
+	 * object occupies. May not be one the terrain alphabet spells, and that tile reads back as wall.
+	 */
+	marker: string;
+	/** The fields this codec encodes for `object`, or undefined when it doesn't own the object. */
+	encode: (object: RoomObject) => Omit<PayloadObject, 'id'> | undefined;
+	/**
+	 * Rebuilds the object `meta` describes. The engine stamps its id and position and inserts it
+	 * into `room`, which is passed only for the room-level state an object implies.
+	 */
+	decode: (meta: PayloadObject, room: Room) => RoomObject;
+}
+
 export const hooks = makeHookRegistration<{
 	roomGenerator: {
 		/** Passes run in ascending order; constraints may consult earlier placements. */
@@ -64,4 +91,5 @@ export const hooks = makeHookRegistration<{
 		 */
 		generate: (context: RoomGeneratorContext) => boolean;
 	};
+	payload: PayloadCodec;
 }>();

--- a/packages/xxscreeps/test/export.ts
+++ b/packages/xxscreeps/test/export.ts
@@ -1,79 +1,12 @@
 import * as fs from 'node:fs/promises';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
-import { Fn } from 'xxscreeps/functional/fn.js';
-import { parseRoomName } from 'xxscreeps/game/room/name.js';
-import * as C from 'xxscreeps:mods/constants';
-import 'xxscreeps:mods/game';
-
-export type Payload = typeof payload;
-
-await using db = await Database.connect();
-await using shard = await Shard.connect(db, 'shard0');
-const map = await shard.loadWorld();
-const terrainMask = [ ' ', '#', ',', '?' ];
-
-// Sort map so that rooms will be continuous in the JSON top to bottom, left to right.
-const roomNames = [ ...Fn.map(map.entries(), ([ roomName ]) => roomName) ].sort((left, right) => {
-	const leftR = parseRoomName(left);
-	const rightR = parseRoomName(right);
-	return (leftR.rx - rightR.rx) || (leftR.ry - rightR.ry);
-});
-const entriesSorted = new Map(Fn.map(roomNames, roomName => [ roomName, map.map.getRoomTerrain(roomName) ]));
-
-// Render room terrain + object string representation
-const payload = Fn.fromEntries(await Fn.pipe(
-	entriesSorted,
-	$$ => Fn.map($$, async ([ roomName, terrain ]) => {
-		const room = await shard.loadRoom(roomName);
-		const objects = Fn.pipe(
-			room['#objects'],
-			$$ => Fn.map($$, object => {
-				const info = function() {
-					// eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-					switch (object['#lookType']) {
-						case 'structure':
-							return object.structureType === C.STRUCTURE_CONTROLLER ? { marker: '@' } : undefined;
-						case 'mineral': return {
-							marker: 'M',
-							meta: {
-								density: object.density,
-								mineral: object.mineralType,
-							},
-						};
-						case 'source': return { marker: 'E' };
-						default:
-					}
-				}();
-				if (info) {
-					return [ `${object.pos.x},${object.pos.y}`, {
-						marker: info.marker,
-						meta: {
-							id: object.id,
-							...info.meta,
-						},
-					} ] as const;
-				}
-			}),
-			$$ => Fn.filter($$),
-			$$ => new Map($$));
-		const metadata: typeof objects extends Map<any, { meta: infer T }> ? T[] : never = [];
-		const layout = [ ...Fn.map(Fn.range(50), yy => [
-			...Fn.map(Fn.range(50), xx => {
-				const object = objects.get(`${xx},${yy}`);
-				if (object) {
-					metadata.push(object.meta);
-					return object.marker;
-				} else {
-					return terrainMask[terrain.get(xx, yy)];
-				}
-			}),
-		].join('')) ];
-		return [ roomName, { layout, objects: metadata.length > 0 ? metadata : undefined } ] as const;
-	}),
-	$$ => Promise.all($$)));
+import { exportPayload } from 'xxscreeps/scripts/payload.js';
 
 const file = process.argv[2];
 if (!file?.endsWith('.json')) {
 	throw new Error('Destination must be .json file');
 }
-await fs.writeFile(file, JSON.stringify(payload, null, 1));
+
+await using db = await Database.connect();
+await using shard = await Shard.connect(db, 'shard0');
+await fs.writeFile(file, JSON.stringify(await exportPayload(shard), null, 1));

--- a/packages/xxscreeps/test/import.ts
+++ b/packages/xxscreeps/test/import.ts
@@ -1,99 +1,20 @@
-import type { Payload } from './export.js';
-import type { RoomObject } from 'xxscreeps/game/object.js';
+import type { Payload } from 'xxscreeps/scripts/payload.js';
 import * as fs from 'node:fs/promises';
 import { loadTerrain } from 'xxscreeps/driver/pathfinder/pathfinder.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
-import { Room } from 'xxscreeps/game/room/index.js';
-import { TerrainWriter, packExits } from 'xxscreeps/game/terrain.js';
-import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
-import { Mineral } from 'xxscreeps/mods/classic/mineral/mineral.js';
-import { Source } from 'xxscreeps/mods/classic/source/source.js';
-import { computeRoomMeta } from 'xxscreeps/mods/modern/sector/terrain.js';
-import { makeWriter } from 'xxscreeps/schema/write.js';
-import * as C from 'xxscreeps:mods/constants';
+import { importPayload } from 'xxscreeps/scripts/payload.js';
 import { testRedis } from './context.js';
 
 // Read file
 const root = new URL('../../test/', import.meta.url);
 const payload = JSON.parse(await fs.readFile(new URL('../test/data/shard.json', root), 'utf8')) as Payload;
 
-// Generate rooms
-const rooms = Object.entries(payload).map(([ roomName, info ]) => {
-	const terrain = new TerrainWriter();
-	const room = new Room();
-	room.name = roomName;
-
-	let ii = 0;
-	type Metadata = Extract<Payload[string]['objects'], any[]>[any];
-	const saveObject = (object: RoomObject, xx: number, yy: number, fn?: (metadata: Metadata) => void) => {
-		const metadata = info.objects![ii++]!;
-		object.id = metadata.id;
-		object.pos = new RoomPosition(xx, yy, room.name);
-		object['#posId'] = object.pos['#id'];
-		fn?.(metadata);
-		room['#insertObject'](object);
-	};
-
-	for (const [ yy, line ] of info.layout.entries()) {
-		for (const [ xx, character ] of [ ...line as Iterable<string> ].entries()) {
-			switch (character) {
-				case ' ': break;
-				case '#':
-					terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
-					break;
-
-				case ',':
-					terrain.set(xx, yy, C.TERRAIN_MASK_SWAMP);
-					break;
-
-				case '@': {
-					terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
-					const controller = new StructureController();
-					room['#user'] = null;
-					saveObject(controller, xx, yy);
-					break;
-				}
-
-				case 'E': {
-					terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
-					const source = new Source();
-					source.energy =
-						source.energyCapacity = C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
-					saveObject(source, xx, yy);
-					break;
-				}
-
-				case 'M': {
-					terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
-					const mineral = new Mineral();
-					saveObject(mineral, xx, yy, metadata => {
-						mineral.density = metadata.density!;
-						mineral.mineralType = metadata.mineral!;
-						mineral.mineralAmount = C.MINERAL_DENSITY[mineral.density]!;
-					});
-				}
-			}
-		}
-	}
-	room['#flushObjects'](null);
-	return { room, terrain };
-});
-
-// Initialize world terrain blob & path finder
-const roomNames = new Set(Fn.map(rooms, ({ room }) => room.name));
-const terrainMap = new Map(Fn.map(rooms, ({ room, terrain }) => [
-	room.name, {
-		exits: packExits(terrain),
-		terrain,
-		...computeRoomMeta(room.name, roomNames),
-	},
-]));
-const terrain = makeWriter(MapSchema.schema)(terrainMap);
+const { rooms, terrain } = importPayload(payload);
 export const testWorld = new MapSchema.World('test', terrain);
+// Seeds the path finder's global terrain as a side effect of importing this module.
 loadTerrain(testWorld);
 
 // Default users
@@ -150,8 +71,8 @@ export async function instantiateTestShard() {
 	await Promise.all([
 		shard.data.set('terrain', terrain),
 		shard.data.set('time', shard.time),
-		shard.data.sAdd('rooms', [ ...Fn.map(rooms, room => room.room.name) ]),
-		Promise.all(Fn.map(rooms, async ({ room }) => {
+		shard.data.sAdd('rooms', rooms.map(room => room.name)),
+		Promise.all(Fn.map(rooms, async room => {
 			await shard.saveRoom(room.name, shard.time, room);
 			await shard.copyRoomFromPreviousTick(room.name, shard.time + 1);
 		})),


### PR DESCRIPTION
The Payload object set is open -- mods define objects -- but the hardcoded switches in `test/export.ts` / `test/import.ts` assume it's closed, so an object no branch knows about silently vanishes on export. The mods' `terrain.ts` files already carry that knowledge, since they author the same objects for room generation.

A `payload` hook kind beside `roomGenerator` lets each mod register `{ marker, encode, decode }` from the terrain slot it already provides, and the shared engine moved to `scripts/payload.ts` so the two test files consume the same code path a future `xxscreeps export` will. `scripts/scrape-world.ts` keeps its switch -- vanilla's object set really is closed.

Two latent fixes ride along. The importer hardcoded the neutral source capacity, which was complete until room generation added an offline path that authors controller-less rooms; a source now records whether it carries the larger capacity, so its sources' capacity survives a round trip. Ownership is only ever recorded as controller presence, so a source reads back keeper or neutral and never an owner's. And `'?'` (wall+swamp) had no parse case and silently landed as plain -- it now reads as the wall it renders as.

A payload still carries controller, sources and minerals only: the keeper lairs and prebuilt extractor that a generated controller-less room also holds are dropped, as before, and each is now one registration away. `scripts/payload.ts` is where `xxscreeps export` would sit.

## Validation

`pnpm build` and `eslint --max-warnings 0` clean; 536/536 tests pass. Re-exporting `test/data/shard.json` after import produced a byte-identical 367,712-byte payload on this branch and on main. Generated a source-keeper room and confirmed its sources encode and decode at 4000 while neutral rooms stay at 1500 and an owned room's 3000 reads back as 1500. Confirmed `'?'` parses to `TERRAIN_MASK_WALL` and that an unregistered character throws rather than becoming plain terrain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
