### PR TITLE
decorations: ownership, placement and the backend routes

### DIFF
--- a/.changeset/decorations-backend.md
+++ b/.changeset/decorations-backend.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Decorations reach the client: backend routes serve the catalog, the inventory and what is placed, pack assets are served immutable, and the room socket and world map pick up placement changes as they happen.

--- a/.changeset/decorations-model.md
+++ b/.changeset/decorations-model.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Decorations gain their account state: per-user grants and typed placement of what the catalog offers — in a room, on a creep, or worn as a badge — handed out with `manage decoration` when `grantAll` is off.

--- a/packages/xxscreeps/backend/endpoints/game/room.ts
+++ b/packages/xxscreeps/backend/endpoints/game/room.ts
@@ -1,16 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
 import { hooks, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 
-hooks.register('route', {
-	path: '/api/game/room-decorations',
-
-	execute() {
-		return {
-			ok: 1,
-			decorations: [],
-		};
-	},
-});
+// The `/api/game/room-decorations` endpoint lives in the `decorations` mod.
 
 interface RoomStatusRequest {
 	room: string;

--- a/packages/xxscreeps/backend/endpoints/user/index.ts
+++ b/packages/xxscreeps/backend/endpoints/user/index.ts
@@ -6,29 +6,10 @@ import './code.js';
 import './profile.js';
 import './world.js';
 
-// Private messaging endpoints (incl. `/api/user/messages/unread-count`) live in the `messages` mod.
+// Private messaging endpoints (incl. `/api/user/messages/unread-count`) live in the `messages` mod,
+// the `/api/user/decorations/*` endpoints in the `decorations` mod.
 const endpoints = [ ...badge ];
 export default endpoints;
-
-hooks.register('route', {
-	path: '/api/user/decorations/themes',
-	execute() {
-		return {
-			ok: 1,
-			list: [],
-		};
-	},
-});
-
-hooks.register('route', {
-	path: '/api/user/decorations/inventory',
-	execute() {
-		return {
-			ok: 1,
-			list: [],
-		};
-	},
-});
 
 hooks.register('route', {
 	path: '/api/user/tutorial-done',

--- a/packages/xxscreeps/mods/meta/decorations/README.md
+++ b/packages/xxscreeps/mods/meta/decorations/README.md
@@ -127,6 +127,89 @@ Beyond that the renderer reads plenty it survives without: `swampColor`, `swampS
 `strokeBrightness`, `strokeWidth`, `strokeLighting`. Those merely render wrong when they are missing,
 so they are the pack's business rather than an invariant — but a landscape wants all of them.
 
+## Storage
+
+```
+user/<userId>/decorations                        set:  itemIds with a stored grant
+user/<userId>/decorations/item/<itemId>          hash: { def, createdAt }
+user/<userId>/decorations/item/<itemId>/active   hash: { activatedAt, shard, prop/<name>… }
+user/<userId>/decorations/active                 set:  itemIds this user has placed
+decorations/<shard>                              zset: `userId/itemId`, scored by room id
+decorations/global                               set:  `userId/itemId` of the creep decorations
+```
+
+Where a room placement stands is the zset's answer, in both directions: a range at a room's score
+is what stands in that room, a member's score is where that member stands, and one read of the
+whole thing tells the world map which rooms it may skip — almost all of them. The hash repeats none
+of it; it carries `shard` only because that names which shard's zset to ask. Deactivation works the
+same way for the other kinds — a member is either in the global set or, a badge, in no shared index
+at all — so nothing has to remember where a placement went: revoking an item drops its ownership
+first, and by the time it is deactivated the indices themselves still answer.
+
+Each fact gets its own hash field. Property values are prefixed `prop/` so a pack may declare a
+property called `room` without colliding with the placement's own fields, and they are decoded back
+to their declared types on read — the definition is the authority in both directions.
+
+The per-user `active` set exists because `grantAll` makes the inventory as large as the catalog;
+without it, listing an inventory would ask after a placement for every definition on the server.
+
+An inventory item always reports a `createdAt`, even the implicit ownership `grantAll` hands out,
+which has no moment of acquisition to report and so reports the epoch. Clients sort the inventory by
+it without checking that it is there — the field is not optional on the official server, because
+there every item is a stored grant. `activatedAt` is genuinely absent until the item is placed.
+
+## Placement
+
+- The item is owned — including implicitly, under `grantAll`.
+- The target shard is this one and the room exists.
+- The player controls or reserves the room, unless `decorations.requireRoomOwnership` is off. That
+  question goes through the controller mod's `isRoomControlled` / `isRoomReserved`, not its keys.
+- Property values are checked against the definition: range bounds, `#rrggbb` colors, string
+  length, unknown properties rejected. An invalid value is an error, never a silent default. Omitted
+  properties fall back to the definition's seed, so a stored placement is always complete.
+- Collisions are checked per user against whichever index the placement lands in: `landscape` blocks
+  `floorLandscape` and `wallLandscape` in the same room, `object` and `metadata` only argue with
+  their own kind decorating the same `objectType`, `wallGraffiti` stacks freely. The check races —
+  two activations can both find the index clear — so after the write the index is read back and
+  same-user conflicts are settled in itemId order, which every racer computes the same way.
+- `creep` decorations name no room — they follow their owner and so appear in every one — and are
+  indexed under `decorations/global`, which is also where they compete with each other. The world map
+  does not draw them: there is no room to draw them in.
+- `badge` decorations name no room either, and land in no shared index at all: they decorate an
+  account rather than a place, so no room view and no map query has anything to ask after one. Only
+  their owner's inventory reports them, which is exactly where the client looks. Several may be worn
+  at once — see below.
+- Activating an already-placed item moves it. The client depends on this when repositioning.
+- A placement goes over the wire flat: the item's `_id`, its target and the property values in one
+  bag. `_id` has to be *inside* it, not beside it — the room view flattens the bag into the object it
+  renders and then matches socket updates against its `_id`. Hand it out only next to the bag and
+  every update appends the decoration again instead of recognising the copy it already has. `_id` is
+  the official client's spelling and stays wire shape only: the backend strips it from what comes in
+  and puts it back on what goes out, and nothing behind the backend ever sees it.
+
+Activate and deactivate publish on a channel per room, plus one shared channel for the creep
+decorations. An open room socket listens to both and re-reads only when one of them fires, so an idle
+room costs nothing per tick. A badge placement wakes nobody: no room view shows one, so there is no
+channel to fire.
+
+## Badges
+
+A `badge` decoration grants a symbol: the two svg paths a badge is drawn from, in the 100×100 box the
+client's badge editor authors them in. `path2` may be empty, which is how a one-color symbol is
+spelled. It carries no colors of its own — the player picks all three in the editor, over whichever
+symbol they chose — so the inventory preview is drawn in the catalog's own greys.
+
+Activating one is what makes the editor offer it beside the 24 numbered shapes. The account badge
+page reads them straight out of the inventory, so nothing else has to be served for it. Saving one
+goes through `/api/user/badge`, which is core's business rather than this mod's: a badge naming paths
+instead of a number has to match a symbol the user has active, and the paths are then taken from the
+grant rather than from the request. The route writes them into an svg attribute, so a client may
+point at a symbol but never author one. Mods answer `Badge.hooks`' `symbols` with what a user holds;
+this one answers with their active badge decorations.
+
+Deactivating a badge takes the symbol out of the editor. A badge already saved from it stays as it
+was — the user's badge is a fact of its own, not a view onto the grant.
+
 ## Configuration
 
 ```yaml
@@ -144,3 +227,22 @@ backend:
   # its own, or the path a proxy mounts it under — e.g. "/(http://localhost:21025)" for steamless
   assetBaseUrl: https://screeps.example.com
 ```
+
+## Handing out decorations
+
+With `grantAll` (the default) there is nothing to do — everybody owns everything, and the ids the
+inventory reports name a decoration rather than a stored grant, so there is nothing to revoke either.
+With it off:
+
+```sh
+xxscreeps manage decoration catalog
+xxscreeps manage decoration grant   <name|id> <decorationId>
+xxscreeps manage decoration list    <name|id>
+xxscreeps manage decoration revoke  <name|id> <itemId>
+xxscreeps manage decoration cleanup [name|id]
+```
+
+Grants are stored either way, so turning `grantAll` off later leaves each user with exactly what
+they were given. What it does not leave them is the placements they made while ownership was
+implicit: those have no grant behind them, so they go invisible and nothing can reach them any more.
+`decoration cleanup` deactivates them — for one user, or with no argument for all of them.

--- a/packages/xxscreeps/mods/meta/decorations/backend.ts
+++ b/packages/xxscreeps/mods/meta/decorations/backend.ts
@@ -1,0 +1,428 @@
+import type { DecorationDefinition, DecorationProp } from './catalog.js';
+import type { PlacedDecoration } from './model.js';
+import type { Placement, PlacementError, PropValue } from './placement.js';
+import type { JSONSchemaType } from 'ajv';
+import type { Database } from 'xxscreeps/engine/db/index.js';
+import type { Shard } from 'xxscreeps/engine/db/shard.js';
+import * as fs from 'node:fs/promises';
+import { hooks, makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { acquireWith } from 'xxscreeps/utility/async.js';
+import { disposableToEffect } from 'xxscreeps/utility/utility.js';
+import { assetContentType, catalog } from './catalog.js';
+import { activateBadge, activateCreep, activateInRoom, deactivate, getGlobalDecorationChannel, getRoomDecorationChannel, listForRoom, listForUser, listGlobal, ownedDefinition } from './model.js';
+import { isOnWorldMap, isPlacedInRoom } from './placement.js';
+import { enumeratedProps } from './renderer.js';
+
+// `_id` is the official client's spelling, a Mongo-ism of the original server. It is wire shape and
+// nothing else, so it lives in this file alone: stripped from what the client sends, put back on
+// what it is served.
+
+/**
+ * A definition as the client wants it: the layout constraints sit inside `props`, next to the
+ * property descriptors. They are kept apart internally because they are scalars, not descriptors.
+ */
+function toClientDefinition(definition: DecorationDefinition) {
+	const { id, layout, props, ...rest } = definition;
+	return { _id: id, ...rest, props: { ...layout, ...props } };
+}
+
+/**
+ * The flat shape the client exchanges — the item id and the target sit alongside the property
+ * values rather than beside them, which is the same shape the activate route reads back. A pack
+ * property named `_id`, `shard` or `room` loses to them here; storage keeps them apart, so nothing
+ * is actually dropped.
+ *
+ * `_id` has to travel *inside* this bag, not next to it: the room view flattens a placement into
+ * one object and later matches socket updates against it by `_id`. Without one every update appends
+ * the decoration again instead of recognising the copy it already has.
+ */
+export const placementToWire = (id: string, placement: Placement): Record<string, PropValue> => ({
+	...placement.props,
+	...placement.shard !== undefined && { shard: placement.shard },
+	...placement.room !== undefined && { room: placement.room },
+	_id: id,
+});
+
+hooks.register('route', {
+	path: '/api/user/decorations/inventory',
+
+	async execute(context) {
+		const { userId } = context.state;
+		if (userId === undefined) {
+			return { ok: 1, list: [] };
+		}
+		const items = await listForUser(context.db, userId);
+		return {
+			ok: 1,
+			list: items.map(item => ({
+				_id: item.id,
+				createdAt: new Date(item.createdAt).toISOString(),
+				activatedAt: item.activatedAt === undefined ? undefined : new Date(item.activatedAt).toISOString(),
+				// `null` is how the client spells "owned, not placed".
+				active: item.active === undefined ? null : placementToWire(item.id, item.active),
+				decoration: toClientDefinition(item.definition),
+			})),
+		};
+	},
+});
+
+hooks.register('route', {
+	path: '/api/user/decorations/themes',
+
+	execute() {
+		return { ok: 1, list: catalog.themes.map(({ id, ...rest }) => ({ _id: id, ...rest })) };
+	},
+});
+
+interface ActivateRequest {
+	_id: string;
+	active: Record<string, unknown>;
+}
+
+const activateSchema: JSONSchemaType<ActivateRequest> = {
+	type: 'object',
+	properties: {
+		_id: { type: 'string', minLength: 1 },
+		// The property values are checked against the decoration's own schema, which ajv can't know.
+		active: { type: 'object', required: [] },
+	},
+	required: [ '_id', 'active' ],
+};
+
+/** An accepted property value. */
+interface ParsedProp {
+	value: PropValue;
+}
+
+/** Longest free-form string a property may hold; lists arrive `!SEP!`-joined into one of these. */
+const maxStringLength = 1024;
+
+const isColor = (value: string) => /^#[0-9a-fA-F]{6}$/.test(value);
+
+/**
+ * One property value as the client sent it. Numbers and booleans are accepted in their string
+ * spelling too — the client round-trips placed values through form state and sends back whatever
+ * that left behind.
+ */
+function parseProp(name: string, prop: DecorationProp, value: unknown): ParsedProp | PlacementError {
+	switch (prop.type) {
+		case 'boolean': {
+			if (typeof value === 'boolean') {
+				return { value };
+			}
+			return value === 'true' || value === '1' ? { value: true } :
+				value === 'false' || value === '0' ? { value: false } :
+				{ error: `'${name}' is not a boolean` };
+		}
+
+		case 'range': {
+			// `Number` reads `null` and `[]` as zero, so anything but a number or its string
+			// spelling is rejected before the conversion rather than after it.
+			const number = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN;
+			if (!Number.isFinite(number)) {
+				return { error: `'${name}' is not a number` };
+			} else if (prop.min !== undefined && number < prop.min) {
+				return { error: `'${name}' is below its minimum of ${prop.min}` };
+			} else if (prop.max !== undefined && number > prop.max) {
+				return { error: `'${name}' is above its maximum of ${prop.max}` };
+			}
+			return { value: number };
+		}
+
+		case 'color':
+			return typeof value === 'string' && isColor(value)
+				? { value }
+				: { error: `'${name}' is not a '#rrggbb' color` };
+
+		case 'display':
+		case 'string':
+			return typeof value === 'string' && value.length <= maxStringLength
+				? { value }
+				: { error: `'${name}' is not a string of at most ${maxStringLength} characters` };
+	}
+}
+
+/**
+ * The `active` payload of an activation request, checked against what the definition declares.
+ * Properties the client left out fall back to the definition's seed, so a placement always carries
+ * a complete set and later readers never have to consult the defaults again. Wire-only baggage —
+ * the `_id` the client sends back with an edited placement — is stripped before the payload gets
+ * here.
+ */
+export function parsePlacement(definition: DecorationDefinition, active: Record<string, unknown>): Placement | PlacementError {
+	const { shard, room, ...rest } = active;
+	// The spread copied only the request's own keys, so what the definition's properties leave
+	// unclaimed is exactly what the request named and the definition does not declare.
+	const unclaimed = new Set(Object.keys(rest));
+	const props: Record<string, PropValue> = {};
+	for (const [ name, prop ] of Object.entries(definition.props)) {
+		const sent = unclaimed.delete(name);
+		// The official client sends readonly properties along with everything else — its editor hides
+		// them but its payload builder does not — so a value here is not an error. It does not win
+		// either: readonly means the definition owns the value, and the seed fills it in, the same
+		// way it covers a property the client left out.
+		if (!sent || prop.readonly) {
+			if (prop.default !== undefined) {
+				props[name] = prop.default;
+			}
+			continue;
+		}
+		const parsed = parseProp(name, prop, rest[name]);
+		if ('error' in parsed) {
+			return parsed;
+		}
+		// The renderer indexes a table by some of these, so they are closed sets rather than the free
+		// strings the client's editor offers when a pack labels the property its own way.
+		const values = enumeratedProps[name];
+		if (values !== undefined && !values.includes(String(parsed.value))) {
+			return { error: `'${name}' is not one of ${values.map(value => `'${value}'`).join(', ')}` };
+		}
+		props[name] = parsed.value;
+	}
+	const [ unknown ] = unclaimed;
+	if (unknown !== undefined) {
+		return { error: `'${definition.id}' has no property '${unknown}'` };
+	}
+	if (!isPlacedInRoom(definition.type)) {
+		return { props };
+	} else if (typeof shard !== 'string' || typeof room !== 'string') {
+		return { error: `'${definition.id}' must be placed in a room` };
+	}
+	return { shard, room, props };
+}
+
+/**
+ * The activation request, parsed apart and dispatched to whichever kind of placement the definition
+ * calls for. The three kinds share nothing past this point: a room placement has a target to check,
+ * a creep decoration lands in the global index, a badge in no shared index at all.
+ */
+export async function activate(db: Database, shard: Shard, userId: string, itemId: string, active: Record<string, unknown>) {
+	const definition = await ownedDefinition(db, userId, itemId);
+	if (definition === undefined) {
+		return { error: 'not owned' };
+	}
+	// `_id` comes back with an edited placement; it names the item the request already identifies,
+	// so it is dropped here rather than checked against the pack's properties.
+	const { _id, ...rest } = active;
+	const placement = parsePlacement(definition, rest);
+	if ('error' in placement) {
+		return placement;
+	}
+	if (isPlacedInRoom(definition.type)) {
+		if (placement.shard !== shard.name) {
+			return { error: 'unknown shard' };
+		}
+		return activateInRoom(db, shard, userId, itemId, definition, placement.room!, placement.props);
+	} else if (definition.type === 'creep') {
+		return activateCreep(db, userId, itemId, definition, placement.props);
+	} else {
+		return activateBadge(db, userId, itemId, placement.props);
+	}
+}
+
+hooks.register('route', {
+	path: '/api/user/decorations/activate',
+	method: 'post',
+
+	execute: makeValidatedPayloadRoute(activateSchema, async context => {
+		const { userId } = context.state;
+		if (userId === undefined) {
+			return { error: 'not authenticated' };
+		}
+		const { _id, active } = context.request.body;
+		return await activate(context.db, context.shard, userId, _id, active) ?? { ok: 1 };
+	}),
+});
+
+interface DeactivateRequest {
+	decorations: string[];
+}
+
+/** Well past what the client sends at once, and low enough that one request stays one batch of reads. */
+const maxDeactivateCount = 256;
+
+const deactivateSchema: JSONSchemaType<DeactivateRequest> = {
+	type: 'object',
+	properties: {
+		decorations: { type: 'array', items: { type: 'string', minLength: 1 }, maxItems: maxDeactivateCount },
+	},
+	required: [ 'decorations' ],
+};
+
+hooks.register('route', {
+	path: '/api/user/decorations/deactivate',
+	method: 'post',
+
+	execute: makeValidatedPayloadRoute(deactivateSchema, async context => {
+		const { userId } = context.state;
+		if (userId === undefined) {
+			return { error: 'not authenticated' };
+		}
+		await deactivate(context.db, userId, context.request.body.decorations);
+		return { ok: 1 };
+	}),
+});
+
+// Pack assets: files a pack ships, plus the previews the catalog drew for its landscapes. Only what
+// the catalog registered is servable — the request never names a path on disk, it names a key in
+// that map, so there is nothing to sanitize.
+interface CachedAsset {
+	body: Buffer;
+	type: string;
+}
+const assetCache = new Map<string, CachedAsset>();
+
+hooks.register('route', {
+	path: '/assets/decorations/:asset(.*)',
+
+	async execute(context) {
+		const key = context.params.asset!;
+		const asset = assetCache.get(key) ?? await async function() {
+			const source = catalog.assets.get(key);
+			if (source === undefined) {
+				return;
+			}
+			const body = source.kind === 'file' ? await fs.readFile(source.file) : Buffer.from(source.body);
+			const entry = {
+				body,
+				type: assetContentType(key) ?? function(): never {
+					throw new Error(`Decoration asset '${key}' has an unsupported file type`);
+				}(),
+			};
+			assetCache.set(key, entry);
+			return entry;
+		}();
+		if (asset === undefined) {
+			return;
+		}
+		// The url carries a version, so the response never needs revalidating: a changed asset shows
+		// up under a new url instead.
+		context.set('Cache-Control', 'public, max-age=31536000, immutable');
+		context.set('Content-Type', asset.type);
+		// These end up as WebGL textures, and the browser refuses to upload a cross-origin image it
+		// was not allowed to read — pixi asks for one anonymously as soon as the url is not the
+		// client's own origin, which is exactly what `assetBaseUrl` is for. Public files, no
+		// credentials, nothing to scope the permission to.
+		context.set('Access-Control-Allow-Origin', '*');
+		context.body = asset.body;
+		return true;
+	},
+});
+
+/** An item as the room and map views report it: the placement plus who owns it. */
+const toClientItem = (item: PlacedDecoration) => ({
+	_id: item.id,
+	user: item.userId,
+	active: placementToWire(item.id, item.active),
+	decoration: toClientDefinition(item.definition),
+});
+
+interface RoomDecorationsRequest {
+	room: string;
+	shard?: string;
+}
+
+const roomDecorationsSchema: JSONSchemaType<RoomDecorationsRequest> = {
+	type: 'object',
+	properties: {
+		room: { type: 'string', minLength: 1 },
+		shard: { type: 'string', nullable: true },
+	},
+	required: [ 'room' ],
+};
+
+hooks.register('route', {
+	path: '/api/game/room-decorations',
+
+	execute: makeValidatedQueryRoute(roomDecorationsSchema, async context => {
+		const { room, shard } = context.request.query;
+		const [ placed, global ] = await Promise.all([
+			listForRoom(context.db, shard ?? context.shard.name, room),
+			listGlobal(context.db),
+		]);
+		return { ok: 1, decorations: [ ...placed, ...global ].map(toClientItem) };
+	}),
+});
+
+hooks.register('roomSocket', async (shard, userId, roomName) => {
+	// Re-read only once something in the room changed. Creep decorations show up in every room, so
+	// this watches their channel too.
+	let stale = true;
+	const markStale = () => { stale = true; };
+	using disposable = new DisposableStack();
+	await acquireWith(
+		fn => disposable.defer(fn),
+		getRoomDecorationChannel(shard.db, shard.name, roomName).listen(markStale),
+		getGlobalDecorationChannel(shard.db).listen(markStale),
+	);
+
+	return [
+		disposableToEffect(disposable.move()),
+		async () => {
+			if (!stale) {
+				return {};
+			}
+			stale = false;
+			const [ placed, global ] = await Promise.all([
+				listForRoom(shard.db, shard.name, roomName),
+				listGlobal(shard.db),
+			]);
+			return { decorations: [ ...placed, ...global ].map(toClientItem) };
+		},
+	];
+});
+
+/** Whether any loaded decoration can stand in a room at all. A badge-only catalog leaves the map
+ * with nothing to show, so the hook below is skipped outright. */
+const hasRoomDecorations = Fn.some(catalog.definitions.values(), definition => isPlacedInRoom(definition.type));
+
+// Creep decorations are deliberately absent: they belong to a creep rather than to a room, so there
+// is no room for the map to draw them in.
+if (hasRoomDecorations) {
+	hooks.register('mapStats', async (context, { rooms, response, userIds }) => {
+		const decorations: Record<string, unknown> = {};
+		await Fn.mapAwait(rooms, async ({ room, stats }) => {
+			const items = await listForRoom(context.db, context.shard.name, room.name);
+			// The map only shows what its owner published to it.
+			const visible = items.filter(item => isOnWorldMap(item.active));
+			if (visible.length === 0) {
+				return;
+			}
+			stats.decorations = visible.map(item => {
+				userIds.add(item.userId);
+				// The client looks the definition up in the dictionary below rather than inline, so the
+				// same decoration placed in fifty rooms is described once.
+				decorations[item.definition.id] = mapDecoration(item.definition);
+				return { _id: item.id, user: item.userId, decoration: item.definition.id, active: placementToWire(item.id, item.active) };
+			});
+		});
+		if (Object.keys(decorations).length > 0) {
+			response.decorations = decorations;
+		}
+	});
+}
+
+/** The reduced shape the map renderer needs; it never draws the editable properties. */
+const mapDecoration = (definition: DecorationDefinition) => ({
+	type: definition.type,
+	...definition.graphics !== undefined && { graphics: definition.graphics },
+	...definition.tiling !== undefined && { tiling: definition.tiling },
+	...definition.foregroundUrl !== undefined && { foregroundUrl: definition.foregroundUrl },
+	...definition.floorForegroundUrl !== undefined && { floorForegroundUrl: definition.floorForegroundUrl },
+});
+
+// The client gates its inventory section on this flag, and builds the section's route and sidebar
+// entry from the menu payload riding along with it.
+hooks.register('version', serverData => {
+	serverData.features.push({
+		name: 'inventory',
+		version: 1,
+		menuData: [ {
+			section: 0,
+			after: 'World',
+			item: { id: 'menu-item-inventory', label: 'Inventory', routerLink: '/inventory', svg: 'inventory' },
+			module: 'InventoryModule',
+		} ],
+	});
+});

--- a/packages/xxscreeps/mods/meta/decorations/index.ts
+++ b/packages/xxscreeps/mods/meta/decorations/index.ts
@@ -1,5 +1,7 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
 
 export const manifest: Manifest = {
+	// Placing a decoration checks that the player controls or reserves the room.
+	dependencies: [ 'xxscreeps/mods/classic/controller' ],
 	provides: [ 'config', 'test' ],
 };

--- a/packages/xxscreeps/mods/meta/decorations/index.ts
+++ b/packages/xxscreeps/mods/meta/decorations/index.ts
@@ -3,5 +3,5 @@ import type { Manifest } from 'xxscreeps/config/mods.js';
 export const manifest: Manifest = {
 	// Placing a decoration checks that the player controls or reserves the room.
 	dependencies: [ 'xxscreeps/mods/classic/controller' ],
-	provides: [ 'config', 'test' ],
+	provides: [ 'backend', 'config', 'test' ],
 };

--- a/packages/xxscreeps/mods/meta/decorations/model.ts
+++ b/packages/xxscreeps/mods/meta/decorations/model.ts
@@ -1,0 +1,430 @@
+import type { DecorationDefinition } from './catalog.js';
+import type { Placement, PlacementError, PlacementTarget, PropValue } from './placement.js';
+import type { Database } from 'xxscreeps/engine/db/index.js';
+import type { Shard } from 'xxscreeps/engine/db/shard.js';
+import { config } from 'xxscreeps/config/index.js';
+import { Channel } from 'xxscreeps/engine/db/channel.js';
+import { hooks as badgeHooks } from 'xxscreeps/engine/db/user/badge.js';
+import { hooks as userHooks } from 'xxscreeps/engine/db/user/index.js';
+import { generateId } from 'xxscreeps/engine/schema/id.js';
+import { mappedPrimitiveComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
+import { makeRoomNameFromId, parseRoomNameToId } from 'xxscreeps/game/room/name.js';
+import { isRoomControlled, isRoomReserved } from 'xxscreeps/mods/classic/controller/model.js';
+import { catalog } from './catalog.js';
+import { conflicts, decodeProps, encodeProps } from './placement.js';
+
+// Who owns which decoration, and where they put it. Ownership is an account fact, not a shard fact,
+// so it lives in the shared `db.data` store next to the other per-user records — `active.shard`
+// says which shard a placement points at.
+//
+// With `decorations.grantAll` (the default) the whole catalog is owned by everybody and no grant is
+// read from the store at all — the natural setup for a private server, where decorations are a
+// customisation option rather than something to earn. Explicit grants are still written and kept;
+// they take effect once `grantAll` is turned off. Placements are stored either way.
+//
+// A placement made while `grantAll` is on has no stored grant behind it. Turning the flag off
+// strands it — invisible everywhere, unreachable from the client — until `xxscreeps manage
+// decoration cleanup` takes it down again; see {@link deactivateStranded}.
+
+/** set: ids of the inventory items `userId` was granted. */
+const inventoryKey = (userId: string) => `user/${userId}/decorations`;
+/** hash: `{ def, createdAt }` of one granted item. Item ids come from clients and, under `grantAll`,
+ * from packs, so item keys get a segment of their own — an id like `active` must not be able to land
+ * on one of the sets below. */
+const itemKey = (userId: string, itemId: string) => `user/${userId}/decorations/item/${itemId}`;
+/** hash: `{ activatedAt, shard, prop/… }` of one placed item. Absent when it is not placed. Which
+ * room it stands in is not repeated here — that is the zset's answer. */
+const activeKey = (userId: string, itemId: string) => `user/${userId}/decorations/item/${itemId}/active`;
+/** set: ids `userId` has placed. Saves asking after every item they own, which under `grantAll` is
+ * the whole catalog. */
+const activeIndexKey = (userId: string) => `user/${userId}/decorations/active`;
+/** zset: everything placed in a room of one shard — score the room's id, member `userId/itemId`.
+ * One structure answers both directions: a range at a room's score is what stands there, a member's
+ * score is where it stands. */
+const shardIndexKey = (shardName: string) => `decorations/${shardName}`;
+/** set: `userId/itemId` of the creep decorations, which follow their owner instead of a room. */
+const globalIndexKey = 'decorations/global';
+
+export const grantAll = () => config.decorations?.grantAll ?? true;
+
+/**
+ * Announces that what is placed in a room changed, so open room sockets re-read it. Creep
+ * decorations show up in every room, so they get their own channel that all of them watch.
+ */
+export const getRoomDecorationChannel = (db: Database, shardName: string, room: string) =>
+	new Channel<DecorationUpdate>(db.pubsub, `decorations/${shardName}/${room}`);
+export const getGlobalDecorationChannel = (db: Database) =>
+	new Channel<DecorationUpdate>(db.pubsub, globalIndexKey);
+
+export interface DecorationUpdate {
+	type: 'updated';
+}
+
+/** One decoration a user owns, resolved against the catalog. */
+export interface OwnedDecoration {
+	id: string;
+	definition: DecorationDefinition;
+	/**
+	 * Epoch milliseconds the item was granted. Every inventory item carries one, because the client
+	 * sorts by it — the implicit ownership `grantAll` hands out has no moment of acquisition to
+	 * report, so it reports the epoch and the whole catalog ties.
+	 */
+	createdAt: number;
+	/** Where it is placed, or absent while it sits unplaced in the inventory. */
+	active?: Placement;
+	/** Epoch milliseconds it was placed. */
+	activatedAt?: number;
+}
+
+const indexMember = (userId: string, itemId: string) => `${userId}/${itemId}`;
+
+/** Ids never contain a slash, so the first one separates the two halves. */
+function parseIndexMember(member: string) {
+	const slash = member.indexOf('/');
+	return { userId: member.slice(0, slash), itemId: member.slice(slash + 1) };
+}
+
+/**
+ * The placement of one item, or `undefined` when it is not placed. The room it stands in — if it
+ * stands in one at all — is the zset's answer, not the hash's.
+ */
+async function loadPlacement(db: Database, userId: string, itemId: string, definition: DecorationDefinition) {
+	const fields = await db.data.hGetAll(activeKey(userId, itemId));
+	if (fields.activatedAt === undefined) {
+		return;
+	}
+	const room = await async function() {
+		if (fields.shard === undefined) {
+			return;
+		}
+		const score = await db.data.zScore(shardIndexKey(fields.shard), indexMember(userId, itemId));
+		return score === null ? undefined : makeRoomNameFromId(score);
+	}();
+	const placement: Placement = {
+		...fields.shard !== undefined && { shard: fields.shard },
+		...room !== undefined && { room },
+		props: decodeProps(definition, fields),
+	};
+	return { placement, activatedAt: Number(fields.activatedAt) };
+}
+
+/**
+ * The definition behind an item `userId` owns, or `undefined` when they do not own it.
+ *
+ * Under `grantAll` an item has no stored grant, so the id names the decoration directly — which is
+ * exactly what {@link listForUser} hands the client in that mode.
+ */
+export async function ownedDefinition(db: Database, userId: string, itemId: string) {
+	const def = await db.data.hGet(itemKey(userId, itemId), 'def');
+	if (def !== null) {
+		return catalog.definitions.get(def);
+	}
+	return grantAll() ? catalog.definitions.get(itemId) : undefined;
+}
+
+/**
+ * Everything `userId` owns.
+ *
+ * A stored item whose definition is gone — its pack was unloaded — is left in the store but kept
+ * out of the listing; the grant becomes visible again once the pack is back.
+ */
+async function loadOwned(db: Database, userId: string): Promise<OwnedDecoration[]> {
+	if (grantAll()) {
+		// Implicit ownership has no record to carry an id, so the decoration's own id names the item.
+		// That keeps the id stable across restarts, which is what the client needs to place and
+		// remove one. Nor is there a moment it was acquired, so every item reports the epoch and the
+		// catalog ties — a sort by age leaves it in the order the server listed it.
+		return [ ...Fn.map(catalog.definitions.values(), definition => ({ id: definition.id, definition, createdAt: 0 })) ];
+	}
+	const ids = await db.data.sMembers(inventoryKey(userId));
+	const items = await Fn.mapAwait(ids, async (id): Promise<OwnedDecoration | undefined> => {
+		const fields = await db.data.hGetAll(itemKey(userId, id));
+		const definition = catalog.definitions.get(fields.def!);
+		if (definition === undefined) {
+			console.warn(`User ${userId} owns decoration '${fields.def}', which no loaded pack defines`);
+			return;
+		}
+		return { id, definition, createdAt: Number(fields.createdAt) };
+	});
+	return [ ...Fn.filter(items) ];
+}
+
+export async function listForUser(db: Database, userId: string): Promise<OwnedDecoration[]> {
+	const [ owned, placed ] = await Promise.all([
+		loadOwned(db, userId),
+		db.data.sMembers(activeIndexKey(userId)),
+	]);
+	const placedIds = new Set(placed);
+	return Fn.mapAwait(owned, async (item): Promise<OwnedDecoration> => {
+		if (!placedIds.has(item.id)) {
+			return item;
+		}
+		const placed = await loadPlacement(db, userId, item.id, item.definition);
+		return { ...item, ...placed !== undefined && { active: placed.placement, activatedAt: placed.activatedAt } };
+	});
+}
+
+/** One decoration standing in a room, as the room and map views report it. */
+export interface PlacedDecoration {
+	id: string;
+	userId: string;
+	definition: DecorationDefinition;
+	active: Placement;
+	activatedAt: number;
+}
+
+/** The members of one placement index, resolved against the catalog. The caller says where the
+ * index put them — a room, or nowhere for the global one — since the hash does not repeat it. */
+async function resolveIndexMembers(db: Database, members: string[], target: PlacementTarget): Promise<PlacedDecoration[]> {
+	const items = await Fn.mapAwait(members, async member => {
+		const { userId, itemId } = parseIndexMember(member);
+		const [ definition, fields ] = await Promise.all([
+			ownedDefinition(db, userId, itemId),
+			db.data.hGetAll(activeKey(userId, itemId)),
+		]);
+		if (definition === undefined || fields.activatedAt === undefined) {
+			return;
+		}
+		const active: Placement = { ...target, props: decodeProps(definition, fields) };
+		return { id: itemId, userId, definition, active, activatedAt: Number(fields.activatedAt) };
+	});
+	return [ ...Fn.filter(items) ];
+}
+
+/** Everything placed in one room, across all users. */
+export async function listForRoom(db: Database, shardName: string, room: string): Promise<PlacedDecoration[]> {
+	const roomId = parseRoomNameToId(room);
+	const members = await db.data.zRange(shardIndexKey(shardName), roomId, roomId, { by: 'SCORE' });
+	return resolveIndexMembers(db, members, { shard: shardName, room });
+}
+
+/**
+ * The creep decorations, which follow their owner instead of a room and so show up in every one of
+ * them. They are the same set no matter which room is being viewed, which is why a caller reading
+ * many rooms — the world map — asks for them once rather than per room.
+ */
+export const listGlobal = async (db: Database) =>
+	resolveIndexMembers(db, await db.data.sMembers(globalIndexKey), {});
+
+/** Give `userId` a decoration from the catalog. Returns the id of the new inventory item. */
+export async function grant(db: Database, userId: string, definitionId: string) {
+	if (!catalog.definitions.has(definitionId)) {
+		throw new Error(`No such decoration: ${definitionId}`);
+	}
+	const id = generateId(12);
+	await Promise.all([
+		db.data.sAdd(inventoryKey(userId), [ id ]),
+		db.data.hmSet(itemKey(userId, id), { def: definitionId, createdAt: Date.now() }),
+	]);
+	return id;
+}
+
+/**
+ * Take an inventory item away again. Returns false if the user didn't have it — which is the answer
+ * for every id under `grantAll`, whose ownership has no grant to take away. Ownership goes first so
+ * that a `false` leaves the placement where it was rather than half-revoking an item the caller is
+ * about to be told they never held.
+ */
+export async function revoke(db: Database, userId: string, itemId: string) {
+	const [ removed ] = await Promise.all([
+		db.data.sRem(inventoryKey(userId), [ itemId ]),
+		db.data.del(itemKey(userId, itemId)),
+	]);
+	if (removed === 0) {
+		return false;
+	}
+	await deactivate(db, userId, [ itemId ]);
+	return true;
+}
+
+/** Whether `userId` holds or reserves `room`, which placing something there requires. */
+async function controlsRoom(shard: Shard, userId: string, room: string) {
+	const [ controlled, reserved ] = await Promise.all([
+		isRoomControlled(shard, userId, room),
+		isRoomReserved(shard, userId, room),
+	]);
+	return controlled || reserved;
+}
+
+/** The hash write and the per-user index entry every activation makes, whatever index it lands in. */
+const writePlacement = (db: Database, userId: string, itemId: string, props: Record<string, PropValue>, fields: Record<string, string>) =>
+	Promise.all([
+		db.data.hmSet(activeKey(userId, itemId), { activatedAt: Date.now(), ...fields, ...encodeProps(props) }),
+		db.data.sAdd(activeIndexKey(userId), [ itemId ]),
+	]);
+
+/**
+ * Take down whatever `userId` placed in one index that argues with itself, settled in itemId order:
+ * the first of a conflicting pair stays. Run after the write, because the pre-check races — two
+ * activations can both find the index clear and land conflicting decorations. Every racer reads the
+ * same index and settles it the same way, so however the writes interleaved they converge on one
+ * survivor.
+ */
+async function settleConflicts(db: Database, userId: string, items: PlacedDecoration[]) {
+	const mine = items.filter(item => item.userId === userId).sort(mappedPrimitiveComparator(item => item.id));
+	const kept: PlacedDecoration[] = [];
+	const losers = [ ...Fn.transform(mine, function*(item) {
+		if (kept.some(winner => conflicts(winner.definition, item.definition))) {
+			yield item.id;
+		} else {
+			kept.push(item);
+		}
+	}) ];
+	await deactivate(db, userId, losers);
+}
+
+/** Whether another of `userId`'s placements argues with placing `definition` as `itemId`. */
+const blocked = (items: PlacedDecoration[], userId: string, itemId: string, definition: DecorationDefinition) =>
+	items.some(other => other.userId === userId && other.id !== itemId && conflicts(definition, other.definition));
+
+/**
+ * Place an item in a room, replacing wherever it sat before. The client relies on the replacement:
+ * it moves a decoration by activating it again at the new spot. The caller resolved `definition`
+ * against the user's inventory already; property values arrive parsed.
+ */
+export async function activateInRoom(
+	db: Database, shard: Shard, userId: string, itemId: string, definition: DecorationDefinition,
+	room: string, props: Record<string, PropValue>,
+): Promise<PlacementError | undefined> {
+	if (!await shard.data.sIsMember('rooms', room)) {
+		return { error: 'unknown room' };
+	} else if ((config.decorations?.requireRoomOwnership ?? true) && !await controlsRoom(shard, userId, room)) {
+		return { error: 'room not controlled' };
+	} else if (blocked(await listForRoom(db, shard.name, room), userId, itemId, definition)) {
+		return { error: 'already decorated' };
+	}
+	// The old placement is taken down first for everything the zAdd below cannot do: the old room
+	// may sit on another shard's zset, its viewers are told through its own channel, and the hash
+	// is deleted rather than merged over. First, not after — a move within one room writes the same
+	// zset member, so a deactivate running later would drop the entry it just wrote.
+	await deactivate(db, userId, [ itemId ]);
+	await Promise.all([
+		writePlacement(db, userId, itemId, props, { shard: shard.name }),
+		db.data.zAdd(shardIndexKey(shard.name), [ [ parseRoomNameToId(room), indexMember(userId, itemId) ] ]),
+		announce(getRoomDecorationChannel(db, shard.name, room)),
+	]);
+	await settleConflicts(db, userId, await listForRoom(db, shard.name, room));
+	return undefined;
+}
+
+/**
+ * Place a creep decoration, which follows its owner rather than standing in a room and so lands in
+ * the one index every room view reads alongside its own.
+ */
+export async function activateCreep(
+	db: Database, userId: string, itemId: string, definition: DecorationDefinition, props: Record<string, PropValue>,
+): Promise<PlacementError | undefined> {
+	if (blocked(await listGlobal(db), userId, itemId, definition)) {
+		return { error: 'already decorated' };
+	}
+	await deactivate(db, userId, [ itemId ]);
+	await Promise.all([
+		writePlacement(db, userId, itemId, props, {}),
+		db.data.sAdd(globalIndexKey, [ indexMember(userId, itemId) ]),
+		announce(getGlobalDecorationChannel(db)),
+	]);
+	await settleConflicts(db, userId, await listGlobal(db));
+	return undefined;
+}
+
+/**
+ * Wear a badge decoration. It is in no shared index and announces nothing: it is worn rather than
+ * placed, nobody but its owner ever asks after one, and the per-user index already knows it was
+ * activated. Nor does anything conflict — the badge editor lists every worn symbol and they take
+ * turns rather than compete.
+ */
+export async function activateBadge(
+	db: Database, userId: string, itemId: string, props: Record<string, PropValue>,
+): Promise<PlacementError | undefined> {
+	await deactivate(db, userId, [ itemId ]);
+	await writePlacement(db, userId, itemId, props, {});
+	return undefined;
+}
+
+/**
+ * Tell open room sockets to re-read. Fired alongside the write, since reads are not synchronized.
+ */
+const announce = (channel: Channel<DecorationUpdate>) => channel.publish({ type: 'updated' });
+
+/**
+ * Take items off the map. Unknown or already-unplaced ids are left alone. Which index held an item
+ * is asked of the indices themselves — the zset of the hash's shard, or the global set — rather
+ * than remembered anywhere: a revoked item has already lost its definition by the time it gets
+ * here, and the data structures answer without one.
+ */
+export async function deactivate(db: Database, userId: string, itemIds: Iterable<string>) {
+	await Fn.mapAwait(itemIds, async itemId => {
+		const fields = await db.data.hGetAll(activeKey(userId, itemId));
+		if (fields.activatedAt === undefined) {
+			return;
+		}
+		const member = indexMember(userId, itemId);
+		const channel = await async function() {
+			if (fields.shard === undefined) {
+				const removed = await db.data.sRem(globalIndexKey, [ member ]);
+				return removed > 0 ? getGlobalDecorationChannel(db) : undefined;
+			} else {
+				const [ score ] = await Promise.all([
+					db.data.zScore(shardIndexKey(fields.shard), member),
+					db.data.zRem(shardIndexKey(fields.shard), [ member ]),
+				]);
+				return score === null ? undefined : getRoomDecorationChannel(db, fields.shard, makeRoomNameFromId(score));
+			}
+		}();
+		await Promise.all([
+			db.data.del(activeKey(userId, itemId)),
+			db.data.sRem(activeIndexKey(userId), [ itemId ]),
+			channel === undefined ? undefined : announce(channel),
+		]);
+	});
+}
+
+/**
+ * Deactivate the placements standing without ownership behind them: made while `grantAll` was on —
+ * keyed by decoration id, no stored grant — and stranded when the flag went off. A placement whose
+ * stored grant merely lost its pack is left alone; it comes back with the pack. Returns the ids
+ * taken down.
+ */
+export async function deactivateStranded(db: Database, userId: string) {
+	if (grantAll()) {
+		return [];
+	}
+	const placed = await db.data.sMembers(activeIndexKey(userId));
+	const stranded = [ ...Fn.filter(await Fn.mapAwait(placed, async itemId =>
+		await db.data.hGet(itemKey(userId, itemId), 'def') === null ? itemId : undefined), nonNullPredicate) ];
+	await deactivate(db, userId, stranded);
+	return stranded;
+}
+
+async function removeAllForUser(db: Database, userId: string) {
+	const [ ids, placed ] = await Promise.all([
+		db.data.sMembers(inventoryKey(userId)),
+		db.data.sMembers(activeIndexKey(userId)),
+	]);
+	// Implicit grants have no inventory entry, so placements are tracked separately from ownership.
+	await deactivate(db, userId, placed);
+	await Promise.all([
+		db.data.del(inventoryKey(userId)),
+		db.data.del(activeIndexKey(userId)),
+		...Fn.map(ids, id => db.data.del(itemKey(userId, id))),
+	]);
+}
+
+// Tear down a removed user's decorations as part of `User.remove`.
+userHooks.register('remove', removeAllForUser);
+
+// The symbols a user's badge decorations grant them. The account badge editor offers these beside
+// the numbered shapes, and a badge naming one is only stored if it shows up here — so a symbol stops
+// being wearable the moment its decoration is deactivated, though a badge already saved from it
+// stays as it was.
+badgeHooks.register('symbols', async (db, userId) => {
+	const items = await listForUser(db, userId);
+	return [ ...Fn.transform(items, function*(item) {
+		// Only a badge decoration carries a symbol, which the catalog checks when it loads a pack.
+		if (item.active !== undefined && item.definition.badge !== undefined) {
+			yield item.definition.badge;
+		}
+	}) ];
+});

--- a/packages/xxscreeps/mods/meta/decorations/placement.ts
+++ b/packages/xxscreeps/mods/meta/decorations/placement.ts
@@ -1,0 +1,94 @@
+import type { DecorationDefinition, DecorationProp, DecorationType } from './catalog.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+
+// The storage side of a placement: encoding property values for keyval and reading them back, plus
+// the domain predicates every consumer shares. Parsing what the client sends is the backend's
+// business and lives in [backend.ts](./backend.ts); the definition is the authority for a
+// property's type in both directions.
+
+/** A property value as the client exchanges it. */
+export type PropValue = boolean | number | string;
+
+/** Where a decoration stands. Absent for the global decorations that ride along with creeps. */
+export interface PlacementTarget {
+	shard?: string;
+	room?: string;
+}
+
+/** Where a decoration is placed, and the property values the player chose. */
+export interface Placement extends PlacementTarget {
+	props: Record<string, PropValue>;
+}
+
+/** A rejected placement, carrying the message handed back to the client. */
+export interface PlacementError {
+	error: string;
+}
+
+/**
+ * Whether a decoration of this type stands in a room. A creep decoration follows its owner from room
+ * to room and a badge is worn on the account rather than put anywhere, so neither names one — the
+ * client offers no room picker for either.
+ */
+export const isPlacedInRoom = (type: DecorationType) => type !== 'creep' && type !== 'badge';
+
+/** Whether a placement is visible on the world map, which the `world` property decides. */
+export const isOnWorldMap = (placement: Placement) => placement.props.world === true;
+
+/** Property values share the placement's hash with its target, so they carry a prefix of their own. */
+const propFieldPrefix = 'prop/';
+
+/** Hash fields hold strings; the definition tells {@link decodeProps} what each one was. */
+export const encodeProps = (props: Record<string, PropValue>): Record<string, string> =>
+	Object.fromEntries(Object.entries(props).map(([ name, value ]) =>
+		[ `${propFieldPrefix}${name}`, String(typeof value === 'boolean' ? Number(value) : value) ]));
+
+const decodeProp = (prop: DecorationProp, value: string): PropValue => {
+	switch (prop.type) {
+		case 'boolean': return value === '1';
+		case 'range': return Number(value);
+		case 'color': case 'display': case 'string': return value;
+	}
+};
+
+/** Fields naming a property the definition no longer declares are dropped, the way a pack edit leaves them. */
+export const decodeProps = (definition: DecorationDefinition, fields: Record<string, string>) => Fn.pipe(
+	Object.entries(fields),
+	$$ => Fn.transform($$, function*([ field, value ]) {
+		if (field.startsWith(propFieldPrefix)) {
+			const name = field.slice(propFieldPrefix.length);
+			const prop = Object.hasOwn(definition.props, name) ? definition.props[name] : undefined;
+			if (prop !== undefined) {
+				yield [ name, decodeProp(prop, value) ] as const;
+			}
+		}
+	}),
+	$$ => Object.fromEntries($$),
+);
+
+/**
+ * Decoration types whose presence in a room excludes `type` from it. A landscape paints both the
+ * floor and the walls, so it collides with either half; graffiti may be stacked freely.
+ */
+function conflictingTypes(type: DecorationType): readonly DecorationType[] {
+	switch (type) {
+		case 'floorLandscape': return [ 'floorLandscape', 'landscape' ];
+		case 'wallLandscape': return [ 'wallLandscape', 'landscape' ];
+		case 'landscape': return [ 'landscape', 'floorLandscape', 'wallLandscape' ];
+		case 'object': return [ 'object' ];
+		case 'metadata': return [ 'metadata' ];
+		case 'creep': return [ 'creep' ];
+		// Graffiti may be stacked freely, and a player may wear several granted symbols at once: the
+		// badge editor lists every one of them and they take turns rather than compete.
+		case 'wallGraffiti': case 'badge': return [];
+	}
+}
+
+/** Whether two decorations may not occupy the same room at the same time. */
+export function conflicts(left: DecorationDefinition, right: DecorationDefinition) {
+	if (!conflictingTypes(left.type).includes(right.type)) {
+		return false;
+	}
+	// Overlays and renderer overrides only argue when they decorate the same kind of object.
+	return left.type === 'object' || left.type === 'metadata' ? left.objectType === right.objectType : true;
+}

--- a/packages/xxscreeps/mods/meta/decorations/test.ts
+++ b/packages/xxscreeps/mods/meta/decorations/test.ts
@@ -3,8 +3,31 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { config } from 'xxscreeps/config/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { assert, describe, test } from 'xxscreeps/test/index.js';
 import { catalog, loadCatalog } from './catalog.js';
+import { grant, listForUser, revoke } from './model.js';
+import { conflicts } from './placement.js';
+
+const alice = '100';
+
+/** Toggle implicit ownership for one test, restoring whatever the config said. */
+function withGrantAll(grantAll: boolean) {
+	const decorations = config.decorations ??= {};
+	const previous = decorations.grantAll;
+	decorations.grantAll = grantAll;
+	return {
+		[Symbol.dispose]() {
+			if (previous === undefined) {
+				delete decorations.grantAll;
+			} else {
+				decorations.grantAll = previous;
+			}
+		},
+	};
+}
 
 /**
  * The bundled pack's directory. Fixtures name their artwork out of it: every asset a pack
@@ -454,6 +477,92 @@ describe('mods/meta/decorations', () => {
 						`'${definition.id}' draws both foregrounds from one texture`);
 				}
 			}
+		});
+	});
+
+	describe('ownership', () => {
+		test('granted decorations show up, revoked ones do not', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(false);
+			const { db } = testShard;
+			const [ definition ] = catalog.definitions.values();
+
+			assert.deepStrictEqual(await listForUser(db, alice), []);
+			const itemId = await grant(db, alice, definition!.id);
+			const owned = await listForUser(db, alice);
+			assert.strictEqual(owned.length, 1);
+			assert.strictEqual(owned[0]?.id, itemId);
+			assert.strictEqual(owned[0].definition.id, definition!.id);
+
+			assert.strictEqual(await revoke(db, alice, itemId), true);
+			assert.strictEqual(await revoke(db, alice, itemId), false);
+			assert.deepStrictEqual(await listForUser(db, alice), []);
+		});
+
+		// The client sorts the inventory by age and does not check first, so an item without one takes
+		// the page down. Implicit ownership has no moment to report, so it reports the epoch.
+		test('every owned item carries the moment it was granted', async () => {
+			await using testShard = await instantiateTestShard();
+			const { db } = testShard;
+			{
+				using grantAll = withGrantAll(true);
+				const owned = await listForUser(db, alice);
+				assert.ok(owned.length > 0);
+				assert.ok(owned.every(item => item.createdAt === 0), 'implicit ownership ties on the epoch');
+			}
+			using grantAll = withGrantAll(false);
+			const [ definition ] = catalog.definitions.values();
+			await grant(db, alice, definition!.id);
+			const owned = await listForUser(db, alice);
+			assert.strictEqual(owned.length, 1);
+			assert.ok(owned[0]!.createdAt > 0, 'a stored grant reports when it was made');
+		});
+
+		test('granting something the catalog does not have is an error', async () => {
+			await using testShard = await instantiateTestShard();
+			await assert.rejects(grant(testShard.db, alice, 'no-such-decoration'), /No such decoration/);
+		});
+
+		test('grantAll hands out the whole catalog, keyed by decoration id', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const owned = await listForUser(testShard.db, alice);
+			assert.strictEqual(owned.length, catalog.definitions.size);
+			for (const item of owned) {
+				assert.strictEqual(item.id, item.definition.id);
+			}
+		});
+
+		test('removing a user drops their decorations', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(false);
+			const { db } = testShard;
+			const [ definition ] = catalog.definitions.values();
+
+			await grant(db, alice, definition!.id);
+			await User.remove(db, alice);
+			assert.deepStrictEqual(await listForUser(db, alice), []);
+		});
+	});
+
+	describe('placement', () => {
+		const floor = catalog.definitions.get('xx-floor-plain')!;
+		const wall = catalog.definitions.get('xx-wall-plain')!;
+		const room = catalog.definitions.get('xx-room-neon')!;
+
+		test('a landscape collides with both halves it paints', () => {
+			assert.ok(conflicts(room, floor));
+			assert.ok(conflicts(room, wall));
+			assert.ok(!conflicts(floor, wall));
+			assert.ok(conflicts(floor, floor));
+		});
+
+		test('renderer overrides only argue over the same kind of object', () => {
+			const controller = { ...floor, id: 'test-controller', type: 'metadata' as const, objectType: 'controller' };
+			const spawn = { ...controller, id: 'test-spawn', objectType: 'spawn' };
+			assert.ok(conflicts(controller, { ...controller, id: 'test-other' }));
+			assert.ok(!conflicts(controller, spawn));
+			assert.ok(!conflicts(controller, floor));
 		});
 	});
 });

--- a/packages/xxscreeps/mods/meta/decorations/test.ts
+++ b/packages/xxscreeps/mods/meta/decorations/test.ts
@@ -4,14 +4,23 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { config } from 'xxscreeps/config/index.js';
+import * as Badge from 'xxscreeps/engine/db/user/badge.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
+import { insertControlledRoom } from 'xxscreeps/mods/classic/controller/model.js';
 import { instantiateTestShard } from 'xxscreeps/test/import.js';
 import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { activate, parsePlacement, placementToWire } from './backend.js';
 import { catalog, loadCatalog } from './catalog.js';
-import { grant, listForUser, revoke } from './model.js';
-import { conflicts } from './placement.js';
+import { deactivate, deactivateStranded, grant, listForRoom, listForUser, listGlobal, revoke } from './model.js';
+import { conflicts, isOnWorldMap } from './placement.js';
 
 const alice = '100';
+const shard = 'shard0';
+const roomName = 'W10N10';
+const otherRoomName = 'W10N9';
+
+/** The `active` payload of a floor landscape activation request. */
+const floorPlacement = (active: Record<string, unknown> = {}) => ({ shard, room: roomName, ...active });
 
 /** Toggle implicit ownership for one test, restoring whatever the config said. */
 function withGrantAll(grantAll: boolean) {
@@ -550,6 +559,82 @@ describe('mods/meta/decorations', () => {
 		const wall = catalog.definitions.get('xx-wall-plain')!;
 		const room = catalog.definitions.get('xx-room-neon')!;
 
+		test('property values are checked against the definition', () => {
+			assert.ok('error' in parsePlacement(floor, { shard, room: roomName, nope: 1 }));
+			assert.ok('error' in parsePlacement(floor, { shard, room: roomName, floorBackgroundColor: 'red' }));
+			assert.ok('error' in parsePlacement(floor, { shard, room: roomName, floorBackgroundBrightness: 99 }));
+			assert.ok('error' in parsePlacement(floor, { floorBackgroundColor: '#123456' }), 'a room is required');
+		});
+
+		// The client offers a free text field unless the pack labels the property its own way, so a
+		// value the renderer's animation table has no entry for has to lose here rather than there.
+		test('an animation outside the renderer\'s table is rejected', async () => {
+			const loaded = await loadCatalog([ source({
+				name: 'test',
+				themes: byId(theme),
+				decorations: byId({ ...graffiti, props: { ...graffiti.props, animation: { type: 'string', default: '' } } }),
+			}) ]);
+			const definition = loaded.definitions.get('test-graffiti')!;
+			assert.ok('error' in parsePlacement(definition, { shard, room: roomName, animation: 'wiggle' }));
+			assert.ok(!('error' in parsePlacement(definition, { shard, room: roomName, animation: 'neon' })));
+			assert.ok(!('error' in parsePlacement(definition, { shard, room: roomName, animation: '' })), 'none is a value');
+		});
+
+		test('numbers and booleans are accepted in their string spelling', () => {
+			const placement = parsePlacement(floor, { shard, room: roomName, floorBackgroundBrightness: '0.5', world: 'true' });
+			assert.ok(!('error' in placement));
+			assert.strictEqual(placement.props.floorBackgroundBrightness, 0.5);
+			assert.strictEqual(placement.props.world, true);
+		});
+
+		test('properties the client leaves out fall back to the definition seed', () => {
+			const placement = parsePlacement(floor, { shard, room: roomName });
+			assert.ok(!('error' in placement));
+			assert.strictEqual(placement.props.floorBackgroundColor, floor.props.floorBackgroundColor!.default);
+		});
+
+		// The official client sends readonly properties back like any other, so a value here cannot be
+		// rejected — but readonly promises the definition owns the value, so it cannot win either.
+		test('a readonly property keeps its seed no matter what the client sends', () => {
+			const placement = parsePlacement(floor, { shard, room: roomName, floorForegroundColor: '#ff0000' });
+			assert.ok(!('error' in placement));
+			assert.strictEqual(placement.props.floorForegroundColor, floor.props.floorForegroundColor!.default);
+		});
+
+		test('what the client sends round-trips back in the same shape', () => {
+			const sent = { shard, room: roomName, world: false, floorBackgroundColor: '#abcdef' };
+			const placement = parsePlacement(floor, sent);
+			assert.ok(!('error' in placement));
+			// Flat in, flat out: the id and the target sit next to the property values, never wrapping
+			// them. The room view flattens this bag and matches socket updates against its `_id`, so
+			// the id has to be inside it.
+			const wire = placementToWire('item-1', placement);
+			assert.strictEqual(wire._id, 'item-1');
+			assert.strictEqual(wire.shard, shard);
+			assert.strictEqual(wire.room, roomName);
+			assert.strictEqual(wire.world, false);
+			assert.strictEqual(wire.floorBackgroundColor, '#abcdef');
+			assert.ok(!('props' in wire));
+			// And it parses again unchanged once the activate route strips the wire-only `_id`, which
+			// is the trip the client's edit-and-resend makes.
+			const { _id, ...resent } = wire;
+			assert.deepStrictEqual(parsePlacement(floor, resent), placement);
+		});
+
+		test('a creep decoration names no room, since it follows its owner', () => {
+			const creep = { ...floor, id: 'test-creep', type: 'creep' as const };
+			const placement = parsePlacement(creep, {});
+			assert.ok(!('error' in placement));
+			assert.strictEqual(placement.room, undefined);
+			assert.strictEqual(placement.shard, undefined);
+		});
+
+		test('a badge names no room either, since it is worn rather than placed', () => {
+			const placement = parsePlacement(catalog.definitions.get('xx-chevrons')!, {});
+			assert.ok(!('error' in placement));
+			assert.strictEqual(placement.room, undefined);
+		});
+
 		test('a landscape collides with both halves it paints', () => {
 			assert.ok(conflicts(room, floor));
 			assert.ok(conflicts(room, wall));
@@ -563,6 +648,206 @@ describe('mods/meta/decorations', () => {
 			assert.ok(conflicts(controller, { ...controller, id: 'test-other' }));
 			assert.ok(!conflicts(controller, spawn));
 			assert.ok(!conflicts(controller, floor));
+		});
+	});
+
+	describe('activation', () => {
+		/** Placing needs a room the player holds, which the test shard does not hand out. */
+		async function ownRoom(testShard: Awaited<ReturnType<typeof instantiateTestShard>>, room = roomName) {
+			await insertControlledRoom(testShard.shard, alice, room);
+		}
+
+		test('an owned decoration can be placed and shows up in the room', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			assert.strictEqual(await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement()), undefined);
+			const placed = await listForRoom(db, shard, roomName);
+			assert.strictEqual(placed.length, 1);
+			assert.strictEqual(placed[0]?.id, 'xx-floor-plain');
+			assert.strictEqual(placed[0].userId, alice);
+			assert.strictEqual(placed[0].active.room, roomName);
+			assert.deepStrictEqual(await listForRoom(db, shard, otherRoomName), []);
+
+			const [ item ] = (await listForUser(db, alice)).filter(each => each.id === 'xx-floor-plain');
+			assert.strictEqual(item?.active?.room, roomName);
+			assert.ok(item.activatedAt !== undefined);
+		});
+
+		test('placing in a room the player does not hold is refused', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const result = await activate(testShard.db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			assert.deepStrictEqual(result, { error: 'room not controlled' });
+		});
+
+		test('an unknown room is refused', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			await ownRoom(testShard);
+			const result = await activate(testShard.db, testShard.shard, alice, 'xx-floor-plain', floorPlacement({ room: 'W99N99' }));
+			assert.deepStrictEqual(result, { error: 'unknown room' });
+		});
+
+		test('a decoration the player does not own is refused', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(false);
+			await ownRoom(testShard);
+			const result = await activate(testShard.db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			assert.deepStrictEqual(result, { error: 'not owned' });
+		});
+
+		test('a landscape refuses a room that already has a floor', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			const result = await activate(db, testShard.shard, alice, 'xx-room-neon', floorPlacement());
+			assert.deepStrictEqual(result, { error: 'already decorated' });
+		});
+
+		test('re-activating moves the decoration instead of duplicating it', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+			await ownRoom(testShard, otherRoomName);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement({ room: otherRoomName }));
+
+			assert.deepStrictEqual(await listForRoom(db, shard, roomName), []);
+			assert.strictEqual((await listForRoom(db, shard, otherRoomName)).length, 1);
+		});
+
+		test('deactivating takes it back off the map', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			await deactivate(db, alice, [ 'xx-floor-plain' ]);
+			assert.deepStrictEqual(await listForRoom(db, shard, roomName), []);
+			const [ item ] = (await listForUser(db, alice)).filter(each => each.id === 'xx-floor-plain');
+			assert.strictEqual(item?.active, undefined);
+		});
+
+		test('a revoke that finds no grant leaves the placement alone', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			// Implicit ownership has no grant to take away, so this fails — without undoing the placement.
+			assert.strictEqual(await revoke(db, alice, 'xx-floor-plain'), false);
+			assert.strictEqual((await listForRoom(db, shard, roomName)).length, 1);
+		});
+
+		// A placement made under implicit ownership has no stored grant behind it. Turning `grantAll`
+		// off strands it — nothing lists it, so nothing can deactivate it — which is what the cleanup
+		// sweep is for.
+		test('turning grantAll off strands a placement until cleanup', async () => {
+			await using testShard = await instantiateTestShard();
+			const { db } = testShard;
+			await ownRoom(testShard);
+			{
+				using grantAll = withGrantAll(true);
+				await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+				// Nothing is stranded while ownership is implicit.
+				assert.deepStrictEqual(await deactivateStranded(db, alice), []);
+			}
+			using grantAll = withGrantAll(false);
+			assert.deepStrictEqual(await listForRoom(db, shard, roomName), [], 'the placement is invisible');
+			assert.deepStrictEqual(await deactivateStranded(db, alice), [ 'xx-floor-plain' ]);
+			assert.deepStrictEqual(await deactivateStranded(db, alice), []);
+			{
+				// Taken down rather than lying in wait: implicit ownership lists the item unplaced again.
+				using grantAllAgain = withGrantAll(true);
+				const [ item ] = (await listForUser(db, alice)).filter(each => each.id === 'xx-floor-plain');
+				assert.strictEqual(item?.active, undefined);
+			}
+		});
+
+		test('cleanup leaves a placement with a stored grant alone', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(false);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			const itemId = await grant(db, alice, 'xx-floor-plain');
+			await activate(db, testShard.shard, alice, itemId, floorPlacement());
+			assert.deepStrictEqual(await deactivateStranded(db, alice), []);
+			assert.strictEqual((await listForRoom(db, shard, roomName)).length, 1);
+		});
+
+		test('removing a user takes their placements with them', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			await User.remove(db, alice);
+			assert.deepStrictEqual(await listForRoom(db, shard, roomName), []);
+		});
+
+		// The symbol only reaches `/api/user/badge` while the decoration granting it is active — that
+		// route stores a badge naming paths of its own, and takes the paths from the grant rather than
+		// from the request.
+		test('an active badge is a symbol its owner may wear', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			const symbol = catalog.definitions.get('xx-chevrons')!.badge!;
+			const worn = { color1: '#111111', color2: '#222222', color3: '#333333', flip: false, type: symbol };
+
+			await assert.rejects(Badge.validate(db, alice, { ...worn }), /not granted/);
+			assert.strictEqual(await activate(db, testShard.shard, alice, 'xx-chevrons', {}), undefined);
+			assert.deepStrictEqual(await Badge.validate(db, alice, { ...worn }), worn);
+
+			// And a symbol nobody granted stays out, however well-formed the request looks.
+			await assert.rejects(
+				Badge.validate(db, alice, { ...worn, type: { path1: 'M 0 0 H 1 Z', path2: '' } }), /not granted/);
+
+			await deactivate(db, alice, [ 'xx-chevrons' ]);
+			await assert.rejects(Badge.validate(db, alice, { ...worn }), /not granted/);
+		});
+
+		// It decorates an account rather than a room, so no room view has anything to draw for it —
+		// unlike the creep decorations, which every room reports alongside what stands in it.
+		test('a badge is reported to nobody but its owner', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			await activate(db, testShard.shard, alice, 'xx-chevrons', {});
+			assert.deepStrictEqual(await listForRoom(db, shard, roomName), []);
+			assert.deepStrictEqual(await listGlobal(db), []);
+			const [ item ] = (await listForUser(db, alice)).filter(each => each.id === 'xx-chevrons');
+			assert.ok(item?.active !== undefined);
+		});
+
+		test('the world-map flag survives the round trip through storage', async () => {
+			await using testShard = await instantiateTestShard();
+			using grantAll = withGrantAll(true);
+			const { db } = testShard;
+			await ownRoom(testShard);
+
+			// The bundled pack seeds `world` on, so a defaulted placement is map-visible.
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement());
+			const [ shown ] = await listForRoom(db, shard, roomName);
+			assert.strictEqual(isOnWorldMap(shown!.active), true);
+
+			await activate(db, testShard.shard, alice, 'xx-floor-plain', floorPlacement({ world: false }));
+			const [ hidden ] = await listForRoom(db, shard, roomName);
+			assert.strictEqual(isOnWorldMap(hidden!.active), false);
 		});
 	});
 });

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -21,7 +21,7 @@ import * as User from 'xxscreeps/engine/db/user/index.js';
 import { updateUserRoomRelationships, userToIntentRoomsSetKey } from 'xxscreeps/engine/processor/model.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { getServiceChannel } from 'xxscreeps/engine/service/index.js';
