### PR TITLE
scripts: seal the world's outer boundary

### DIFF
--- a/.changeset/seal-world-boundary.md
+++ b/.changeset/seal-world-boundary.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Add `seal-world`: walls off the outer boundary of a generated world.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ options apply to the sector's normal rooms. Also available as
 `npx xxscreeps generate-sector W20N20`, taking the same flags as
 `generate-room`.
 
+`sealWorldBoundary` walls off the world's outer boundary, where the outermost
+rooms still carry the exits they rolled toward neighbors that were never
+generated. Each such room is rebuilt with its outward borders walled off and
+its inward ones inherited, which re-rolls its terrain and objects — so run it
+once the world's extent is final and before players are placed; a boundary room
+holding a player's objects is refused. Also available as
+`npx xxscreeps seal-world`, taking the `generate-room` flags plus `--dry-run`
+to list the rooms it would rebuild.
+
 ## Docker
 
 If you want to run xxscreeps in Docker, you can do this:

--- a/packages/xxscreeps/engine/processor/model.ts
+++ b/packages/xxscreeps/engine/processor/model.ts
@@ -234,7 +234,7 @@ export async function roomsDidFinalize(shard: Shard, roomsCount: number, time: n
 	}
 }
 
-const isSystemUser = (userId: string) => userId.length <= 2;
+export const isSystemUser = (userId: string) => userId.length <= 2;
 export async function updateUserRoomRelationships(shard: Shard, room: Room, previous?: ReturnType<typeof flushUsers>) {
 	const checkPlayers = (current: string[], previous?: string[]) => {
 		// Filter out NPCs

--- a/packages/xxscreeps/scripts/room-gen.ts
+++ b/packages/xxscreeps/scripts/room-gen.ts
@@ -1,7 +1,8 @@
 import type { ExitMap, GenerateRoomOptions, HighwayOrientation, RoomGeneratorContext } from './symbols.js';
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import type { RoomType } from 'xxscreeps/mods/modern/sector/terrain.js';
-import { mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
+import { isSystemUser } from 'xxscreeps/engine/processor/model.js';
+import { mappedNumericComparator, mappedPrimitiveComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import { makeLocalIterateInRangeTo } from 'xxscreeps/game/direction.js';
@@ -464,6 +465,12 @@ function fillUnreachable(grid: Grid): void {
 			}
 		}
 	}
+	// A room walled off on all four sides has no border to reach from, so every open tile reads as
+	// unreachable and filling them would leave solid rock where a sealed room's terrain belongs.
+	// `buildBaseTerrain` keeps such a room's ground for the same reason.
+	if (stack.length === 0) {
+		return;
+	}
 	while (stack.length > 0) {
 		const [ cxx, cyy ] = stack.pop()!;
 		for (const [ nxx, nyy ] of iterateGridInRange(cxx, cyy, 1)) {
@@ -572,6 +579,9 @@ const kHighwaySmoothFactor = 5;
 
 // Tiles of depth a clipped mass wins back per tile away from the lane opening bounding it.
 const kHighwayLaneClipSlope = 3;
+
+// Tiles of wall a border with no opening carries at minimum, whatever the noise field does there.
+const kHighwaySealFloor = 3;
 
 // Tiles the wall mass intrudes from the border at world position (wx, wy): a heavy-tailed wedge
 // (low base, high exponent), mostly shallow with a rare deep plunge. edgeNoise in [0, 1) bounds it
@@ -683,19 +693,36 @@ function genHighwayTerrain(
 		...exits.left.map(yy => [ 0, yy ] as const),
 		...exits.right.map(yy => [ 49, yy ] as const),
 	];
-	// Depth (in tiles) the mass intrudes along one border, indexed by the tile `at(ii)`: the noise
-	// wedge sampled at that tile's world position, anchored at the corners and receding toward any
-	// nearby exit. A border the lane runs along carries no mass and stays zeroed, so its term never
-	// walls a lane tile.
-	const depthAlongBorder = (active: boolean, at: (ii: number) => readonly [ number, number ]) => {
-		if (!active) {
+	// Depth (in tiles) the mass on one border intrudes, indexed by the tile `at(ii)`: the noise wedge
+	// sampled at that tile's world position, anchored at the corners and receding toward any nearby
+	// exit.
+	const depthAlongBorder = (dir: keyof ExitMap, at: (ii: number) => readonly [ number, number ]) => {
+		// Whether the lane runs out through this border. A crossing's four sides are all lane ends,
+		// but each of them carries the shallow corner masses that stop its opening from running the
+		// border's full width, so a crossing never counts as one here.
+		const laneEnd = orientation !== 'crossing' && isHighwayLaneSide(orientation, dir);
+		const sealed = exits[dir].length === 0;
+		// An open end of the lane carries no mass and stays zeroed, so its term never walls a lane
+		// tile.
+		if (laneEnd && !sealed) {
 			return new Array<number>(50).fill(0);
 		}
+		// A border with no opening at all carries a mass, and the deep lane mass rather than the
+		// shallow corner one: the lane does not continue through it, so the mass has to close the
+		// corridor rather than flank an opening.
+		const borderMass = sealed ? kHighwayLaneMass : mass;
+		// A mass flanking an opening only has to read as the side of a corridor, and the noise field
+		// leaving a stretch of it at the border line alone reads as exactly that. A sealed border is
+		// where the corridor stops instead, so a stretch left to the line reads as a line drawn across
+		// it rather than as the ground the lane runs into -- most visibly at the world's boundary,
+		// where nothing is drawn beyond. It holds a floor, receding at exits like the rest of the mass
+		// and clipped to the lane openings with it.
+		const floor = sealed ? kHighwaySealFloor : 0;
 		return Fn.pipe(
 			Fn.range(50),
 			$$ => Fn.map($$, ii => {
 				const [ bx, by ] = at(ii);
-				return edgeDepth(wox + bx, woy + by, mass) * cornerTaper(ii) *
+				return Math.max(edgeDepth(wox + bx, woy + by, borderMass) * cornerTaper(ii), floor) *
 					exitClearance(bx, by, exitPoints);
 			}),
 			$$ => [ ...$$ ]);
@@ -718,16 +745,16 @@ function genHighwayTerrain(
 			high + Math.max(0, 47 - ii) * kHighwayLaneClipSlope)),
 		$$ => [ ...$$ ]);
 	const leftDepth = clipToLanes(
-		depthAlongBorder(orientation !== 'horizontal', ii => [ 0, ii ]),
+		depthAlongBorder('left', ii => [ 0, ii ]),
 		laneBound(exits.top, true), laneBound(exits.bottom, true));
 	const rightDepth = clipToLanes(
-		depthAlongBorder(orientation !== 'horizontal', ii => [ 49, ii ]),
+		depthAlongBorder('right', ii => [ 49, ii ]),
 		laneBound(exits.top, false), laneBound(exits.bottom, false));
 	const topDepth = clipToLanes(
-		depthAlongBorder(orientation !== 'vertical', ii => [ ii, 0 ]),
+		depthAlongBorder('top', ii => [ ii, 0 ]),
 		laneBound(exits.left, true), laneBound(exits.right, true));
 	const bottomDepth = clipToLanes(
-		depthAlongBorder(orientation !== 'vertical', ii => [ ii, 49 ]),
+		depthAlongBorder('bottom', ii => [ ii, 49 ]),
 		laneBound(exits.left, false), laneBound(exits.right, false));
 	const clutter = genHighwayClutter(wox, woy);
 	for (const [ yy, row ] of grid.entries()) {
@@ -861,6 +888,29 @@ function gridToTerrain(grid: Grid): TerrainWriter {
 	return terrain;
 }
 
+// The four sides of a room, in the order every border walk in this file takes them.
+const kSides = [ 'top', 'right', 'bottom', 'left' ] as const;
+
+interface RoomSide {
+	/** Room-coordinate offset of the neighbor across this side. */
+	dxx: number;
+	dyy: number;
+	/** This room's border on this side, as its `packExits` bit. */
+	exitBit: number;
+	/** The neighbor's border shared with this room, as its `packExits` bit. */
+	sharedExitBit: number;
+	/** The shared border's line within the neighbor, as `exitsArray` walks it. */
+	axis: 'x' | 'y';
+	fixed: number;
+}
+
+const kRoomSides: Record<keyof ExitMap, RoomSide> = {
+	top: { dxx: 0, dyy: -1, exitBit: 1, sharedExitBit: 4, axis: 'y', fixed: 49 },
+	right: { dxx: 1, dyy: 0, exitBit: 2, sharedExitBit: 8, axis: 'x', fixed: 0 },
+	bottom: { dxx: 0, dyy: 1, exitBit: 4, sharedExitBit: 1, axis: 'y', fixed: 0 },
+	left: { dxx: -1, dyy: 0, exitBit: 8, sharedExitBit: 2, axis: 'x', fixed: 49 },
+};
+
 // Builds a room's terrain and objects entirely in memory; performs no storage I/O. `lookupTerrain`
 // resolves an already-built neighbor's terrain so shared exits line up.
 function buildRoom(
@@ -869,33 +919,26 @@ function buildRoom(
 	lookupTerrain: (neighborName: string) => { terrain: Terrain } | undefined,
 ) {
 	const { rx, ry } = parseRoomName(roomName);
-
-	const dirs = {
-		top: { neighborName: makeRoomName(rx, ry - 1), axis: 'y' as const, fixed: 49 },
-		right: { neighborName: makeRoomName(rx + 1, ry), axis: 'x' as const, fixed: 0 },
-		bottom: { neighborName: makeRoomName(rx, ry + 1), axis: 'y' as const, fixed: 0 },
-		left: { neighborName: makeRoomName(rx - 1, ry), axis: 'x' as const, fixed: 49 },
-	};
-
 	const exits: ExitMap = { top: [], right: [], bottom: [], left: [] };
 
-	for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
-		const info = dirs[dir];
+	for (const dir of kSides) {
+		const side = kRoomSides[dir];
+		const neighborName = makeRoomName(rx + side.dxx, ry + side.dyy);
 		const userExits = options?.exits?.[dir];
-		const neighborTerrain = lookupTerrain(info.neighborName);
+		const neighborTerrain = lookupTerrain(neighborName);
 
 		if (userExits) {
 			if (neighborTerrain) {
-				const neighborExits = [ ...exitsArray(neighborTerrain.terrain, info.axis, info.fixed) ];
+				const neighborExits = [ ...exitsArray(neighborTerrain.terrain, side.axis, side.fixed) ];
 				const match = neighborExits.length === userExits.length &&
 					userExits.every(exit => neighborExits.includes(exit));
 				if (!match) {
-					throw new Error(`Exits in room ${info.neighborName} don't match`);
+					throw new Error(`Exits in room ${neighborName} don't match`);
 				}
 			}
 			exits[dir] = userExits;
 		} else if (neighborTerrain) {
-			exits[dir] = [ ...exitsArray(neighborTerrain.terrain, info.axis, info.fixed) ];
+			exits[dir] = [ ...exitsArray(neighborTerrain.terrain, side.axis, side.fixed) ];
 		} else if (options?.highway !== undefined && isHighwayLaneSide(options.highway, dir)) {
 			exits[dir] = [ ...genLaneExit(rx, ry, options.highway, dir) ];
 		} else {
@@ -1019,19 +1062,22 @@ const roomTypeTemplates: Record<RoomType, GenerateRoomOptions> = {
 	sourceKeeper: { controller: false, keeperLairs: true, sources: 3 },
 };
 
-interface SectorDir {
-	dxx: number;
-	dyy: number;
-	// The neighbor's border shared with this room, as its `packExits` bit.
-	sharedExitBit: number;
+// The generation options for one room of the sector template: the loadout of its type, a highway's
+// lane orientation, and the borders it walls off. Only a normal room takes the caller's room-shape
+// flags -- the template rooms follow the vanilla mod-10 pattern.
+function sectorRoomOptions(
+	roomName: string,
+	type: RoomType,
+	options: GenerateRoomOptions | undefined,
+	sealed: Iterable<keyof ExitMap>,
+): GenerateRoomOptions {
+	return {
+		...type === 'normal' && options,
+		...roomTypeTemplates[type],
+		...type === 'highway' && { highway: highwayOrientation(roomName) },
+		exits: Fn.fromEntries(Fn.map(sealed, dir => [ dir, [] ])),
+	};
 }
-
-const kSectorDirs: Record<keyof ExitMap, SectorDir> = {
-	top: { dxx: 0, dyy: -1, sharedExitBit: 4 },
-	right: { dxx: 1, dyy: 0, sharedExitBit: 8 },
-	bottom: { dxx: 0, dyy: 1, sharedExitBit: 1 },
-	left: { dxx: -1, dyy: 0, sharedExitBit: 2 },
-};
 
 // The live world walls off some borders where both sides carry a wall mass: a normal room seals
 // about one of its four sides on average, and a highway seals its mass sides at much the same
@@ -1077,12 +1123,12 @@ function *accumulateSector(
 		// Roll seals on void borders; sides facing a built room inherit its border instead.
 		const sealed: (keyof ExitMap)[] = [];
 		let openSides = 0;
-		for (const dir of [ 'top', 'right', 'bottom', 'left' ] as const) {
-			const sectorDir = kSectorDirs[dir];
-			const neighborName = makeSignedRoomName(rx + sectorDir.dxx, ry + sectorDir.dyy);
+		for (const dir of kSides) {
+			const side = kRoomSides[dir];
+			const neighborName = makeSignedRoomName(rx + side.dxx, ry + side.dyy);
 			const record = terrainMap.get(neighborName);
 			if (record) {
-				if ((record.exits & sectorDir.sharedExitBit) !== 0) {
+				if ((record.exits & side.sharedExitBit) !== 0) {
 					openSides += 1;
 				}
 			} else if (isSealableSide(type, dir, roomName, neighborName, hasController) &&
@@ -1100,12 +1146,7 @@ function *accumulateSector(
 			sealed.shift();
 		}
 
-		const roomOptions: GenerateRoomOptions = {
-			...type === 'normal' && options,
-			...template,
-			...type === 'highway' && { highway: highwayOrientation(roomName) },
-			exits: Fn.fromEntries(Fn.map(sealed, dir => [ dir, [] ])),
-		};
+		const roomOptions = sectorRoomOptions(roomName, type, options, sealed);
 		const { room, terrain } = buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
 		commitRoom(terrainMap, roomName, terrain);
 		existing.add(roomName);
@@ -1123,6 +1164,90 @@ export async function generateSector(
 	const [ world, existingRooms ] = await Promise.all([ shard.loadWorld(), shard.data.sMembers('rooms') ]);
 	const terrainMap = new Map(world.terrain);
 	const rooms = [ ...accumulateSector(origin, options, terrainMap, new Set(existingRooms)) ];
+	refreshRoomMeta(terrainMap, Fn.map(rooms, room => room.name));
+	await flushRooms(shard, terrainMap, rooms);
+	return rooms;
+}
+
+/** A room on the world's outer boundary, with the sides facing rooms the world lacks. */
+export interface BoundaryRoom {
+	roomName: string;
+	sealed: (keyof ExitMap)[];
+}
+
+/** The `packExits` bits of one room -- all the boundary walk reads of a terrain record. */
+interface RoomExitBits {
+	exits: number;
+}
+
+// Every room holding an opening onto a room the world doesn't have, in room-name order. A room
+// generated with no neighbor rolls ordinary exits on that side, so this is the whole outer boundary
+// of a freshly built world -- and it is empty once the boundary is sealed, which makes the pass
+// idempotent. `sealed` carries every side facing the void, opening or not: `buildRoom` re-rolls any
+// border the caller doesn't author, so a side already walled off has to be authored again to stay
+// that way.
+export function worldBoundary(terrainMap: ReadonlyMap<string, RoomExitBits>): BoundaryRoom[] {
+	return [ ...Fn.pipe(
+		terrainMap.entries(),
+		$$ => Fn.map($$, ([ roomName, { exits } ]) => {
+			const { rx, ry } = parseSignedRoomName(roomName);
+			const sealed = [ ...Fn.reject(kSides, dir => {
+				const side = kRoomSides[dir];
+				return terrainMap.has(makeSignedRoomName(rx + side.dxx, ry + side.dyy));
+			}) ];
+			return { roomName, sealed, exits };
+		}),
+		$$ => Fn.filter($$, room => Fn.some(room.sealed, dir => (room.exits & kRoomSides[dir].exitBit) !== 0)),
+		$$ => Fn.map($$, ({ roomName, sealed }): BoundaryRoom => ({ roomName, sealed })),
+	) ].sort(mappedPrimitiveComparator(room => room.roomName));
+}
+
+/** The rooms `sealWorldBoundary` would rebuild, without touching storage. */
+export async function findWorldBoundary(shard: Shard): Promise<BoundaryRoom[]> {
+	const world = await shard.loadWorld();
+	return worldBoundary(world.terrain);
+}
+
+// Walls off the world's outer boundary. A room is generated against whatever neighbors already
+// exist and rolls ordinary exits toward the ones that don't, so the outermost rooms of a finished
+// world open onto nothing: the map draws the exit, `describeExits` reports it, and a creep stepping
+// onto that border tile is handed to a room that does not exist. Each such room is rebuilt with
+// its outward borders walled off the way a room generated against an absent neighbor would have
+// been -- the terrain grows a wall mass over the sealed side instead of ending at a bare border
+// line -- while every inward border is inherited from the neighbor that already authored it, so no
+// shared border moves and the world's room set stands.
+//
+// Rebuilding re-rolls a room's terrain and objects, so this is a world-authoring step: run it once
+// the world's extent is final, and before players are placed -- a boundary room holding a player's
+// objects is refused rather than thrown away. A rebuilt room takes the loadout of its mod-10
+// template type, so a boundary room a bare `generate-room` authored off-template comes back as the
+// highway, source-keeper or center room its name says it is. The seal is inherited like any other
+// border, so a sector generated against a sealed boundary afterwards carries it as an interior wall.
+export async function sealWorldBoundary(shard: Shard, options?: GenerateRoomOptions): Promise<Room[]> {
+	await ensureWorldTerrain(shard);
+	const world = await shard.loadWorld();
+	const terrainMap = new Map(world.terrain);
+	const boundary = worldBoundary(terrainMap);
+
+	const claimed = Fn.pipe(
+		await Fn.mapAwait(boundary, ({ roomName }) => shard.loadRoom(roomName, shard.time, true)),
+		$$ => Fn.reject($$, room => Fn.every(room['#users'].presence, isSystemUser)),
+		$$ => Fn.map($$, room => room.name),
+		$$ => [ ...$$ ]);
+	if (claimed.length > 0) {
+		throw new Error(`Refusing to rebuild boundary rooms holding player objects: ${claimed.join(', ')}`);
+	}
+
+	// Each room is committed before the next is built, so a boundary room facing another one shares
+	// the border it has just authored.
+	const rooms = boundary.map(({ roomName, sealed }) => {
+		const roomOptions = sectorRoomOptions(roomName, roomType(roomName), options, sealed);
+		const { room, terrain } = buildRoom(roomName, roomOptions, neighborName => terrainMap.get(neighborName));
+		commitRoom(terrainMap, roomName, terrain);
+		return room;
+	});
+	// `commitRoom` empties a record's sector meta, and the room set is unchanged, so this restamps
+	// the rebuilt rooms with the geometry they already had.
 	refreshRoomMeta(terrainMap, Fn.map(rooms, room => room.name));
 	await flushRooms(shard, terrainMap, rooms);
 	return rooms;

--- a/packages/xxscreeps/scripts/seal-world.ts
+++ b/packages/xxscreeps/scripts/seal-world.ts
@@ -1,0 +1,37 @@
+import { checkArguments } from 'xxscreeps/config/arguments.js';
+import { config } from 'xxscreeps/config/index.js';
+import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { parseRoomOptions, roomOptionArguments } from 'xxscreeps/scripts/generate-room.js';
+import { findWorldBoundary, sealWorldBoundary } from 'xxscreeps/scripts/room-gen.js';
+
+// Walls off the world's outer boundary: every room opening onto a room the world doesn't have is
+// rebuilt with that side sealed, so the edge of the map reads as terrain rather than as exits into
+// nothing. `--dry-run` lists the rooms it would rebuild. Shares the room-shape flags with
+// `generate-room`; they apply to the boundary's normal rooms. See `sealWorldBoundary` for when in a
+// world's life this runs.
+async function main() {
+	const argv = checkArguments({
+		boolean: [ 'dry-run' ] as const,
+		string: [ 'shard', ...roomOptionArguments ] as const,
+	});
+
+	const options = parseRoomOptions(argv);
+	await using db = await Database.connect();
+	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
+	if (argv['dry-run']) {
+		const boundary = await findWorldBoundary(shard);
+		for (const { roomName, sealed } of boundary) {
+			console.log(`${roomName}: ${sealed.join(', ')}`);
+		}
+		console.log(`${boundary.length} room${boundary.length === 1 ? '' : 's'} on the world boundary`);
+		return;
+	}
+
+	const rooms = await sealWorldBoundary(shard, options);
+	await Promise.all([ db.save(), shard.save() ]);
+	console.log(`Sealed ${rooms.length} boundary room${rooms.length === 1 ? '' : 's'}`);
+}
+
+if (process.argv[1] === 'seal-world') {
+	await main();
+}

--- a/packages/xxscreeps/scripts/test.ts
+++ b/packages/xxscreeps/scripts/test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'node:assert';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import * as C from 'xxscreeps/game/constants/index.js';
+import { instantiateTestShard } from 'xxscreeps/test/import.js';
+import { describe, test } from 'xxscreeps/test/index.js';
+import { findWorldBoundary, generateRoom, sealWorldBoundary, worldBoundary } from './room-gen.js';
+
+// A world of the named rooms, each opening on all four sides.
+function openWorld(...roomNames: string[]) {
+	return new Map(Fn.map(roomNames, roomName => [ roomName, { exits: 0b1111 } ] as const));
+}
+
+describe('scripts/room-gen', () => {
+	test('names the sides facing rooms the world lacks', () => {
+		// W1N0 lies west of W0N0, so the two share W0N0's left border with W1N0's right.
+		assert.deepStrictEqual(worldBoundary(openWorld('W0N0', 'W1N0')), [
+			{ roomName: 'W0N0', sealed: [ 'top', 'right', 'bottom' ] },
+			{ roomName: 'W1N0', sealed: [ 'top', 'bottom', 'left' ] },
+		]);
+	});
+
+	test('crosses the world axes', () => {
+		// W0N0's right neighbor is E0N0 and its bottom neighbor is W0S0; the result is name-ordered.
+		assert.deepStrictEqual(
+			worldBoundary(openWorld('W0N0', 'E0N0', 'W0S0')).map(room => room.sealed), [
+				[ 'top', 'right', 'bottom' ],
+				[ 'top', 'left' ],
+				[ 'right', 'bottom', 'left' ],
+			]);
+	});
+
+	test('carries a walled side along with the opening', () => {
+		// A lone room whose only opening is to the north. Rebuilding re-rolls every border the caller
+		// doesn't author, so the three walled sides are authored again rather than left alone.
+		assert.deepStrictEqual(worldBoundary(new Map([ [ 'W0N0', { exits: 0b0001 } ] ])), [
+			{ roomName: 'W0N0', sealed: [ 'top', 'right', 'bottom', 'left' ] },
+		]);
+	});
+
+	test('leaves a fully walled room alone', () => {
+		assert.deepStrictEqual(worldBoundary(new Map([ [ 'W0N0', { exits: 0 } ] ])), []);
+	});
+
+	test('seals a world without disturbing its sector meta', async () => {
+		await using testShard = await instantiateTestShard();
+		const { shard } = testShard;
+		// The fixture's sector is walled in already; a pair of rooms around a sector center is the
+		// smallest world carrying both an open boundary and sector meta to preserve.
+		await shard.data.flushdb();
+		await shard.data.set('time', shard.time);
+		await generateRoom(shard, 'W25N25');
+		await generateRoom(shard, 'W24N25');
+		const before = new Map(Fn.map((await shard.loadWorld()).terrain.entries(),
+			([ roomName, record ]) => [ roomName, record.sectors.join() ] as const));
+		await sealWorldBoundary(shard);
+		const after = (await shard.loadWorld()).terrain;
+		for (const [ roomName, record ] of after) {
+			assert.strictEqual(record.sectors.join(), before.get(roomName), `${roomName} keeps its sectors`);
+		}
+		assert.ok(after.get('W25N25')!.sectorControl, 'the center keeps its sector control');
+		assert.deepStrictEqual(await findWorldBoundary(shard), [], 'the boundary settles in one pass');
+	});
+
+	test('leaves a room sealed on all four sides some ground', async () => {
+		await using testShard = await instantiateTestShard();
+		const { shard } = testShard;
+		// A world of one room seals every side of it, and E0S0's name makes it a highway crossing --
+		// the terrain that carries no reroll to fall back on.
+		await shard.data.flushdb();
+		await shard.data.set('time', shard.time);
+		await generateRoom(shard, 'E0S0');
+		await sealWorldBoundary(shard);
+		const { terrain } = (await shard.loadWorld()).terrain.get('E0S0')!;
+		assert.ok(
+			Fn.some(Fn.range(50), yy => Fn.some(Fn.range(50), xx => terrain.get(xx, yy) !== C.TERRAIN_MASK_WALL)),
+			'the room is not solid wall');
+	});
+});

--- a/packages/xxscreeps/test/run.ts
+++ b/packages/xxscreeps/test/run.ts
@@ -6,6 +6,7 @@ await import('xxscreeps/driver/private/test.js');
 await import('xxscreeps/engine/db/storage/local/test.js');
 await import('xxscreeps/engine/db/user/test.js');
 await import('xxscreeps/game/test.js');
+await import('xxscreeps/scripts/test.js');
 await import('xxscreeps/utility/test.js');
 await import('xxscreeps:mods/test');
 await import('xxscreeps/cli/test.js');

--- a/packages/xxscreeps/xxscreeps.js
+++ b/packages/xxscreeps/xxscreeps.js
@@ -9,6 +9,7 @@ const specifier = process.argv[1];
 const commands = {
 	'generate-room': './dist/scripts/generate-room.js',
 	'generate-sector': './dist/scripts/generate-sector.js',
+	'seal-world': './dist/scripts/seal-world.js',
 	backend: './dist/backend/server.js',
 	cli: './dist/cli/cli.js',
 	eval: './dist/cli/eval.js',


### PR DESCRIPTION
A room is generated against whatever neighbours already exist and rolls ordinary exits toward the ones that don't, so the outermost rooms of a finished world open onto nothing — the map draws the exit, `describeExits` reports it, and a creep stepping onto that border tile is handed to a room that does not exist. `sealWorldBoundary` (`xxscreeps seal-world`, `--dry-run` to list) rebuilds each such room with its outward borders walled off; every inward border is inherited from the neighbour that already authored it, so no shared border moves and the room set stands.

Rebuilding re-rolls a room's terrain and objects, so this is a world-authoring step: run it once the world's extent is final and before players are placed — a boundary room holding a player's objects is refused. A rebuilt room takes the loadout of its mod-10 template type, which only shows on a world a bare `generate-room` authored off-template.

The parts that aren't obvious from the diff:

- The seal set is every side facing the void, not just the ones currently open. `buildRoom` re-rolls any border the caller doesn't author, so a side that was already walled off has to be authored again to stay that way — otherwise the pass opens fresh holes and never settles.
- A sealed highway border takes the deep lane mass and a minimum depth instead of the shallow corner one. The lane doesn't continue through it, so the mass has to close the corridor rather than flank an opening.
- `fillUnreachable` now returns early when no border tile is open. A room walled off on all four sides has no border to reach from, so every open tile read as unreachable and the fill left solid rock where the room's terrain belongs. Reachable today through a re-entered sector hole, not only through this command.
- `isSystemUser` is exported from `engine/processor/model.ts` rather than adding a seventh copy of the `length <= 2` predicate.

## Validation

`tsc -b` and the full suite on `b618e2ce`: 651 tests, 0 failed. `eslint --max-warnings 0 packages` reports only the three pre-existing `unbound-method` warnings in `driver/private/test.ts`, `mods/classic/combat/creep.ts` and `mods/mmo/wallstreet/market.ts`.

`scripts/test.ts` adds six tests: four over the boundary walk — including that an already-walled void side is carried along and that a fully walled room is left alone — and two shard-backed passes. Sealing a two-room world around a sector center keeps every `sectors` / `sectorControl` record intact and leaves nothing for a second pass; a world of one room comes back with ground rather than solid rock. Both shard-backed tests were checked against their production change reverted, and each fails.
