### PR TITLE
memory: shard-optional watch channel & client-visible editor errors

### DIFF
--- a/.changeset/memory-client-parity.md
+++ b/.changeset/memory-client-parity.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Accept shardless memory watch channels; return official error strings from memory editor routes.

--- a/packages/xxscreeps/mods/meta/memory/backend.ts
+++ b/packages/xxscreeps/mods/meta/memory/backend.ts
@@ -38,7 +38,9 @@ async function loadAndParse(shard: Shard, userId: string, path: string) {
 }
 
 hooks.register('subscription', {
-	pattern: /^user:(?<user>[^/]+)\/memory\/(?<shard>[^/]+)\/(?<path>.+)$/,
+	// The client only includes the shard segment when `Api.options.official` is set, so the Steam
+	// client in private-server mode subscribes without it. Same treatment as the `room:` channel.
+	pattern: /^user:(?<user>[^/]+)\/memory\/(?:(?<shard>[^/]+)\/)?(?<path>.+)$/,
 
 	subscribe(params) {
 		const { user, path } = params;
@@ -129,7 +131,7 @@ hooks.register('route', {
 			}
 		}();
 		if (value !== undefined && value.length > 1024 * 1024) {
-			throw new Error('Memory size is too large');
+			return { error: 'memory size is too large' };
 		}
 		const expression = function() {
 			if (path) {
@@ -139,7 +141,13 @@ hooks.register('route', {
 				return `Object.keys(Memory).forEach(key => delete Memory[key]); Object.assign(Memory, ${value}); undefined;`;
 			}
 		}();
-		await requestRunnerEval(context.shard, userId, expression, false);
+		try {
+			await requestRunnerEval(context.shard, userId, expression, false);
+		} catch (err) {
+			// `Runner did not respond` when the player's runner isn't ticking
+			console.error(err);
+			return { error: err instanceof Error ? err.message : String(err) };
+		}
 		return { ok: 1 };
 	}),
 });
@@ -166,7 +174,7 @@ hooks.register('route', {
 		}
 		const segmentId = Number(context.request.query.segment);
 		if (!isValidSegmentId(segmentId)) {
-			return { error: 'invalid segment' };
+			return { error: 'invalid segment ID' };
 		}
 		const blob = await loadMemorySegmentBlob(context.shard, userId, segmentId);
 		// Missing segments read as an empty string, same as `RawMemory.segments` in the runtime
@@ -200,10 +208,10 @@ hooks.register('route', {
 		}
 		const { segment, data } = context.request.body;
 		if (!isValidSegmentId(segment)) {
-			return { error: 'invalid segment' };
+			return { error: 'invalid segment ID' };
 		}
 		if (data.length > kMaxMemorySegmentLength) {
-			throw new Error('Memory segment size is too large');
+			return { error: 'length limit exceeded' };
 		}
 		await Promise.all([
 			saveMemorySegmentBlob(context.shard, userId, segment, utf16ToBuffer(data)),


### PR DESCRIPTION
Two client-compatibility fixes for the memory watcher/editor, verified against the official server (`backend-local`) and the reference client bundle.

**Shard-optional watch channel.** The client only includes the shard segment in the memory watch channel when `Api.options.official` is set, so the Steam client in private-server mode subscribes to `user:<id>/memory/<path>` — which never matched the previous pattern, leaving the memory watcher silently dead there. The pattern now treats the shard segment as optional, same as the `room:` and `roomMap2:` channels.

**Client-visible editor errors.** The memory and memory-segment POST routes threw on failure, which the top-level middleware turned into an empty 500 the client can't display. They now return `{error}` payloads using the official server's exact strings (`memory size is too large`, `length limit exceeded`, `invalid segment ID`), and a failing `requestRunnerEval` (e.g. the player's runner isn't ticking) is logged and reported the same way.