-import { primitiveComparator } from 'xxscreeps/functional/comparator.js';
+import { mappedPrimitiveComparator, primitiveComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
 import { Game, GameState, runAsUser, runOneShot, runWithState } from 'xxscreeps/game/index.js';
@@ -38,6 +38,9 @@ import 'xxscreeps/mods/meta/messages/model.js';
 import { create as createSpawn } from 'xxscreeps/mods/classic/spawn/spawn.js';
 import { createRuin } from 'xxscreeps/mods/classic/structure/ruin.js';
 import { OwnedStructure } from 'xxscreeps/mods/classic/structure/structure.js';
+import { catalog } from 'xxscreeps/mods/meta/decorations/catalog.js';
+// Also a side-effect import: registers the `User.remove` hook for owned decorations.
+import * as Decorations from 'xxscreeps/mods/meta/decorations/model.js';
 import { deleteUserMemoryBlob, loadUserMemoryBlob } from 'xxscreeps/mods/meta/memory/model.js';
 import * as C from 'xxscreeps:mods/constants';
 
@@ -174,6 +177,79 @@ async function userBranch(who: string, branch: string) {
 	await save();
 	await Code.userCodeChannel(db, id).publish({ type: 'switch', branch });
 	out(`Set active branch for ${who} (${id}) to '${branch}'.`);
+}
+
+// Decorations a user owns. `grantAll` (the default) hands out the whole catalog, in which case
+// `list` reports that implicit ownership; grants are still written and surface once it's off.
+function decorationCatalog() {
+	const definitions = [ ...catalog.definitions.values() ].sort(mappedPrimitiveComparator(definition => definition.id));
+	if (definitions.length === 0) {
+		out('(no decorations; no pack is loaded)');
+		return;
+	}
+	const idWidth = Math.max(...Fn.map(definitions, definition => definition.id.length));
+	out(`${'id'.padEnd(idWidth)}  ${'type'.padEnd(15)}  ${'theme'.padEnd(12)}  name`);
+	for (const definition of definitions) {
+		out(`${definition.id.padEnd(idWidth)}  ${definition.type.padEnd(15)}  ${definition.theme.padEnd(12)}  ${definition.name}`);
+	}
+}
+
+async function decorationList(who: string) {
+	const id = await resolveUserId(who);
+	const items = await Decorations.listForUser(db, id);
+	if (items.length === 0) {
+		out('(none)');
+		return;
+	}
+	if (Decorations.grantAll()) {
+		out('Everyone owns the whole catalog while \'decorations.grantAll\' is on; these items have no stored grant.');
+	}
+	const idWidth = Math.max(...Fn.map(items, item => item.id.length));
+	out(`${'item'.padEnd(idWidth)}  ${'decoration'.padEnd(20)}  name`);
+	for (const item of items) {
+		out(`${item.id.padEnd(idWidth)}  ${item.definition.id.padEnd(20)}  ${item.definition.name}`);
+	}
+}
+
+async function decorationGrant(who: string, definitionId: string) {
+	const id = await resolveUserId(who);
+	const itemId = await Decorations.grant(db, id, definitionId);
+	await save();
+	out(`Granted '${definitionId}' to ${who} (${id}) as ${itemId}.`);
+}
+
+async function decorationRevoke(who: string, itemId: string) {
+	const id = await resolveUserId(who);
+	if (!await Decorations.revoke(db, id, itemId)) {
+		// `list` reports implicit ownership under `grantAll`, whose ids name a decoration rather
+		// than a stored grant. Revoking one is not a thing you can do; turning `grantAll` off is.
+		throw new Error(Decorations.grantAll()
+			? `User ${who} has no stored grant ${itemId}; ownership is implicit while 'decorations.grantAll' is on`
+			: `User ${who} does not own item ${itemId}`);
+	}
+	await save();
+	out(`Revoked ${itemId} from ${who} (${id}).`);
+}
+
+// Placements made while `decorations.grantAll` was on have no stored grant; turning the flag off
+// strands them — invisible to everyone, held in the store, unreachable from the client. This takes
+// them off the map. With no user given, every user is swept.
+async function decorationCleanup(who: string | undefined) {
+	if (Decorations.grantAll()) {
+		out('Nothing is stranded while \'decorations.grantAll\' is on; ownership is implicit.');
+		return;
+	}
+	const ids = who === undefined ? await db.data.sMembers('users') : [ await resolveUserId(who) ];
+	const counts = await Fn.mapAwait(ids, async id => {
+		const removed = await Decorations.deactivateStranded(db, id);
+		if (removed.length > 0) {
+			out(`Deactivated for ${id}: ${removed.join(', ')}`);
+		}
+		return removed.length;
+	});
+	await save();
+	const total = Fn.accumulate(counts);
+	out(total === 0 ? 'No stranded placements.' : `Deactivated ${total} stranded placements.`);
 }
 
 // Modules are keyed by filename (`main.js`, ...) — the same shape the backend saves for players.
@@ -351,6 +427,11 @@ function usage(): never {
   user badge    <name|id> <json|file>
   user password <name|id> <password>
   user branch   <name|id> <branch>
+  decoration catalog
+  decoration list    <name|id>
+  decoration grant   <name|id> <decorationId>
+  decoration revoke  <name|id> <itemId>
+  decoration cleanup [name|id]
   bot  add    <name> <codeDir> [branch] [--spawn <room> [x,y]]
   bot  update <name|id> <codeDir> [branch]
   bot  remove <name|id>
@@ -376,6 +457,11 @@ try {
 		case 'user badge': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBadge(rest[0], rest[1]); break;
 		case 'user password': if (rest[0] === undefined || rest[1] === undefined) usage(); await userPassword(rest[0], rest[1]); break;
 		case 'user branch': if (rest[0] === undefined || rest[1] === undefined) usage(); await userBranch(rest[0], rest[1]); break;
+		case 'decoration catalog': decorationCatalog(); break;
+		case 'decoration list': if (rest[0] === undefined) usage(); await decorationList(rest[0]); break;
+		case 'decoration grant': if (rest[0] === undefined || rest[1] === undefined) usage(); await decorationGrant(rest[0], rest[1]); break;
+		case 'decoration revoke': if (rest[0] === undefined || rest[1] === undefined) usage(); await decorationRevoke(rest[0], rest[1]); break;
+		case 'decoration cleanup': await decorationCleanup(rest[0]); break;
 		case 'bot add': {
 			const spawnIndex = rest.indexOf('--spawn');
 			const args = spawnIndex === -1 ? rest : rest.slice(0, spawnIndex);


### PR DESCRIPTION
The rest of the decorations mod, on top of #365. Two commits, reviewable one at a time — I kept them separate because the first is pure account state and the second is pure wire surface, but they only make sense together: the model has no caller until the routes exist, so splitting them across two PRs would land a feature nothing can reach.

**`decorations: own, place and wear what the catalog offers`** — the account state. `model.ts` stores grants and placements in `db.data`; decorations are not `RoomObject`s, they cost no bytes in a room blob and the processor never touches them. Room placements live in one zset per shard scored by room id, so *where a decoration stands* is the data structure's own answer in both directions — a range at a room's score is what stands there, a member's score is where it stands. A room's channel fires when its placements change and one global channel carries the creep decorations, so an idle room costs nothing per tick. `placement.ts` holds the storage half: the props codec and which definitions collide. Each kind of placement — room, creep, badge — has a typed entry point, racing conflicts settle deterministically in itemId order, and deactivation drops a placement the same way everywhere, stranded ones included.

Placing checks room ownership through the controller model (#362). A badge decoration is worn rather than placed and answers the badge symbols hook (#364). `manage decoration` hands out grants when `grantAll` is off — with it on (the default) everybody owns the whole catalog and no grant is read at all, which is the natural setup for a private server.

**`decorations: serve the catalog, the inventory and what is placed`** — the routes. Assets are served immutable; the urls already carry a content cache-bust, so a browser may keep them forever. The inventory and themes routes replace the core stubs, and `activate` parses the request apart right here — the client's `_id` spelling is wire shape and nothing else, so it is stripped from what comes in and put back on what goes out, and it lives in this one file. The room socket and the world map re-read a room's placements when its channel fires. The client learns the whole feature from the version endpoint's feature flags and menu entries (#363).

Both commits build, pass the suite and lint on their own (623 and 645 tests). I also carried your catalog-slice edits forward into these files: `color` rather than `colour` throughout, and the one inline object type is now a named interface — `PlacementTarget`, which `Placement` extends, since it was the location half of that interface spelled out a second time.