### PR TITLE
pf: fix inverted `ignoreDestructibleStructures` obstacle check

### DIFF
--- a/.changeset/ignore-destructible-structures.md
+++ b/.changeset/ignore-destructible-structures.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Fix the `ignoreDestructibleStructures` pathing option, whose obstacle checker marked exactly the structures it was meant to path through, and every road and container along with them.

--- a/packages/xxscreeps/mods/classic/structure/structure.ts
+++ b/packages/xxscreeps/mods/classic/structure/structure.ts
@@ -288,11 +288,13 @@ export function lookForStructureAt<Type extends string>(room: Room, pos: RoomPos
 // Register pathfinding and movement rules
 const destructibleStructureTypes = new Set(Object.keys(C.CONSTRUCTION_COST));
 registerObstacleChecker(params => {
+	const { user } = params;
 	if (params.ignoreDestructibleStructures) {
+		// Anything which can be torn down is walked through, the rest still blocks
 		return object => object instanceof Structure &&
-			destructibleStructureTypes.has(object.structureType);
+			!destructibleStructureTypes.has(object.structureType) &&
+			object['#checkObstacle'](user);
 	} else {
-		const { user } = params;
 		return object => object instanceof Structure && object['#checkObstacle'](user);
 	}
 });

--- a/packages/xxscreeps/mods/classic/structure/test.ts
+++ b/packages/xxscreeps/mods/classic/structure/test.ts
@@ -1,5 +1,6 @@
-import { RoomPosition } from 'xxscreeps/game/position.js';
+import { RoomPosition, iterateNeighbors } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
+import { create as createWall } from 'xxscreeps/mods/classic/defense/wall.js';
 import { create as createExtractor } from 'xxscreeps/mods/classic/mineral/extractor.js';
 import { create as createRoad } from 'xxscreeps/mods/classic/road/road.js';
 import { create as createExtension } from 'xxscreeps/mods/classic/spawn/extension.js';
@@ -224,6 +225,37 @@ describe('mods/classic/structure', () => {
 				const hostile = Game.rooms.W8N1?.find(C.FIND_HOSTILE_STRUCTURES);
 				assert.ok(hostile);
 				assert.strictEqual(hostile.length, 0, 'should return empty array in unowned room');
+			});
+		}));
+	});
+
+	describe('ignoreDestructibleStructures', () => {
+		// A creep outside a wall ring, with a road on the way to the ring
+		const sim = simulate({
+			W9N1: room => {
+				room['#insertObject'](createCreep(new RoomPosition(28, 25, 'W9N1'), [ C.MOVE ], 'Walker', '100'));
+				room['#insertObject'](createRoad(new RoomPosition(27, 25, 'W9N1')));
+				for (const pos of iterateNeighbors(new RoomPosition(25, 25, 'W9N1'))) {
+					room['#insertObject'](createWall(pos));
+				}
+			},
+		});
+
+		test('walls block a path by default', () => sim(async ({ player }) => {
+			await player('100', Game => {
+				const path = Game.creeps.Walker!.pos.findPathTo(new RoomPosition(25, 25, 'W9N1'), { maxRooms: 1 });
+				assert.ok(!path.some(step => step.x === 25 && step.y === 25), 'path should not reach the walled center');
+			});
+		}));
+
+		test('walls are walked through when ignored', () => sim(async ({ player }) => {
+			await player('100', Game => {
+				const path = Game.creeps.Walker!.pos.findPathTo(new RoomPosition(25, 25, 'W9N1'), {
+					maxRooms: 1,
+					ignoreDestructibleStructures: true,
+				});
+				assert.ok(path.some(step => step.x === 25 && step.y === 25), 'path should run through the walls');
+				assert.ok(path.some(step => step.x === 27 && step.y === 25), 'the road should stay walkable');
 			});
 		}));
 	});


### PR DESCRIPTION
fix the `ignoreDestructibleStructures` pathing option, whose obstacle checker marked exactly the structures it was meant to path through, and every road and container along with them.