### PR TITLE
config: derive default service concurrency from `os.availableParallelism()`

### DIFF
--- a/.changeset/available-parallelism-concurrency.md
+++ b/.changeset/available-parallelism-concurrency.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Derive the default processor and runner `concurrency` from `os.availableParallelism()` instead of `os.cpus().length`, so a process confined by CPU affinity no longer oversubscribes itself with cores it can't run on.

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -145,7 +145,7 @@ export interface LauncherConfig {
 export interface ProcessorConfig {
 	/**
 	 * Total number of processor tasks to run at a time. The default is the number of CPU cores
-	 * (including hyper-threaded) + 1
+	 * available to this process (including hyper-threaded, respecting CPU affinity) + 1
 	 */
 	concurrency?: number;
 
@@ -170,8 +170,8 @@ export interface RunnerConfig {
 	cpu?: RunnerCPUConfig;
 
 	/**
-	 * Total number of run tasks to run at a time. The default is the number of CPU cores (including
-	 * hyper-threaded) + 1
+	 * Total number of run tasks to run at a time. The default is the number of CPU cores available to
+	 * this process (including hyper-threaded, respecting CPU affinity) + 1
 	 */
 	concurrency?: number;
 
@@ -289,11 +289,11 @@ export const defaults = {
 		respawnTimeout: 0,
 	},
 	processor: {
-		concurrency: os.cpus().length + 1,
+		concurrency: os.availableParallelism() + 1,
 		intentAbandonTimeout: 5000,
 	},
 	runner: {
-		concurrency: os.cpus().length + 1,
+		concurrency: os.availableParallelism() + 1,
 		cpu: {
 			bucket: 10000,
 			memoryLimit: 256,


### PR DESCRIPTION
`config.ts` derives the default `concurrency` for both the processor and the runner from `os.cpus().length`, which enumerates every CPU the host reports and ignores the process's CPU affinity. When the process is confined to a subset of CPUs — `taskset`, a cpuset cgroup, a container CPU pinning policy — the default is computed from cores the process cannot actually run on, and both services start oversubscribed.

`os.availableParallelism()` wraps libuv's `uv_available_parallelism`, which on Linux derives the count from `sched_getaffinity`.

Measured inside a Kubernetes pod pinned with `taskset -c 0-11` on a 20-thread host (6 P-cores = threads 0-11, 8 E-cores = threads 12-19):

```
Cpus_allowed_list:	0-11
os.cpus().length = 20  |  availableParallelism = 12
```

So on that deployment the runner defaulted to `concurrency: 21` while owning 12 threads.

### Scope

- Honors CPU affinity: `taskset`, cpuset cgroups (`cpuset.cpus`), and Kubernetes' CPU Manager `static` policy.
- Does **not** account for CFS quota (`cpu.max`, i.e. Kubernetes `limits.cpu`). A container limited to 2 CPUs' worth of quota but with all 20 CPUs in its cpuset still reports 20. That's a libuv-level limitation, not worked around here.
- Only the default changes; an explicitly configured `concurrency` behaves exactly as before.

The two `concurrency` doc comments are reworded to match, since "the number of CPU cores (including hyper-threaded)" stops being accurate once affinity is honored.

`os.availableParallelism()` landed in Node 18.14/19.4 and `package.json` already declares `"node": ">=20.0.0"`, so no engine bump is needed.

Build and tests are green (645 passed, 0 failed).
