### PR TITLE
backend: give the version hook's serverData a shape

### DIFF
--- a/.changeset/version-serverdata-types.md
+++ b/.changeset/version-serverdata-types.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Type the `serverData` bag `version` hooks amend: named features with optional client menu entries.

--- a/packages/xxscreeps/backend/endpoints/version.ts
+++ b/packages/xxscreeps/backend/endpoints/version.ts
@@ -1,4 +1,5 @@
 import type { Endpoint } from 'xxscreeps/backend/index.js';
+import type { ServerData } from 'xxscreeps/backend/symbols.js';
 import { hooks } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 
@@ -10,7 +11,7 @@ export const VersionEndpoint: Endpoint = {
 	path: '/api/version',
 
 	execute() {
-		const serverData: Record<string, unknown> = {
+		const serverData: ServerData = {
 			features: [
 				{ name: 'auth', version: 1 },
 				{ name: 'official-like', version: 1 },

--- a/packages/xxscreeps/backend/symbols.ts
+++ b/packages/xxscreeps/backend/symbols.ts
@@ -30,6 +30,37 @@ export interface MapStatsPayload {
 	userIds: Set<string>;
 }
 
+/**
+ * A menu entry a feature contributes to the client's sidebar. The official client ships an empty
+ * router configuration and a sidebar holding only the built-in links; everything else is injected
+ * from here at connect time, which is why the route's client module rides along with the entry.
+ */
+export interface ClientMenuEntry {
+	/** Index of the sidebar section receiving the entry. */
+	section: number;
+	/** Position inside the section. Ignored when `after` names an entry. */
+	start?: number;
+	/** Label of the entry to insert after. */
+	after?: string;
+	/** Entries to replace at the insertion point. */
+	deleteCount?: number;
+	item: Record<string, unknown>;
+	/** Lazily-loaded client module owning the entry's route, e.g. `InventoryModule`. */
+	module?: string;
+}
+
+/** One entry of `serverData.features`, the flags a client uses to decide which sections to show. */
+export interface ServerFeature {
+	name: string;
+	version: number;
+	menuData?: ClientMenuEntry[];
+}
+
+/** The `serverData` bag of `/api/version`, which `version` hooks amend. */
+export interface ServerData extends Record<string, unknown> {
+	features: ServerFeature[];
+}
+
 export const hooks = makeHookRegistration<{
 	backendReady: (db: Database, shard: Shard) => void;
 	mapStats: (context: Context, payload: MapStatsPayload) => MaybePromise<void>;
@@ -37,7 +68,7 @@ export const hooks = makeHookRegistration<{
 	roomSocket: (shard: Shard, userId: string | undefined, roomName: string) =>
 		AsyncEffectAndResult<((time: number) => MaybePromise<object>) | undefined>;
 	sendUserInfo: (db: Database, userId: string, userInfo: Record<string, unknown>, privateSelf: boolean) => Promise<void>;
-	version: (serverData: Record<string, unknown>) => void;
+	version: (serverData: ServerData) => void;
 	route: Endpoint;
 	subscription: SubscriptionEndpoint;
 }>();


### PR DESCRIPTION
The `version` hook amended a bare `Record<string, unknown>`, so a mod contributing a feature flag — or the client menu entries the official client reads out of `features[].menuData` — was on its own about the layout. Spell the bag out as `ServerData`, with `ServerFeature` and `ClientMenuEntry` describing what the client actually consumes.

Types only, no behavior change. Part of a small series leading up to a decorations mod (whose backend advertises itself through these feature flags); this one stands alone.