### PR TITLE
badge: let mods grant svg symbols beyond the numbered shapes

### DIFF
--- a/.changeset/badge-symbol-grants.md
+++ b/.changeset/badge-symbol-grants.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add a badge `symbols` hook, so a mod may grant svg symbols beyond the numbered shapes.

--- a/packages/xxscreeps/backend/endpoints/user/badge.ts
+++ b/packages/xxscreeps/backend/endpoints/user/badge.ts
@@ -26,7 +26,7 @@ const BadgeEndpoint: Endpoint = {
 		if (userId === undefined) {
 			return { error: 'not logged in' };
 		}
-		const badge = Badge.validate(context.request.body.badge);
+		const badge = await Badge.validate(context.db, userId, context.request.body.badge);
 		await Badge.save(context.db, userId, JSON.stringify(badge));
 		return { ok: 1 };
 	}),

--- a/packages/xxscreeps/engine/db/user/badge.ts
+++ b/packages/xxscreeps/engine/db/user/badge.ts
@@ -1,5 +1,8 @@
+import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import { Ajv } from 'ajv';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 import jsonSchema from './badge.schema.json' with { type: 'json' };
 import * as User from './index.js';
 
@@ -22,33 +25,89 @@ export interface UserBadge {
 	type: number;
 }
 
+/**
+ * A symbol drawn from paths of its own instead of one of the numbered shapes. The invader wears one;
+ * so does a player who was granted one — see {@link hooks}.
+ */
+export interface BadgeSymbol {
+	path1: string;
+	path2: string;
+}
+
 interface SvgBadge {
 	color1: Color;
 	color2: Color;
 	color3: Color;
-	type: {
-		path1: string;
-		path2: string;
-	};
+	type: BadgeSymbol;
 	flip: boolean;
 }
 
 export type Badge = UserBadge | SvgBadge;
 
+export const hooks = makeHookRegistration<{
+	/**
+	 * The symbols `userId` may wear beyond the numbered shapes everybody has. A mod handing out
+	 * artwork of its own — room decorations offer badges among them — answers with what that user
+	 * holds at this moment; nothing else reaches {@link validate}.
+	 */
+	symbols: (db: Database, userId: string) => Promise<Iterable<BadgeSymbol>>;
+}>();
+const symbolHooks = hooks.makeMapped('symbols');
+
 const ajv = new Ajv();
 const validator = ajv.compile<UserBadge>(jsonSchema);
+
+/**
+ * The other half of {@link Badge}. A request spelling its symbol out is not taken at its word — see
+ * {@link validate} — so this only has to recognise the shape.
+ */
+const svgBadgeSchema: JSONSchemaType<SvgBadge> = {
+	type: 'object',
+	properties: {
+		color1: { type: 'string', pattern: '^#[a-f0-9]{6}$' },
+		color2: { type: 'string', pattern: '^#[a-f0-9]{6}$' },
+		color3: { type: 'string', pattern: '^#[a-f0-9]{6}$' },
+		flip: { type: 'boolean' },
+		type: {
+			type: 'object',
+			properties: {
+				path1: { type: 'string' },
+				path2: { type: 'string' },
+			},
+			required: [ 'path1', 'path2' ],
+		},
+	},
+	required: [ 'color1', 'color2', 'color3', 'flip', 'type' ],
+};
+const validateSvgBadge = ajv.compile(svgBadgeSchema);
 
 export function isUserBadge(badge: Badge): badge is UserBadge {
 	return typeof badge.type === 'number';
 }
 
