### PR TITLE
email: hold an address pending confirmation, and confirm it from a mailed link

### DIFF
--- a/.changeset/auth-purpose-tokens.md
+++ b/.changeset/auth-purpose-tokens.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Sign tokens for purposes other than login, with their own lifetime, and never authenticate one.

--- a/.changeset/backend-mail.md
+++ b/.changeset/backend-mail.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Mail the confirmation link for a pending address, through a `mailer` a mod registers.

--- a/.changeset/email-verification-link.md
+++ b/.changeset/email-verification-link.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Confirm a pending address from a signed, expiring link; report an unconfirmed one as `emailDirty`.

--- a/.changeset/user-change-email.md
+++ b/.changeset/user-change-email.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `POST /api/user/email`, which the client's account page already calls to change an address.

--- a/.changeset/user-email-resend.md
+++ b/.changeset/user-email-resend.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `POST /api/user/email/resend`, which mails the confirmation link for a pending address again.

--- a/.changeset/user-info-email.md
+++ b/.changeset/user-info-email.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Report a user's email address on `/api/auth/me` from core, not only from the password mod.

--- a/.changeset/user-pending-email.md
+++ b/.changeset/user-pending-email.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Hold a user's email address pending confirmation instead of trusting it when given.

--- a/packages/xxscreeps/backend/auth/email.ts
+++ b/packages/xxscreeps/backend/auth/email.ts
@@ -1,0 +1,10 @@
+import { config } from 'xxscreeps/config/index.js';
+
+export function validateEmail(email: string) {
+	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(email);
+}
+
+/** Whether an address given to the backend is parked until the user proves the inbox is theirs. */
+export function holdsPendingEmail() {
+	return config.backend.autoVerifyEmail === false;
+}

--- a/packages/xxscreeps/backend/auth/email.ts
+++ b/packages/xxscreeps/backend/auth/email.ts
@@ -1,4 +1,16 @@
 import { config } from 'xxscreeps/config/index.js';
