### PR TITLE
backend: hold a socket subscription's channel name until it stops sending

### DIFF
--- a/.changeset/socket-subscription-name-race.md
+++ b/.changeset/socket-subscription-name-race.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Stop a socket subscription from holding its channel name after it has been unsubscribed.

--- a/packages/xxscreeps/backend/socket.ts
+++ b/packages/xxscreeps/backend/socket.ts
@@ -36,6 +36,20 @@ export type SubscriptionEndpoint = {
 	subscribe: (this: SubscriptionInstance, parameters: Record<string, string>) => Promise<Effect> | Effect;
 };
 
+/**
+ * One subscription of a socket. A channel is addressed by its name alone, so a name must never be
+ * held by two of them at once. Tearing one down is asynchronous, which is why the name stays taken
+ * until the old subscription has finished stopping.
+ */
+interface Subscription {
+	/** Resolves once it is listening, to the effect which stops it. */
+	effect: Promise<Effect>;
+	/** Drops anything it sends from here on. Applied the moment the name is given up. */
+	mute: Effect;
+	/** Set once it has been unsubscribed; resolves once its listener is gone. */
+	stopped?: Promise<void>;
+}
+
 // Undocumented SockJS internals
 interface ConnectionWithSession extends Connection {
 	_session: {
@@ -146,25 +160,36 @@ export function installSocketHandlers(koa: Koa<State, Context>, context: Backend
 
 		// Set up subscription bookkeeping for this socket
 		let user: string | undefined;
-		const subscriptions = new Map<string, Promise<Effect>>();
+
+		const subscriptions = new Map<string, Subscription>();
+
+		/** Stops a subscription and gives up its name. Idempotent: the same stop is handed back. */
+		const stop = (name: string, subscription: Subscription) => subscription.stopped ?? function() {
+			// Tearing the listener down doesn't reach a callback which is already running, so the
+			// subscription is muted here instead of when the effect eventually resolves.
+			subscription.mute();
+			const stopped = async function() {
+				try {
+					(await subscription.effect)();
+				} catch (error) {
+					console.error(error);
+				} finally {
+					// A resubscribe may already have claimed the name, and that one is not ours to drop.
+					if (subscriptions.get(name) === subscription) {
+						subscriptions.delete(name);
+					}
+					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+					pendingTeardowns.delete(stopped!);
+				}
+			}();
+			subscription.stopped = stopped;
+			pendingTeardowns.add(stopped);
+			return stopped;
+		}();
+
 		const close = () => {
 			void async function() {
-				await Fn.mapAwait(subscriptions, async ([ name, subscription ]) => {
-					subscriptions.delete(name);
-					const teardown = async function() {
-						try {
-							const effect = await subscription;
-							effect();
-						} catch (error) {
-							console.error(error);
-						} finally {
-							// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-							pendingTeardowns.delete(teardown!);
-						}
-					}();
-					pendingTeardowns.add(teardown);
-					await teardown;
-				});
+				await Fn.mapAwait(subscriptions, ([ name, subscription ]) => stop(name, subscription));
 			}();
 			connection.close();
 		};
@@ -217,18 +242,32 @@ export function installSocketHandlers(koa: Koa<State, Context>, context: Backend
 						const result = handler.pattern.exec(name!);
 						if (result) {
 							// Don't let subscriptions collide
-							if (subscriptions.has(name!)) {
+							const previous = subscriptions.get(name!);
+							if (previous !== undefined && previous.stopped === undefined) {
 								return;
 							}
 							const encodedName = JSON.stringify(name);
+							let muted = false as boolean;
 							const instance: SubscriptionInstance = {
 								context,
 								user,
-								send: jsonEncodedMessage => connection.write(`[${encodedName},${jsonEncodedMessage}]`),
+								send: jsonEncodedMessage => {
+									if (!muted) {
+										connection.write(`[${encodedName},${jsonEncodedMessage}]`);
+									}
+								},
 							};
-							const subscription = Promise.resolve(handler.subscribe.call(instance, result.groups!));
+							// The client gives a channel up and claims it again as it moves between rooms, so a
+							// resubscribe waits the old subscription out rather than running alongside it.
+							const subscription: Subscription = {
+								effect: async function() {
+									await previous?.stopped;
+									return handler.subscribe.call(instance, result.groups!);
+								}(),
+								mute: () => { muted = true; },
+							};
 							subscriptions.set(name!, subscription);
-							subscription.catch(error => {
+							subscription.effect.catch(error => {
 								console.error(error);
 								close();
 							});
@@ -240,10 +279,9 @@ export function installSocketHandlers(koa: Koa<State, Context>, context: Backend
 				const unsubscriptionRequest = /^unsubscribe (?<name>.+)$/.exec(message);
 				if (unsubscriptionRequest) {
 					const { name } = unsubscriptionRequest.groups!;
-					const unlistener = subscriptions.get(name!);
-					if (unlistener) {
-						subscriptions.delete(name!);
-						unlistener.then(unlistener => unlistener(), console.error);
+					const subscription = subscriptions.get(name!);
+					if (subscription !== undefined) {
+						void stop(name!, subscription);
 					}
 				}
 			}

--- a/packages/xxscreeps/backend/sockets/room.ts
+++ b/packages/xxscreeps/backend/sockets/room.ts
@@ -62,9 +62,11 @@ export async function subscribeToRoom(shard: Shard, roomName: string, listener: 
 		};
 
 		// Listen for room updates
-		disposable.defer(await getRoomChannel(shard, roomName).listen(() => {
-			// This happens before the tick is totally done
-			didUpdate = true;
+		disposable.defer(await getRoomChannel(shard, roomName).listen(event => {
+			if (event.type === 'didUpdate') {
+				// This happens before the tick is totally done
+				didUpdate = true;
+			}
 		}));
 
 		// Listen for game time updates

--- a/packages/xxscreeps/backend/sockets/room.ts
+++ b/packages/xxscreeps/backend/sockets/room.ts
@@ -62,11 +62,9 @@ export async function subscribeToRoom(shard: Shard, roomName: string, listener: 
 		};
 
 		// Listen for room updates
-		disposable.defer(await getRoomChannel(shard, roomName).listen(event => {
-			if (event.type === 'didUpdate') {
-				// This happens before the tick is totally done
-				didUpdate = true;
-			}
+		disposable.defer(await getRoomChannel(shard, roomName).listen(() => {
+			// This happens before the tick is totally done
+			didUpdate = true;
 		}));
 
 		// Listen for game time updates
@@ -126,8 +124,6 @@ export const roomSubscription: SubscriptionEndpoint = {
 	async subscribe(parameters) {
 		let previous: any;
 		let previousTime = -1;
-		let skipUntil = 0;
-		let missedUpdateDuringSkip = false;
 		const { shard } = this.context;
 		const seenUsers = new Set<string>();
 		const roomName = parameters.room!;
@@ -142,16 +138,7 @@ export const roomSubscription: SubscriptionEndpoint = {
 		// Listen for room updates. Must be done after hooks are resolved because `update` will call hooks.
 		await acquireWith(
 			fn => disposable.defer(fn),
-			subscribeToRoom(shard, roomName, (room, time, roomDidUpdate) => mustNotReject(async () => {
-				if (Date.now() < skipUntil) {
-					if (roomDidUpdate) {
-						missedUpdateDuringSkip = true;
-					}
-					return;
-				}
-				const didUpdate = roomDidUpdate || missedUpdateDuringSkip;
-				missedUpdateDuringSkip = false;
-
+			subscribeToRoom(shard, roomName, (room, time, didUpdate) => mustNotReject(async () => {
 				// Render current room state
 				room['#initialize']();
 				const visibleUsers = new Set<string>();
@@ -209,18 +196,6 @@ export const roomSubscription: SubscriptionEndpoint = {
 				this.send(JSON.stringify(response));
 				previousTime = time;
 			})),
-
-			getRoomChannel(shard, roomName).listen(event => {
-				if (event.type === 'willSpawn') {
-					// There is a race condition in the client where if you send an update while placing your
-					// initial spawn the renderer will break until next refresh. It happens because the client
-					// unsubscribes and immediately resubscribes to the channel. Since channels are only
-					// addressed by the name of the channel messages from the old subscription will be sent to
-					// the new handlers. Shut down event for a full second when someone is spawning in the
-					// current room to avoid this condition.
-					skipUntil = Date.now() + 1000;
-				}
-			}),
 		);
 
 		// Disconnect on socket hangup

--- a/packages/xxscreeps/engine/processor/model.ts
+++ b/packages/xxscreeps/engine/processor/model.ts
@@ -19,8 +19,7 @@ export function getProcessorChannel(shard: Shard) {
 
 export function getRoomChannel(shard: Shard, roomName: string) {
 	type Message =
-		{ type: 'didUpdate'; time: number } |
-		{ type: 'willSpawn' };
+		{ type: 'didUpdate'; time: number };
 	return new Channel<Message>(shard.pubsub, `processor/room/${roomName}`);
 }
 

--- a/packages/xxscreeps/engine/processor/model.ts
+++ b/packages/xxscreeps/engine/processor/model.ts
@@ -1,3 +1,4 @@
+import type { NullMessage } from 'xxscreeps/engine/db/channel.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { RoomIntentPayload, SingleIntent } from 'xxscreeps/engine/processor/index.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
@@ -19,6 +20,7 @@ export function getProcessorChannel(shard: Shard) {
 
 export function getRoomChannel(shard: Shard, roomName: string) {
 	type Message =
+		NullMessage |
 		{ type: 'didUpdate'; time: number };
 	return new Channel<Message>(shard.pubsub, `processor/room/${roomName}`);
 }

--- a/packages/xxscreeps/mods/classic/spawn/backend.ts
+++ b/packages/xxscreeps/mods/classic/spawn/backend.ts
@@ -3,7 +3,7 @@ import type { AnyStructure } from 'xxscreeps/mods/classic/structure/structure.js
 import { bindRenderer, hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
-import { getRoomChannel, pushIntentsForRoomNextTick, userToIntentRoomsSetKey, userToPresenceRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
+import { pushIntentsForRoomNextTick, userToIntentRoomsSetKey, userToPresenceRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { Game, runOneShot } from 'xxscreeps/game/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
@@ -147,9 +147,6 @@ hooks.register('route', {
 		if (lastSpawn !== null && now < Number(lastSpawn) + config.game.respawnTimeout * 3600 * 1000) {
 			throw new Error('Too soon after last respawn');
 		}
-
-		// Insert delay to workaround client bugs [see room socket]
-		await getRoomChannel(context.shard, roomName).publish({ type: 'willSpawn' });
 
 		// Ensure user has no objects
 		const roomNames = await context.shard.scratch.sMembers(userToIntentRoomsSetKey(userId));


### PR DESCRIPTION
A socket subscription gave up its channel name the moment it was unsubscribed, but tearing it down is asynchronous. In that window the old subscription kept writing to the socket, and a resubscribe of the same name was let through to run alongside it.

Surfaced while working on room decorations, but it has nothing to do with them — any client moving between rooms hits it.

## What the client does on a room change

The room view addresses its room socket as `room:<shard>/<room>`. When it navigates it unsubscribes that channel and subscribes the next one — and when it re-enters the same room, or rebuilds its renderer, it unsubscribes and resubscribes **the same name**, back to back.

At the same time its `$destroy` handler calls `GameRenderer.release()`, which runs `Assets.reset()` and empties pixi's asset cache, but leaves its own "renderer is ready" flag set. So a room update that still arrives after that point gets applied to a released renderer.
The missing flag reset is the client's own bug. What we were feeding it was the updates that arrive after it has let the channel go.

## The fix

A subscription now owns its channel name until it has actually stopped:

- **Unsubscribe mutes it immediately.** Tearing the listener down doesn't reach a callback that is already running, so `send` is gated by a flag flipped the moment the name is given up. Nothing reaches the client for a channel it no longer holds.
- **The name is freed when the teardown completes**, not when the unsubscribe arrives.
- **A resubscribe awaits the previous subscription's teardown** before it starts listening, instead of running alongside it. Two subscriptions can no longer write under one name.

`close()` goes through the same path, so a hangup and an unsubscribe tear down identically.

## Why the second commit drops the `willSpawn` workaround

`sockets/room.ts` dropped every room update for a full second after `willSpawn`, then folded what it had swallowed into the next one. Its comment named the cause exactly:

> There is a race condition in the client where if you send an update while placing your initial spawn the renderer will break until next refresh. It happens because the client unsubscribes and immediately resubscribes to the channel. Since channels are only addressed by the name of the channel messages from the old subscription will be sent to the new handlers.

That is the condition the first commit removes — at the point where it happens, for every channel, rather than by withholding updates from everyone watching a room and only for one known trigger.

## Testing

Verified against a local server with the official client behind `screeps-steamless-client`: placing a first spawn and moving between rooms both behave with the workaround gone, and the asset 404s are gone. No automated coverage — the socket layer has none today; a regression test would want to assert that a subscribe/unsubscribe/subscribe on one name stops the first listener before the second starts sending.