-export function validate(badge: object): UserBadge {
+/**
+ * The badge `userId` asked for, in the shape it is stored in.
+ *
+ * One of the numbered shapes is taken as it arrives. Anything else has to name a symbol granted to
+ * that user, and the paths are then taken from the grant rather than from the request: the badge
+ * route writes them straight into an svg attribute, so a client may point at a symbol but never
+ * author one.
+ */
+export async function validate(db: Database, userId: string, badge: object): Promise<Badge> {
 	// @ts-expect-error
 	delete badge._watching;
-	if (!validator(badge)) {
+	if (validator(badge)) {
+		return badge;
+	} else if (!validateSvgBadge(badge)) {
 		throw new Error(`Invalid badge\n${validator.errors![0]!.message}`);
 	}
-	return badge;
+	const { path1, path2 } = badge.type;
+	const granted = Fn.concat(await Promise.all(symbolHooks(db, userId)));
+	const symbol = Fn.find(granted, symbol => symbol.path1 === path1 && symbol.path2 === path2);
+	if (symbol === undefined) {
+		throw new Error('Badge symbol was not granted');
+	}
+	return { ...badge, type: symbol };
 }
 
 export async function save(db: Database, userId: string, badge: string) {

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -1,4 +1,4 @@
-import type { UserBadge } from './badge.js';
+import type { Badge } from './badge.js';
 import type { Database } from 'xxscreeps/engine/db/index.js';
 import type { MaybePromise } from 'xxscreeps/utility/types.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
@@ -19,7 +19,7 @@ export const infoKey = (userId: string) => `user/${userId}`;
 
 interface BackendUserInfo {
 	username: string;
-	badge: UserBadge | null;
+	badge: Badge | null;
 }
 
 const annoyingUsernames = [
@@ -117,7 +117,7 @@ export async function loadBackendUserInfo(db: Database, userId: string): Promise
 	if (info.username != null) {
 		return {
 			username: info.username,
-			badge: info.badge == null ? null : JSON.parse(info.badge) as UserBadge,
+			badge: info.badge == null ? null : JSON.parse(info.badge) as Badge,
 		};
 	}
 }

--- a/packages/xxscreeps/engine/db/user/test.ts
+++ b/packages/xxscreeps/engine/db/user/test.ts
@@ -4,13 +4,15 @@ import * as Badge from './badge.js';
 import * as User from './index.js';
 
 describe('engine/db/user', () => {
-	test('Badge.generateRandom produces a schema-valid badge', () => {
+	test('Badge.generateRandom produces a schema-valid badge', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
 		// A colour channel below 0x100000 renders as fewer than six hex digits; without
 		// zero-padding that fails the `^#[a-f0-9]{6}$` schema (~1/16 per channel), so loop
 		// enough times to surface it. validate() throws on a malformed badge.
 		for (let index = 0; index < 256; ++index) {
 			const badge = Badge.generateRandom();
-			assert.strictEqual(Badge.validate(badge), badge);
+			assert.strictEqual(await Badge.validate(db, '100', badge), badge);
 		}
 	});
 

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -138,11 +138,13 @@ async function userRemove(who: string) {
 
 // `source` is inline JSON or a path to a `.json` file holding a badge object (the same shape the
 // `/api/user/badge` endpoint accepts). The standard 24 numbered badges are `{ color1, color2,
-// color3, flip, param, type }`; see engine/db/user/badge.ts for the schema.
+// color3, flip, param, type }`; see engine/db/user/badge.ts for the schema. A `type` naming paths
+// instead of a number is a granted symbol — a badge decoration the user has active — and is checked
+// against what they hold, the same way the endpoint checks one.
 async function userBadge(who: string, source: string) {
 	const id = await resolveUserId(who);
 	const json = source.endsWith('.json') ? await fs.readFile(source, 'utf8') : source;
-	const badge = Badge.validate(JSON.parse(json) as object);
+	const badge = await Badge.validate(db, id, JSON.parse(json) as object);
 	await Badge.save(db, id, JSON.stringify(badge));
 	await save();
 	out(`Set badge for ${who} (${id}).`);


### PR DESCRIPTION
The invader already wears a badge drawn from paths of its own, but a player could never hold one: validation only recognised the 24 numbered shapes. Teach it the svg shape and add a `symbols` hook answering what a user may wear. A request spelling out paths is not taken at its word — the badge route writes them into an svg attribute, so the paths are taken from a matching grant or the badge is refused.

Part of a small series leading up to a decorations mod (badge-type decorations grant these symbols); this one stands alone. The catalog slice of that mod will follow on top of this.