+import { checkSignedToken } from './token.js';
+
+// Route which confirms an address; also the path baked into the link mailed to the user.
+export const emailVerifyPath = '/api/auth/email/verify';
+
+// Distinguishes these from login tokens, which share the signing key.
+const kPurpose = 'email-verify';
+
+// The token binds the exact address as well as the user, so a link only ever confirms what it was
+// minted for, and never a later address the user has since asked for. `userId` never contains the
+// separator, so the address is whatever follows it.
+const kSeparator = ':';
 
 export function validateEmail(email: string) {
 	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(email);
@@ -7,4 +19,20 @@ export function validateEmail(email: string) {
 /** Whether an address given to the backend is parked until the user proves the inbox is theirs. */
 export function holdsPendingEmail() {
 	return config.backend.autoVerifyEmail === false;
+}
+
+/** Read back the user and address a confirmation link was minted for, or `undefined`. */
+export async function checkEmailVerificationToken(token: string) {
+	const payload = await checkSignedToken(kPurpose, token);
+	if (payload === undefined) {
+		return;
+	}
+	const separator = payload.indexOf(kSeparator);
+	if (separator === -1) {
+		return;
+	}
+	return {
+		userId: payload.slice(0, separator),
+		email: payload.slice(separator + 1),
+	};
 }

--- a/packages/xxscreeps/backend/auth/email.ts
+++ b/packages/xxscreeps/backend/auth/email.ts
@@ -1,11 +1,16 @@
+import type { MailRefusal } from 'xxscreeps/backend/mail.js';
+import type { Database } from 'xxscreeps/engine/db/index.js';
+import { mailer } from 'xxscreeps/backend/mail.js';
 import { config } from 'xxscreeps/config/index.js';
-import { checkSignedToken } from './token.js';
+import { pendingEmailForUser, setEmail } from 'xxscreeps/engine/db/user/index.js';
+import { checkSignedToken, makeSignedToken } from './token.js';
 
 // Route which confirms an address; also the path baked into the link mailed to the user.
 export const emailVerifyPath = '/api/auth/email/verify';
 
 // Distinguishes these from login tokens, which share the signing key.
 const kPurpose = 'email-verify';
+const kDefaultTtlHours = 24;
 
 // The token binds the exact address as well as the user, so a link only ever confirms what it was
 // minted for, and never a later address the user has since asked for. `userId` never contains the
@@ -16,9 +21,17 @@ export function validateEmail(email: string) {
 	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(email);
 }
 
-/** Whether an address given to the backend is parked until the user proves the inbox is theirs. */
-export function holdsPendingEmail() {
-	return config.backend.autoVerifyEmail === false;
+/**
+ * Build the confirmation link for `email`. It is rooted at `backend.publicUrl` rather than at the
+ * origin of the request which triggered the mail: that origin is the `Host` header, so a forged one
+ * would have us mail a link pointing at somebody else's server.
+ *
+ * The link stays valid for `backend.emailVerifyTtlHours`.
+ */
+async function makeEmailVerificationLink(base: string, userId: string, email: string) {
+	const ttl = (config.backend.emailVerifyTtlHours ?? kDefaultTtlHours) * 60 * 60;
+	const token = await makeSignedToken(kPurpose, `${userId}${kSeparator}${email}`, ttl);
+	return `${base.replace(/\/+$/, '')}${emailVerifyPath}?token=${encodeURIComponent(token)}`;
 }
 
 /** Read back the user and address a confirmation link was minted for, or `undefined`. */
@@ -35,4 +48,60 @@ export async function checkEmailVerificationToken(token: string) {
 		userId: payload.slice(0, separator),
 		email: payload.slice(separator + 1),
 	};
+}
+
+/** Whether an address given to the backend is parked until the user proves the inbox is theirs. */
+export function holdsPendingEmail() {
+	return config.backend.autoVerifyEmail === false;
+}
+
+/**
+ * Mail `userId` the link confirming whichever address they are waiting on, if any. Returns a refusal
+ * when the mail was deliberately not sent, and nothing when it is on its way or the user has nothing
+ * pending — the caller which cares about that difference has already read the pending address.
+ */
+export async function sendPendingEmailVerification(db: Database, userId: string) {
+	const email = await pendingEmailForUser(db, userId);
+	if (email === null) {
+		return;
+	}
+	const base = config.backend.publicUrl;
+	if (base === undefined) {
+		// Nothing to point the user at. `backendReady` says so once at startup; here it is the same
+		// answer a mailer gives when it declines, since the caller has the same nothing to report.
+		return { reason: 'no public url' };
+	}
+	const url = await makeEmailVerificationLink(base, userId, email);
+	return mailer.current.send({
+		to: email,
+		subject: 'Confirm your email address',
+		text: 'Please confirm this address by opening the link below:\n\n' +
+			`${url}\n\n` +
+			"If you didn't ask for this you can ignore this message.",
+		html: '<p>Please confirm this address by opening the link below:</p>' +
+			`<p><a href="${url}">Confirm my email address</a></p>` +
+			`<p>Or paste this into your browser:<br><code>${url}</code></p>` +
+			"<p>If you didn't ask for this you can ignore this message.</p>",
+	});
+}
+
+/**
+ * Set `email` as the user's address, holding it pending when this server confirms addresses, and
+ * mail the confirmation link when it does. Reports whether the address is pending and why no mail
+ * went out, if that is the case.
+ */
+export async function setAndVerifyEmail(db: Database, userId: string, email: string) {
+	const { pending } = await setEmail(db, userId, email, holdsPendingEmail());
+	const refusal = pending ? await sendPendingEmailVerification(db, userId) : undefined;
+	return { pending, refusal };
+}
+
+/**
+ * Log a confirmation mail which was deliberately not sent. Registration has no field to carry the
+ * reason, and the user can ask for the mail again from their account page once they are in.
+ */
+export function reportUnsentVerification(userId: string, refusal: MailRefusal | undefined) {
+	if (refusal !== undefined) {
+		console.error(`Could not mail an address confirmation to user ${userId}: ${refusal.reason}`);
+	}
 }

--- a/packages/xxscreeps/backend/auth/test.ts
+++ b/packages/xxscreeps/backend/auth/test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { checkEmailVerificationToken } from './email.js';
 import { checkSignedToken, checkToken, makeSignedToken, makeToken } from './token.js';
 
 describe('auth tokens', () => {
@@ -26,5 +27,12 @@ describe('auth tokens', () => {
 	test('garbage is refused rather than thrown at', async () => {
 		assert.strictEqual(await checkToken('not-a-token'), undefined);
 		assert.strictEqual(await checkSignedToken('greeting', ''), undefined);
+	});
+});
+
+describe('email verification links', () => {
+	// The round trip through a real mailed link is exercised in `backend/test.ts`.
+	test('a login token is not a verification link', async () => {
+		assert.strictEqual(await checkEmailVerificationToken(await makeToken('100')), undefined);
 	});
 });

--- a/packages/xxscreeps/backend/auth/test.ts
+++ b/packages/xxscreeps/backend/auth/test.ts
@@ -1,0 +1,30 @@
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { checkSignedToken, checkToken, makeSignedToken, makeToken } from './token.js';
+
+describe('auth tokens', () => {
+	test('a login token round-trips', async () => {
+		assert.strictEqual(await checkToken(await makeToken('abc123')), 'abc123');
+		assert.strictEqual(await checkToken(await makeToken('new:abc123:steam:76561')), 'new:abc123:steam:76561');
+	});
+
+	test('a signed token round-trips for its own purpose only', async () => {
+		const token = await makeSignedToken('greeting', 'hello', 60);
+		assert.strictEqual(await checkSignedToken('greeting', token), 'hello');
+		assert.strictEqual(await checkSignedToken('farewell', token), undefined);
+	});
+
+	test('an expired token is refused', async () => {
+		assert.strictEqual(await checkSignedToken('greeting', await makeSignedToken('greeting', 'hello', -1)), undefined);
+	});
+
+	test('a signed token can never authenticate', async () => {
+		// Both kinds share the signing key, so this is what keeps a token minted for some other
+		// purpose from being presented as a session token.
+		assert.strictEqual(await checkToken(await makeSignedToken('greeting', 'hello', 60)), undefined);
+	});
+
+	test('garbage is refused rather than thrown at', async () => {
+		assert.strictEqual(await checkToken('not-a-token'), undefined);
+		assert.strictEqual(await checkSignedToken('greeting', ''), undefined);
+	});
+});

--- a/packages/xxscreeps/backend/auth/token.ts
+++ b/packages/xxscreeps/backend/auth/token.ts
@@ -45,10 +45,22 @@ async function decrypt(data: string) {
 	return Consumers.buffer(cipher);
 }
 
+// Purpose tag separator. Login payloads are a user id or a `new:...` triplet, neither of which can
+// contain a nul byte, so the tag is what keeps the two token kinds apart in one key space.
+const kPurposeSeparator = '\0';
+
+function makeStringToken(payload: string, expiresInSeconds: number) {
+	const expires = Math.floor(Date.now() / 1000) + expiresInSeconds;
+	const buffer = Buffer.alloc(4 + Buffer.byteLength(payload, 'utf8'));
+	buffer.writeInt32LE(-expires);
+	buffer.write(payload, 4, 'utf8');
+	return encrypt(buffer);
+}
+
 export function makeToken(id: string) {
-	const expires = Math.floor(Date.now() / 1000) + kTokenExpiry;
 	if (/^[a-f0-9]+$/.test(id)) {
 		// Hex only id
+		const expires = Math.floor(Date.now() / 1000) + kTokenExpiry;
 		const buffer = Buffer.alloc(5 + (id.length + 1 >>> 1), 0);
 		const odd = id.length % 2;
 		buffer.writeInt32LE(expires);
@@ -57,15 +69,11 @@ export function makeToken(id: string) {
 		return encrypt(buffer);
 	} else {
 		// Any string
-		const payload = Buffer.from(id, 'utf8');
-		const buffer = Buffer.alloc(4 + payload.length);
-		buffer.writeInt32LE(-expires);
-		buffer.set(payload, 4);
-		return encrypt(buffer);
+		return makeStringToken(id, kTokenExpiry);
 	}
 }
 
-export async function checkToken(token?: string) {
+async function readToken(token?: string) {
 	const buffer = await decrypt(token ?? '');
 	if (!buffer) {
 		return;
@@ -82,4 +90,30 @@ export async function checkToken(token?: string) {
 		// Any string
 		return buffer.toString('utf8', 4);
 	}
+}
+
+export async function checkToken(token?: string) {
+	const value = await readToken(token);
+	// Purpose-tagged tokens share the signing key but must never authenticate a request.
+	return value?.includes(kPurposeSeparator) ? undefined : value;
+}
+
+/**
+ * Mint a token which carries `payload` for a named `purpose` other than authentication — e.g. the
+ * address confirmation link mailed to a user. Signed with the same key as login tokens, so links
+ * survive a restart and work across backend replicas without shared storage, but tagged with the
+ * purpose so the two can never be exchanged for one another.
+ */
+export function makeSignedToken(purpose: string, payload: string, expiresInSeconds: number) {
+	return makeStringToken(`${purpose}${kPurposeSeparator}${payload}`, expiresInSeconds);
+}
+
+/**
+ * Read back a token minted by `makeSignedToken`, or `undefined` if it's invalid, expired, or was
+ * minted for another purpose.
+ */
+export async function checkSignedToken(purpose: string, token?: string) {
+	const value = await readToken(token);
+	const prefix = `${purpose}${kPurposeSeparator}`;
+	return value?.startsWith(prefix) ? value.slice(prefix.length) : undefined;
 }

--- a/packages/xxscreeps/backend/endpoints/register.ts
+++ b/packages/xxscreeps/backend/endpoints/register.ts
@@ -1,11 +1,8 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Endpoint } from 'xxscreeps/backend/index.js';
+import { holdsPendingEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
 import { makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
-
-function validateEmail(email: string) {
-	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(email);
-}
 
 interface CheckEmailRequest {
 	email: string;
@@ -97,12 +94,12 @@ const SetUsernameEndpoint: Endpoint = {
 			return { error: 'invalid' };
 		}
 
-		// Register
-		const providers = [ { provider, id: providerId } ];
+		// Register. The address is established after the user exists, since holding one pending writes
+		// it against their record.
+		await User.create(context.db, newUserId, username, [ { provider, id: providerId } ]);
 		if (email != null) {
-			providers.push({ provider: 'email', id: email });
+			await User.setEmail(context.db, newUserId, email, holdsPendingEmail());
 		}
-		await User.create(context.db, newUserId, username, providers);
 		context.state.userId = newUserId;
 		context.state.newUserId = undefined;
 		context.state.provider = undefined;

--- a/packages/xxscreeps/backend/endpoints/register.ts
+++ b/packages/xxscreeps/backend/endpoints/register.ts
@@ -1,6 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Endpoint } from 'xxscreeps/backend/index.js';
-import { holdsPendingEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
+import { reportUnsentVerification, setAndVerifyEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
 import { makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 
@@ -97,9 +97,8 @@ const SetUsernameEndpoint: Endpoint = {
 		// Register. The address is established after the user exists, since holding one pending writes
 		// it against their record.
 		await User.create(context.db, newUserId, username, [ { provider, id: providerId } ]);
-		if (email != null) {
-			await User.setEmail(context.db, newUserId, email, holdsPendingEmail());
-		}
+		const mail = email == null ? undefined : await setAndVerifyEmail(context.db, newUserId, email);
+		reportUnsentVerification(newUserId, mail?.refusal);
 		context.state.userId = newUserId;
 		context.state.newUserId = undefined;
 		context.state.provider = undefined;

--- a/packages/xxscreeps/backend/endpoints/user/email.ts
+++ b/packages/xxscreeps/backend/endpoints/user/email.ts
@@ -1,5 +1,6 @@
-import { checkEmailVerificationToken, emailVerifyPath } from 'xxscreeps/backend/auth/email.js';
-import { hooks } from 'xxscreeps/backend/index.js';
+import type { JSONSchemaType } from 'ajv';
+import { checkEmailVerificationToken, emailVerifyPath, holdsPendingEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
+import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 
@@ -26,4 +27,41 @@ hooks.register('route', {
 		context.redirect(redirectTarget(verified));
 		return true;
 	},
+});
+
+interface SetEmailRequest {
+	email: string;
+}
+
+const setEmailRequestSchema: JSONSchemaType<SetEmailRequest> = {
+	type: 'object',
+	properties: {
+		email: { type: 'string' },
+	},
+	required: [ 'email' ],
+};
+
+// Change (or set) the logged-in user's email address. Per `backend.autoVerifyEmail` the address is
+// either confirmed immediately or held pending — `pending` in the response tells the client which.
+// Any previously-confirmed address stays active until a pending one is confirmed.
+hooks.register('route', {
+	method: 'post',
+	path: '/api/user/email',
+
+	execute: makeValidatedPayloadRoute(setEmailRequestSchema, async context => {
+		const { userId } = context.state;
+		if (userId === undefined) {
+			return { error: 'not authenticated' };
+		}
+		const { email } = context.request.body;
+		if (!validateEmail(email)) {
+			return { error: 'invalid' };
+		}
+		const owner = await User.findUserByProvider(context.db, 'email', email);
+		if (owner !== null && owner !== userId) {
+			return { error: 'exists' };
+		}
+		const { pending } = await User.setEmail(context.db, userId, email, holdsPendingEmail());
+		return { ok: 1, pending };
+	}),
 });

--- a/packages/xxscreeps/backend/endpoints/user/email.ts
+++ b/packages/xxscreeps/backend/endpoints/user/email.ts
@@ -1,6 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
-import { checkEmailVerificationToken, emailVerifyPath, holdsPendingEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
+import { checkEmailVerificationToken, emailVerifyPath, holdsPendingEmail, setAndVerifyEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
+import { mailer } from 'xxscreeps/backend/mail.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 
@@ -61,7 +62,20 @@ hooks.register('route', {
 		if (owner !== null && owner !== userId) {
 			return { error: 'exists' };
 		}
-		const { pending } = await User.setEmail(context.db, userId, email, holdsPendingEmail());
-		return { ok: 1, pending };
+		const { pending, refusal } = await setAndVerifyEmail(context.db, userId, email);
+		return { ok: 1, pending, ...refusal !== undefined && { error: refusal.reason } };
 	}),
+});
+
+// Holding addresses pending is a promise that someone will ask the user to confirm them, and the
+// backend can't keep it alone. Say so once rather than leaving registrations quietly stranded.
+hooks.register('backendReady', () => {
+	if (holdsPendingEmail()) {
+		if (!mailer.registered) {
+			console.error('`backend.autoVerifyEmail` is off but no mod delivers mail — addresses will be held pending with no confirmation link to open');
+		}
+		if (config.backend.publicUrl === undefined) {
+			console.error('`backend.autoVerifyEmail` is off but `backend.publicUrl` is not set — there is no address to root a confirmation link at');
+		}
+	}
 });

--- a/packages/xxscreeps/backend/endpoints/user/email.ts
+++ b/packages/xxscreeps/backend/endpoints/user/email.ts
@@ -1,0 +1,29 @@
+import { checkEmailVerificationToken, emailVerifyPath } from 'xxscreeps/backend/auth/email.js';
+import { hooks } from 'xxscreeps/backend/index.js';
+import { config } from 'xxscreeps/config/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+
+// Report the outcome as a query parameter, ahead of any fragment: the client routes on the hash, so
+// a destination like `/#!/account` has to keep its fragment last.
+function redirectTarget(verified: boolean) {
+	const base = config.backend.emailVerifyRedirect ?? '/';
+	const hash = base.indexOf('#');
+	const [ path, fragment ] = hash === -1 ? [ base, '' ] : [ base.slice(0, hash), base.slice(hash) ];
+	return `${path}${path.includes('?') ? '&' : '?'}emailVerified=${verified ? 1 : 0}${fragment}`;
+}
+
+// The target of the confirmation link mailed to the user. A human opens this in a browser, so every
+// outcome — a good link, a forged or expired one, a superseded address — ends in a redirect rather
+// than an error payload; the destination reads `emailVerified` to tell the user what happened.
+hooks.register('route', {
+	path: emailVerifyPath,
+
+	async execute(context) {
+		const { token } = context.request.query;
+		const link = typeof token === 'string' ? await checkEmailVerificationToken(token) : undefined;
+		const verified = link !== undefined &&
+			await User.verifyPendingEmail(context.db, link.userId, link.email);
+		context.redirect(redirectTarget(verified));
+		return true;
+	},
+});

--- a/packages/xxscreeps/backend/endpoints/user/email.ts
+++ b/packages/xxscreeps/backend/endpoints/user/email.ts
@@ -1,5 +1,5 @@
 import type { JSONSchemaType } from 'ajv';
-import { checkEmailVerificationToken, emailVerifyPath, holdsPendingEmail, setAndVerifyEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
+import { checkEmailVerificationToken, emailVerifyPath, holdsPendingEmail, sendPendingEmailVerification, setAndVerifyEmail, validateEmail } from 'xxscreeps/backend/auth/email.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { mailer } from 'xxscreeps/backend/mail.js';
 import { config } from 'xxscreeps/config/index.js';
@@ -65,6 +65,31 @@ hooks.register('route', {
 		const { pending, refusal } = await setAndVerifyEmail(context.db, userId, email);
 		return { ok: 1, pending, ...refusal !== undefined && { error: refusal.reason } };
 	}),
+});
+
+// Ask for the confirmation mail again — one can be lost, junked, or simply expire, and without this
+// the only way out of a pending address is setting it all over again.
+hooks.register('route', {
+	method: 'post',
+	path: '/api/user/email/resend',
+
+	async execute(context) {
+		const { userId } = context.state;
+		if (userId === undefined) {
+			return { error: 'not authenticated' };
+		}
+		if (await User.pendingEmailForUser(context.db, userId) === null) {
+			// Nothing to confirm: no address at all, or it is confirmed already.
+			return { ok: 1, pending: false };
+		}
+		const refusal = await sendPendingEmailVerification(context.db, userId);
+		if (refusal !== undefined) {
+			// A mailer declining is the user's answer, not an error of ours: it carries why, and when
+			// to come back if that is only for now.
+			return { error: refusal.reason, ...refusal.retryInSeconds !== undefined && { retryInSeconds: refusal.retryInSeconds } };
+		}
+		return { ok: 1, pending: true };
+	},
 });
 
 // Holding addresses pending is a promise that someone will ask the user to confirm them, and the

--- a/packages/xxscreeps/backend/endpoints/user/index.ts
+++ b/packages/xxscreeps/backend/endpoints/user/index.ts
@@ -3,6 +3,7 @@ import { hooks, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import badge from './badge.js';
 import './auth.js';
 import './code.js';
+import './email.js';
 import './profile.js';
 import './world.js';
 

--- a/packages/xxscreeps/backend/endpoints/user/profile.ts
+++ b/packages/xxscreeps/backend/endpoints/user/profile.ts
@@ -20,9 +20,10 @@ hooks.register('route', {
 			// Real user
 			const { userId } = context.state;
 			const info = {};
-			const [ user, providers ] = await Promise.all([
+			const [ user, providers, pendingEmail ] = await Promise.all([
 				User.loadBackendUserInfo(context.db, userId),
 				User.findProvidersForUser(context.db, userId),
+				User.pendingEmailForUser(context.db, userId),
 				Promise.all(sendUserInfo(context.db, userId, info, true)),
 			]);
 			return Object.assign(info, {
@@ -30,8 +31,11 @@ hooks.register('route', {
 				_id: userId,
 				cpu: 100,
 				// The address is the `email` provider, which is core state — a user has one whether or
-				// not the mod which lets them sign in with it is installed.
+				// not the mod which lets them sign in with it is installed. An address still awaiting
+				// confirmation is reported in its place, flagged: the client shows `email` as the
+				// address on file and reads `emailDirty` as "not confirmed yet".
 				...providers.email !== undefined && { email: providers.email },
+				...pendingEmail !== null && { email: pendingEmail, emailDirty: true },
 				...user,
 			});
 

--- a/packages/xxscreeps/backend/endpoints/user/profile.ts
+++ b/packages/xxscreeps/backend/endpoints/user/profile.ts
@@ -20,7 +20,7 @@ hooks.register('route', {
 			// Real user
 			const { userId } = context.state;
 			const info = {};
-			const [ user ] = await Promise.all([
+			const [ user, providers ] = await Promise.all([
 				User.loadBackendUserInfo(context.db, userId),
 				User.findProvidersForUser(context.db, userId),
 				Promise.all(sendUserInfo(context.db, userId, info, true)),
@@ -29,6 +29,9 @@ hooks.register('route', {
 				ok: 1,
 				_id: userId,
 				cpu: 100,
+				// The address is the `email` provider, which is core state — a user has one whether or
+				// not the mod which lets them sign in with it is installed.
+				...providers.email !== undefined && { email: providers.email },
 				...user,
 			});
 

--- a/packages/xxscreeps/backend/mail.ts
+++ b/packages/xxscreeps/backend/mail.ts
@@ -1,0 +1,36 @@
+import type { MaybePromise } from 'xxscreeps/utility/types.js';
+import { makeProviderRegistration } from 'xxscreeps/utility/hook.js';
+
+/** A mail the backend wants delivered, rendered and ready to send. */
+export interface EmailMessage {
+	to: string;
+	subject: string;
+	text: string;
+	html?: string;
+}
+
+/** Why a mailer declined to send, e.g. an address it rate-limits or refuses outright. */
+export interface MailRefusal {
+	reason: string;
+	/** When the caller may try again, for a refusal which is only temporary. */
+	retryInSeconds?: number;
+}
+
+export interface Mailer {
+	/**
+	 * Deliver `message`. Return nothing once it is on its way, or a refusal to report that it was
+	 * deliberately not sent — which is not a failure and reaches the user as an explanation. Throwing
+	 * is for delivery actually breaking.
+	 */
+	send: (message: EmailMessage) => MaybePromise<MailRefusal | undefined>;
+}
+
+/**
+ * How mail leaves the server. There is deliberately room for exactly one implementation — SMTP or a
+ * provider's API, not both at once — so two mods fighting over delivery fail loudly instead of
+ * quietly mailing everything twice. With none registered every message is refused, which is what
+ * lets a caller say so rather than pretend it sent something.
+ */
+export const mailer = makeProviderRegistration<Mailer>('mail', {
+	send: () => ({ reason: 'no mailer' }),
+});

--- a/packages/xxscreeps/backend/test.ts
+++ b/packages/xxscreeps/backend/test.ts
@@ -1,0 +1,107 @@
+import type { EmailMessage, MailRefusal } from './mail.js';
+import { config } from 'xxscreeps/config/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { assert, describe, test } from 'xxscreeps/test/index.js';
+import { checkEmailVerificationToken, sendPendingEmailVerification } from './auth/email.js';
+import { mailer } from './mail.js';
+
+/** Override one `backend` config value for the lifetime of the binding. */
+function backendConfigForTesting<Key extends keyof typeof config.backend>(key: Key, value: typeof config.backend[Key]): Disposable {
+	const previous = config.backend[key];
+	config.backend[key] = value;
+	return { [Symbol.dispose]() { config.backend[key] = previous; } };
+}
+
+interface MailFixture {
+	/** Address the backend is reachable at, or nothing to leave it unconfigured. */
+	publicUrl?: string | undefined;
+	/** What the transport answers with, or nothing to have it accept and record the message. */
+	refusal?: MailRefusal;
+	/** Whether a transport is installed at all. */
+	transport?: boolean;
+}
+
+// Stands in for the transport a server installs, capturing what it was handed. A provider takes one
+// implementation, so a test holds the slot for its own scope rather than for the whole run.
+function backendMail(fixture: MailFixture = {}) {
+	const { refusal, transport = true } = fixture;
+	const sent: EmailMessage[] = [];
+	const stack = new DisposableStack();
+	// Always overridden, so a `publicUrl` in the developer's own config can't decide a test.
+	stack.use(backendConfigForTesting('publicUrl',
+		'publicUrl' in fixture ? fixture.publicUrl : 'https://screeps.test/'));
+	if (transport) {
+		stack.use(mailer.register({
+			send(message) {
+				if (refusal !== undefined) {
+					return refusal;
+				}
+				sent.push(message);
+			},
+		}));
+	}
+	return { sent, [Symbol.dispose]: () => stack.dispose() };
+}
+
+describe('backend/mail', () => {
+	test('a pending address is mailed a link which confirms it', async () => {
+		await using testShard = await instantiateTestShard();
+		using mail = backendMail();
+		const { db } = testShard;
+		await User.create(db, '400', 'Pending');
+		await User.setEmail(db, '400', 'pending@test.dev', true);
+
+		assert.strictEqual(await sendPendingEmailVerification(db, '400'), undefined);
+		assert.strictEqual(mail.sent.length, 1);
+		assert.strictEqual(mail.sent[0]!.to, 'pending@test.dev');
+
+		// The link is rooted at `publicUrl` and carries a token good for exactly this address.
+		const url = new URL(/https:\/\/\S+/.exec(mail.sent[0]!.text)![0]);
+		assert.strictEqual(url.origin, 'https://screeps.test');
+		assert.deepStrictEqual(await checkEmailVerificationToken(url.searchParams.get('token')!), {
+			userId: '400',
+			email: 'pending@test.dev',
+		});
+
+		// And opening it is what promotes the address.
+		assert.strictEqual(await User.verifyPendingEmail(db, '400', 'pending@test.dev'), true);
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'pending@test.dev'), '400');
+	});
+
+	test('nothing is mailed to a user with no pending address', async () => {
+		await using testShard = await instantiateTestShard();
+		using mail = backendMail();
+		await User.create(testShard.db, '401', 'Confirmed');
+		assert.strictEqual(await sendPendingEmailVerification(testShard.db, '401'), undefined);
+		assert.strictEqual(mail.sent.length, 0);
+	});
+
+	test('a refusal comes back to the caller', async () => {
+		await using testShard = await instantiateTestShard();
+		using mail = backendMail({ refusal: { reason: 'throttled', retryInSeconds: 30 } });
+		await User.create(testShard.db, '402', 'Throttled');
+		await User.setEmail(testShard.db, '402', 'throttled@test.dev', true);
+		assert.deepStrictEqual(await sendPendingEmailVerification(testShard.db, '402'),
+			{ reason: 'throttled', retryInSeconds: 30 });
+		assert.strictEqual(mail.sent.length, 0);
+	});
+
+	test('without a public url there is no link to mail', async () => {
+		await using testShard = await instantiateTestShard();
+		using mail = backendMail({ publicUrl: undefined });
+		await User.create(testShard.db, '403', 'Rootless');
+		await User.setEmail(testShard.db, '403', 'rootless@test.dev', true);
+		assert.deepStrictEqual(await sendPendingEmailVerification(testShard.db, '403'), { reason: 'no public url' });
+		assert.strictEqual(mail.sent.length, 0);
+	});
+
+	test('with no transport installed every message is refused', async () => {
+		await using testShard = await instantiateTestShard();
+		using mail = backendMail({ transport: false });
+		await User.create(testShard.db, '404', 'Unreachable');
+		await User.setEmail(testShard.db, '404', 'unreachable@test.dev', true);
+		assert.deepStrictEqual(await sendPendingEmailVerification(testShard.db, '404'), { reason: 'no mailer' });
+		assert.strictEqual(mail.sent.length, 0);
+	});
+});

--- a/packages/xxscreeps/config/config.schema.json
+++ b/packages/xxscreeps/config/config.schema.json
@@ -27,6 +27,16 @@
           "description": "Network interface to bind server to. Format is: \"host\" or \"host:port\". Host can be * to bind to all interfaces: \"*:port\". Port is 21025, if not specified.",
           "type": "string"
         },
+        "emailVerifyRedirect": {
+          "default": "/",
+          "description": "Where the backend sends a user's browser after they open an address confirmation link. The outcome is appended as `emailVerified=1` or `emailVerified=0`, so the destination can report it. Defaults to the server root, which is the client on a stock install; point it elsewhere when the client is served from another origin.",
+          "type": "string"
+        },
+        "emailVerifyTtlHours": {
+          "default": 24,
+          "description": "How long an address confirmation link stays valid, in hours.",
+          "type": "number"
+        },
         "proxy": {
           "description": "Reverse proxy configuration. TODO: mTLS, otherwise publicly-accessible backends on the public internet can receive forged requests. This isn't a big deal for us at the moment since we don't do anything with the client ip.",
           "properties": {

--- a/packages/xxscreeps/config/config.schema.json
+++ b/packages/xxscreeps/config/config.schema.json
@@ -5,7 +5,7 @@
       "properties": {
         "allowEmailRegistration": {
           "default": false,
-          "description": "Whether to allow users sign up without steam with only their email address.",
+          "description": "Whether to allow users sign up without steam with only their email address. Note: xxscreeps itself does not send a confirmation mail; install a mod which does and set `autoVerifyEmail: false` to require one.",
           "type": "boolean"
         },
         "allowGuestAccess": {
@@ -19,7 +19,7 @@
         },
         "autoVerifyEmail": {
           "default": true,
-          "description": "Whether email addresses are trusted immediately on registration/change, rather than held pending until the user confirms them. Note that an address held pending is not yet a sign-in identity — until it is confirmed the user signs in by username.",
+          "description": "Whether email addresses are trusted immediately on registration/change, rather than held pending until the user opens a confirmation link. Turning this off needs `publicUrl` set and a mod which delivers mail; without either, addresses are held pending with no way to confirm them. Note that an address held pending is not yet a sign-in identity — until it is confirmed the user signs in by username.",
           "type": "boolean"
         },
         "bind": {
@@ -49,6 +49,10 @@
             "forwardedCount"
           ],
           "type": "object"
+        },
+        "publicUrl": {
+          "description": "Where this server is reachable from a browser, e.g. \"https://screeps.example.com\". Links the backend mails out are rooted here. It cannot be taken from the request which triggers the mail: that origin is the `Host` header, so a forged one would have us mail a link pointing somewhere else entirely.",
+          "type": "string"
         },
         "secret": {
           "description": "Secret used for session authentication. If not specified a new secret will be generated each restart.",

--- a/packages/xxscreeps/config/config.schema.json
+++ b/packages/xxscreeps/config/config.schema.json
@@ -5,7 +5,7 @@
       "properties": {
         "allowEmailRegistration": {
           "default": false,
-          "description": "Whether to allow users sign up without steam with only their email address. Note: there is currently no confirmation mail send to the user to verify the address.",
+          "description": "Whether to allow users sign up without steam with only their email address.",
           "type": "boolean"
         },
         "allowGuestAccess": {
@@ -16,6 +16,11 @@
         "assetBaseUrl": {
           "description": "Prefix put in front of urls the backend mints for assets it serves, which are otherwise rooted at `/`. Needed when the backend does not sit at the root of the origin the client is served from: an origin of its own, e.g. \"https://screeps.example.com\", or the path a proxy mounts it under, e.g. \"/(http://localhost:21025)\" for the steamless client. Prepended verbatim, so it takes either.",
           "type": "string"
+        },
+        "autoVerifyEmail": {
+          "default": true,
+          "description": "Whether email addresses are trusted immediately on registration/change, rather than held pending until the user confirms them. Note that an address held pending is not yet a sign-in identity — until it is confirmed the user signs in by username.",
+          "type": "boolean"
         },
         "bind": {
           "default": "*",

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -13,6 +13,8 @@ export interface BackendConfig {
 
 	/**
 	 * Whether to allow users sign up without steam with only their email address.
+	 * Note: xxscreeps itself does not send a confirmation mail; install a mod which does and set
+	 * `autoVerifyEmail: false` to require one.
 	 * @default false
 	 */
 	allowEmailRegistration?: boolean;
@@ -28,8 +30,10 @@ export interface BackendConfig {
 
 	/**
 	 * Whether email addresses are trusted immediately on registration/change, rather than held
-	 * pending until the user confirms them. Note that an address held pending is not yet a sign-in
-	 * identity — until it is confirmed the user signs in by username.
+	 * pending until the user opens a confirmation link. Turning this off needs `publicUrl` set and a
+	 * mod which delivers mail; without either, addresses are held pending with no way to confirm
+	 * them. Note that an address held pending is not yet a sign-in identity — until it is confirmed
+	 * the user signs in by username.
 	 * @default true
 	 */
 	autoVerifyEmail?: boolean;
@@ -62,6 +66,14 @@ export interface BackendConfig {
 	 * do anything with the client ip.
 	 */
 	proxy?: BackendProxyConfig;
+
+	/**
+	 * Where this server is reachable from a browser, e.g. "https://screeps.example.com". Links the
+	 * backend mails out are rooted here. It cannot be taken from the request which triggers the mail:
+	 * that origin is the `Host` header, so a forged one would have us mail a link pointing somewhere
+	 * else entirely.
+	 */
+	publicUrl?: string;
 
 	/**
 	 * Secret used for session authentication. If not specified a new secret will be generated each

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -42,6 +42,21 @@ export interface BackendConfig {
 	bind?: string;
 
 	/**
+	 * Where the backend sends a user's browser after they open an address confirmation link. The
+	 * outcome is appended as `emailVerified=1` or `emailVerified=0`, so the destination can report
+	 * it. Defaults to the server root, which is the client on a stock install; point it elsewhere
+	 * when the client is served from another origin.
+	 * @default /
+	 */
+	emailVerifyRedirect?: string;
+
+	/**
+	 * How long an address confirmation link stays valid, in hours.
+	 * @default 24
+	 */
+	emailVerifyTtlHours?: number;
+
+	/**
 	 * Reverse proxy configuration. TODO: mTLS, otherwise publicly-accessible backends on the public
 	 * internet can receive forged requests. This isn't a big deal for us at the moment since we don't
 	 * do anything with the client ip.

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -13,7 +13,6 @@ export interface BackendConfig {
 
 	/**
 	 * Whether to allow users sign up without steam with only their email address.
-	 * Note: there is currently no confirmation mail send to the user to verify the address.
 	 * @default false
 	 */
 	allowEmailRegistration?: boolean;
@@ -26,6 +25,14 @@ export interface BackendConfig {
 	 * takes either.
 	 */
 	assetBaseUrl?: string;
+
+	/**
+	 * Whether email addresses are trusted immediately on registration/change, rather than held
+	 * pending until the user confirms them. Note that an address held pending is not yet a sign-in
+	 * identity — until it is confirmed the user signs in by username.
+	 * @default true
+	 */
+	autoVerifyEmail?: boolean;
 
 	/**
 	 * Network interface to bind server to. Format is: "host" or "host:port". Host can be * to bind

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -6,7 +6,7 @@ import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 import { branchManifestKey, buffersKey, saveContent, stringsKey } from './code.js';
 
 // Lifecycle hooks for users. Mods register `remove` handlers to tear down their own per-user,
-// db-scoped state (e.g. private messages) when a user is deleted, so `remove` below stays
+// db-scoped state (e.g. private messages, stats) when a user is deleted, so `remove` below stays
 // self-contained for every caller rather than each call site enumerating mod cleanups.
 export const hooks = makeHookRegistration<{
 	remove: (db: Database, userId: string) => MaybePromise<void>;
@@ -16,6 +16,10 @@ const removeHooks = hooks.makeMapped('remove');
 const providerMembersKey = (provider: string) => `usersByProvider/${provider}`;
 const userProvidersKey = (userId: string) => `user/${userId}/provider`;
 export const infoKey = (userId: string) => `user/${userId}`;
+
+// Field on the user info hash holding an address awaiting confirmation. Distinct from the `email`
+// provider, which only ever holds a *confirmed* address.
+const pendingEmailField = 'pendingEmail';
 
 interface BackendUserInfo {
 	username: string;
@@ -70,6 +74,80 @@ export async function create(db: Database, userId: string, username: string, pro
 	]);
 
 	await saveContent(db, userId, 'main', new Map([ [ 'main', 'module.exports.loop = function () {};' ] ]));
+}
+
+/**
+ * Associate `email` as the user's confirmed `email` provider, replacing any address they had before.
+ * The reverse lookup is claimed with `NX` so two accounts racing to confirm the same address cannot
+ * both win it; returns `false` without writing when somebody else holds it.
+ */
+async function associateEmail(db: Database, userId: string, email: string) {
+	const [ claimed, previous ] = await Promise.all([
+		db.data.hSet(providerMembersKey('email'), email, userId, { if: 'NX' }),
+		db.data.hGet(userProvidersKey(userId), 'email'),
+	]);
+	if (!claimed) {
+		// Somebody holds it — us, if this is a repeat confirmation, and otherwise not ours to take.
+		const holder = await db.data.hGet(providerMembersKey('email'), email);
+		if (holder !== userId) {
+			return false;
+		}
+	}
+	await Promise.all([
+		db.data.hSet(userProvidersKey(userId), 'email', email),
+		// Free the reverse lookup for a replaced address so it can be reused.
+		...previous !== null && previous !== email ? [ db.data.hDel(providerMembersKey('email'), [ previous ]) ] : [],
+	]);
+	return true;
+}
+
+/**
+ * Establish `email` for a user, either confirming it outright or — with `holdPending` — parking it
+ * until they prove the inbox is theirs. Returns whether the address was left pending; throws when
+ * it is confirmed to somebody else already.
+ *
+ * Whether to hold an address is the caller's decision, not this layer's: a backend which can mail a
+ * confirmation link holds them, and the CLI, which cannot, does not. Pending addresses are
+ * deliberately not indexed for uniqueness, so two accounts may await the same one; whoever confirms
+ * first keeps it (see `verifyPendingEmail`).
+ */
+export async function setEmail(db: Database, userId: string, email: string, holdPending: boolean) {
+	if (holdPending) {
+		await db.data.hSet(infoKey(userId), pendingEmailField, email);
+		return { pending: true };
+	}
+	if (!await associateEmail(db, userId, email)) {
+		throw new Error('Already associated');
+	}
+	await db.data.hDel(infoKey(userId), [ pendingEmailField ]);
+	return { pending: false };
+}
+
+/** The address a user is currently waiting to confirm, or `null`. */
+export function pendingEmailForUser(db: Database, userId: string) {
+	return db.data.hGet(infoKey(userId), pendingEmailField);
+}
+
+/**
+ * Confirm a user's pending address, promoting it to their `email` provider. `email` must match the
+ * currently-pending address (guards against a stale/superseded link). Returns `false` when it
+ * doesn't match, or when the address was meanwhile confirmed by another account.
+ *
+ * Confirming an address the user has *already* confirmed succeeds without writing, so opening a
+ * still-valid confirmation link a second time is idempotent rather than an error.
+ */
+export async function verifyPendingEmail(db: Database, userId: string, email: string) {
+	const pending = await db.data.hGet(infoKey(userId), pendingEmailField);
+	if (pending !== email) {
+		const confirmed = await providerIdForUser(db, 'email', userId);
+		return confirmed === email;
+	}
+	// A different account may have confirmed the same address while this one was pending.
+	if (!await associateEmail(db, userId, email)) {
+		return false;
+	}
+	await db.data.hDel(infoKey(userId), [ pendingEmailField ]);
+	return true;
 }
 
 /**

--- a/packages/xxscreeps/engine/db/user/test.ts
+++ b/packages/xxscreeps/engine/db/user/test.ts
@@ -25,3 +25,46 @@ describe('engine/db/user', () => {
 		assert.strictEqual(await User.findUserByProvider(db, 'email', 'remove@me.test'), null);
 	});
 });
+
+describe('User.setEmail', () => {
+	test('confirms the address outright when it is not held pending', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '300', 'AutoVerify');
+		assert.deepStrictEqual(await User.setEmail(db, '300', 'auto@test.dev', false), { pending: false });
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'auto@test.dev'), '300');
+		assert.strictEqual(await User.pendingEmailForUser(db, '300'), null);
+	});
+
+	test('holds pending then promotes on confirmation', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '301', 'Gated');
+		assert.deepStrictEqual(await User.setEmail(db, '301', 'gated@test.dev', true), { pending: true });
+		// Held pending: stored as pendingEmail, not yet a provider.
+		assert.strictEqual(await User.pendingEmailForUser(db, '301'), 'gated@test.dev');
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'gated@test.dev'), null);
+		// A mismatched address is rejected and changes nothing.
+		assert.strictEqual(await User.verifyPendingEmail(db, '301', 'wrong@test.dev'), false);
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'gated@test.dev'), null);
+		// Confirming the pending address promotes it to the `email` provider and clears pending.
+		assert.strictEqual(await User.verifyPendingEmail(db, '301', 'gated@test.dev'), true);
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'gated@test.dev'), '301');
+		assert.strictEqual(await User.pendingEmailForUser(db, '301'), null);
+		// Opening a still-valid link again confirms what is already confirmed, rather than failing.
+		assert.strictEqual(await User.verifyPendingEmail(db, '301', 'gated@test.dev'), true);
+	});
+
+	test('a pending address another account confirmed first is refused', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await Promise.all([ User.create(db, '302', 'First'), User.create(db, '303', 'Second') ]);
+		await Promise.all([
+			User.setEmail(db, '302', 'contested@test.dev', true),
+			User.setEmail(db, '303', 'contested@test.dev', true),
+		]);
+		assert.strictEqual(await User.verifyPendingEmail(db, '302', 'contested@test.dev'), true);
+		assert.strictEqual(await User.verifyPendingEmail(db, '303', 'contested@test.dev'), false);
+		assert.strictEqual(await User.findUserByProvider(db, 'email', 'contested@test.dev'), '302');
+	});
+});

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -144,16 +144,13 @@ hooks.register('route', {
 	}),
 });
 
-// Add password flag and email to user info payload
+// Add password flag to user info payload. The address itself is reported by the profile endpoint —
+// the `email` provider is core state, not a password concern.
 hooks.register('sendUserInfo', async (db, userId, userInfo, privateSelf) => {
 	if (privateSelf) {
 		const password = await db.data.hGet(infoKey(userId), 'password');
 		if (password !== null) {
 			userInfo.password = true;
-		}
-		const email = await User.providerIdForUser(db, 'email', userId);
-		if (email !== null) {
-			userInfo.email = email;
 		}
 	}
 });

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -1,5 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
+import { holdsPendingEmail } from 'xxscreeps/backend/auth/email.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
@@ -134,8 +135,9 @@ hooks.register('route', {
 		}
 		if (allowEmailRegistration) {
 			const newUserId = Id.generateId(12);
-			await User.create(context.db, newUserId, username, [ { provider: 'email', id: email } ]);
+			await User.create(context.db, newUserId, username);
 			await setPassword(context.db, newUserId, password);
+			await User.setEmail(context.db, newUserId, email, holdsPendingEmail());
 			return { ok: 1 };
 		} else {
 			context.status = 500;

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -1,6 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import type { Database } from 'xxscreeps/engine/db/index.js';
-import { holdsPendingEmail } from 'xxscreeps/backend/auth/email.js';
+import { reportUnsentVerification, setAndVerifyEmail } from 'xxscreeps/backend/auth/email.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
@@ -137,7 +137,10 @@ hooks.register('route', {
 			const newUserId = Id.generateId(12);
 			await User.create(context.db, newUserId, username);
 			await setPassword(context.db, newUserId, password);
-			await User.setEmail(context.db, newUserId, email, holdsPendingEmail());
+			// Establishes the address, and mails the confirmation link when this server holds one
+			// pending rather than trusting it outright.
+			const { refusal } = await setAndVerifyEmail(context.db, newUserId, email);
+			reportUnsentVerification(newUserId, refusal);
 			return { ok: 1 };
 		} else {
 			context.status = 500;

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -3,6 +3,7 @@ import './import.js';
 import 'xxscreeps:mods/driver';
 
 await import('xxscreeps/backend/auth/test.js');
+await import('xxscreeps/backend/test.js');
 await import('xxscreeps/driver/private/test.js');
 await import('xxscreeps/engine/db/storage/local/test.js');
 await import('xxscreeps/engine/db/user/test.js');

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -2,6 +2,7 @@ import { flush, summary } from './context.js';
 import './import.js';
 import 'xxscreeps:mods/driver';
 
+await import('xxscreeps/backend/auth/test.js');
 await import('xxscreeps/driver/private/test.js');
 await import('xxscreeps/engine/db/storage/local/test.js');
 await import('xxscreeps/engine/db/user/test.js');

--- a/packages/xxscreeps/utility/hook.ts
+++ b/packages/xxscreeps/utility/hook.ts
@@ -8,11 +8,14 @@ export interface ProviderRegistration<Type extends object> {
 	/**
 	 * Replace the default implementation with `provider`. Throws if a provider was already registered,
 	 * so two mods fighting over the same domain fail loudly instead of one silently shadowing the
-	 * other.
+	 * other. Disposing the result restores the default, which is how a test holds the slot for its
+	 * own scope rather than for the whole run.
 	 */
-	register: (provider: Type) => void;
+	register: (provider: Type) => Disposable;
 	/** The active implementation: the registered override if any, otherwise the default. */
 	readonly current: Type;
+	/** Whether anything replaced the default, for callers which must know there is nobody home. */
+	readonly registered: boolean;
 }
 
 /**
@@ -32,9 +35,13 @@ export function makeProviderRegistration<Type extends object>(name: string, fall
 				throw new Error(`Provider '${name}' is already registered`);
 			}
 			override = provider;
+			return { [Symbol.dispose]() { override = undefined; } };
 		},
 		get current() {
 			return override ?? fallback;
+		},
+		get registered() {
+			return override !== undefined;
 		},
 	};
 }


### PR DESCRIPTION
Sorry about the last two commits in decorations being in one pr.

This one is about email verification and update email, showing the "dirty email" in the client and stuff like that. Not sure what you have planed for email but I guess the sending would be done in a seperate mod? I guess verification still belongs into the server itself.

Again this is devided into several commits that can be pr seperatly, here in one pr as an overview.


An address typed at registration was believed on the spot: `create` associated the `email` provider
outright, so anyone could sign up under an address they don't own and take it away from whoever
does. This adds the other half — hold the address, mail a link, promote it when the user opens one —
behind `backend.autoVerifyEmail`, which stays on by default so a server with no way to send mail
keeps working exactly as it does today.

Two pieces are worth orienting on. Confirmation links are signed with the same key as session
tokens, so they survive a restart and work across replicas without shared storage; a nul-separated
purpose tag keeps the two kinds from ever being exchanged for one another, since no login payload
can contain one. And delivery is a `mailer` provider with room for exactly one implementation —
every server reaches its users differently — so xxscreeps mints and honours the link and a mod
carries it.

Turning `autoVerifyEmail` off needs `backend.publicUrl` set and a mod which sends mail; the backend
says so at startup if either is missing. Links are rooted at `publicUrl` rather than at the request
origin on purpose: that origin is the `Host` header, and a forged one would have us mail somebody a
genuine-looking link pointing elsewhere.

This is the whole chain as one PR to read in context. Every commit builds and passes the suite on
its own, so I can submit them separately instead — three of them (`report the account email`, `sign
tokens for purposes`, `hold an address pending`) don't depend on each other at all. Say which you'd
rather review.

Two things I left alone. `create` is still not transactional (its `// TODO: multi / exec` predates
this), so a lost race on the email index throws after the user record exists — the email reverse
index is claimed with `NX` now, which closes the confirmation race but not that one. And an address
held pending is not yet a sign-in identity: until it is confirmed the user signs in by username,
which is noted on the config option but changes what `POST /api/auth/signin` accepts right after
registration when the flag is off.

## Validation

`npm run build` and `npm test` clean on node 24 — 659 tests, 0 failures — at every one of the seven
commits, not just at the tip. `eslint --max-warnings 0` clean across every file touched. New coverage: token round-trip, purpose isolation, expiry and the
refusal that a login token is not a verification link (`backend/auth/test.ts`); pending-then-promote
including two accounts racing for one address (`engine/db/user/test.ts`); and the mailed link end to
end — sent to the pending address, rooted at `publicUrl`, its token decoding back to the user and
address, and opening it promoting them — plus the no-transport, no-`publicUrl` and refusal paths
(`backend/test.ts`).

Not covered: the `/api/auth/email/verify` and `/api/user/email/resend` routes themselves. Everything
they call is tested; the routing, the redirect target and the response shapes are not.
