### PR TITLE
controller: answer whether one room is controlled or reserved

### DIFF
--- a/.changeset/controller-room-queries.md
+++ b/.changeset/controller-room-queries.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `isRoomControlled` / `isRoomReserved` to the controller model for single-room queries.

--- a/packages/xxscreeps/mods/classic/controller/model.ts
+++ b/packages/xxscreeps/mods/classic/controller/model.ts
@@ -37,6 +37,14 @@ export function removeReservedRoom(shard: Shard, userId: string, roomName: strin
 	return shard.scratch.sRem(reservedRoomsKey(userId), [ roomName ]);
 }
 
+export function isRoomControlled(shard: Shard, userId: string, roomName: string): Promise<boolean> {
+	return shard.scratch.sIsMember(controlledRoomsKey(userId), roomName);
+}
+
+export function isRoomReserved(shard: Shard, userId: string, roomName: string): Promise<boolean> {
+	return shard.scratch.sIsMember(reservedRoomsKey(userId), roomName);
+}
+
 export async function incrementGlobalControlLevel(shard: Shard, userId: string, upgradePower: number) {
 	const gcl = await shard.db.data.hincrBy(User.infoKey(userId), 'gcl', upgradePower);
 	await globalControlChannel(shard, userId).publish({ type: 'gcl', gcl });


### PR DESCRIPTION
The model stores controlled and reserved rooms as sets but only ever handed back whole keys. A feature asking about a single room — the decorations mod I'm preparing checks room ownership before a placement — should not have to read the entire set to learn one membership.

Adds `isRoomControlled` / `isRoomReserved` to the controller model, plus a changeset. First of a small series leading up to a decorations mod; this one stands alone.