### PR TITLE
payload: cover keeper lairs and prebuilt extractors

### DIFF
--- a/.changeset/payload-prebuilt-objects.md
+++ b/.changeset/payload-prebuilt-objects.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Payloads now carry keeper lairs and the prebuilt neutral extractor.

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -5,7 +5,7 @@ import { createRoomObject } from 'xxscreeps/game/object.js';
 import { iterateAllPositions, iterateInRangeTo } from 'xxscreeps/game/position.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from './constants.js';
-import { create as createExtractor } from './extractor.js';
+import { StructureExtractor, create as createExtractor } from './extractor.js';
 import { Mineral } from './mineral.js';
 
 // Mineral roll weights: H and O are twice as common as Z/K/U/L, and six times as common as X.
@@ -69,18 +69,35 @@ hooks.register('roomGenerator', {
 	},
 });
 
+// A prebuilt extractor shares its mineral's tile, so it can't own a layout marker and rides the
+// mineral's metadata instead. Only the neutral one does -- a player-built extractor stays behind
+// like every other owned structure.
 hooks.register('payload', {
 	marker: 'M',
-	encode: object => object instanceof Mineral ? {
-		density: object.density,
-		mineral: object.mineralType,
-	} : undefined,
+	encode(object) {
+		if (object instanceof Mineral) {
+			const extractor = Fn.find(object.room['#lookAt'](object.pos), candidate =>
+				candidate instanceof StructureExtractor && candidate['#user'] === null);
+			return {
+				density: object.density,
+				mineral: object.mineralType,
+				...extractor !== undefined && { extractor: extractor.id },
+			};
+		}
+	},
 	decode(meta) {
 		const mineral = new Mineral();
 		mineral.density = meta.density!;
 		mineral.mineralType = meta.mineral!;
 		mineral.mineralAmount = C.MINERAL_DENSITY[mineral.density]!;
-		return mineral;
+		if (meta.extractor === undefined) {
+			return mineral;
+		}
+		const extractor = new StructureExtractor();
+		extractor.id = meta.extractor;
+		extractor.hits = C.EXTRACTOR_HITS;
+		extractor['#user'] = null;
+		return [ mineral, extractor ];
 	},
 });
 
@@ -93,6 +110,8 @@ declare module 'xxscreeps/scripts/symbols.js' {
 	interface PayloadObject {
 		/** Mineral density, one of the `DENSITY_*` levels. */
 		density?: number;
+		/** Id of the prebuilt neutral extractor sharing the mineral's tile. */
+		extractor?: string;
 		/** The type of mineral deposited. */
 		mineral?: ResourceType;
 	}

--- a/packages/xxscreeps/mods/classic/mineral/test.ts
+++ b/packages/xxscreeps/mods/classic/mineral/test.ts
@@ -1,10 +1,13 @@
-import type { Mineral } from './mineral.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import { Game } from 'xxscreeps/game/index.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
+import { exportPayload, importPayload } from 'xxscreeps/scripts/payload.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
-import { create as createExtractor } from './extractor.js';
+import { StructureExtractor, create as createExtractor } from './extractor.js';
+import { Mineral } from './mineral.js';
 
 describe('mods/classic/mineral', () => {
 	const depletedOutOfRange = simulate({
@@ -59,5 +62,35 @@ describe('mods/classic/mineral', () => {
 			assert.ok(mineral);
 			assert.strictEqual(creep.harvest(mineral), C.ERR_TIRED);
 		});
+	}));
+
+	const prebuiltExtractor = simulate({
+		W6N6: room => {
+			const mineral = room.find(C.FIND_MINERALS)[0]!;
+			room['#insertObject'](createExtractor(mineral.pos, null));
+		},
+		W6N1: room => {
+			const mineral = room.find(C.FIND_MINERALS)[0]!;
+			room['#insertObject'](createExtractor(mineral.pos, '100'));
+			room['#user'] = room.controller!['#user'] = '100';
+		},
+	});
+
+	test('payload round trip', () => prebuiltExtractor(async ({ shard }) => {
+		const payload = await exportPayload(shard);
+		const extractorId = payload.W6N6?.objects?.find(object => object.extractor !== undefined)?.extractor;
+		assert.ok(extractorId !== undefined);
+		const { rooms } = importPayload(payload);
+		const roomObjects = (roomName: string) =>
+			rooms.find(room => room.name === roomName)?.['#objects'] ?? [];
+		const objects = roomObjects('W6N6');
+		const extractor = Fn.find(objects, instanceOfPredicate(StructureExtractor));
+		const mineral = Fn.find(objects, instanceOfPredicate(Mineral));
+		assert.ok(extractor);
+		assert.strictEqual(extractor.id, extractorId);
+		assert.strictEqual(extractor.hits, C.EXTRACTOR_HITS);
+		assert.strictEqual(extractor['#user'], null);
+		assert.strictEqual(extractor['#posId'], mineral?.['#posId']);
+		assert.strictEqual(Fn.find(roomObjects('W6N1'), instanceOfPredicate(StructureExtractor)), undefined);
 	}));
 });

--- a/packages/xxscreeps/mods/classic/source/terrain.ts
+++ b/packages/xxscreeps/mods/classic/source/terrain.ts
@@ -5,7 +5,8 @@ import { iterateAllPositions, iterateNeighbors } from 'xxscreeps/game/position.j
 import { isBorder } from 'xxscreeps/game/terrain.js';
 import { hooks } from 'xxscreeps/scripts/symbols.js';
 import * as C from 'xxscreeps:mods/constants';
-import { create as createKeeperLair } from './keeper-lair.js';
+import { kSourceKeeperUserId } from './game.js';
+import { StructureKeeperLair, create as createKeeperLair } from './keeper-lair.js';
 import { Source } from './source.js';
 
 // Rooms with three or more sources (keeper and center rooms) spread their sources across the room
@@ -105,6 +106,18 @@ hooks.register('payload', {
 			? C.SOURCE_ENERGY_KEEPER_CAPACITY
 			: C.SOURCE_ENERGY_NEUTRAL_CAPACITY;
 		return source;
+	},
+});
+
+// The lair's '#nextSpawnTime' is an absolute tick, which a payload has no baseline for, so a
+// reconstructed lair spawns its first keeper as a fresh one would.
+hooks.register('payload', {
+	marker: 'K',
+	encode: object => object instanceof StructureKeeperLair ? {} : undefined,
+	decode() {
+		const keeperLair = new StructureKeeperLair();
+		keeperLair['#user'] = kSourceKeeperUserId;
+		return keeperLair;
 	},
 });
 

--- a/packages/xxscreeps/mods/classic/source/test.ts
+++ b/packages/xxscreeps/mods/classic/source/test.ts
@@ -1,8 +1,14 @@
 import type { Source } from './source.js';
-import { RoomPosition } from 'xxscreeps/game/position.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
+import { RoomPosition, iterateAllPositions } from 'xxscreeps/game/position.js';
+import { isBorder } from 'xxscreeps/game/terrain.js';
 import { create as createCreep } from 'xxscreeps/mods/classic/creep/creep.js';
+import { exportPayload, importPayload } from 'xxscreeps/scripts/payload.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
+import { kSourceKeeperUserId } from './game.js';
+import { StructureKeeperLair, create as createKeeperLair } from './keeper-lair.js';
 
 describe('mods/classic/source', () => {
 	const depletedOutOfRange = simulate({
@@ -54,5 +60,25 @@ describe('mods/classic/source', () => {
 			assert.ok(creep);
 			assert.strictEqual(creep.harvest(null as unknown as Source), C.ERR_NO_BODYPART);
 		});
+	}));
+
+	const guardedRoom = simulate({
+		W6N6: room => {
+			const terrain = room.getTerrain();
+			const position = Fn.find(iterateAllPositions(room.name), pos =>
+				!isBorder(pos.x, pos.y) && terrain.get(pos.x, pos.y) === C.TERRAIN_MASK_WALL);
+			assert.ok(position);
+			room['#insertObject'](createKeeperLair(position));
+		},
+	});
+
+	test('payload round trip', () => guardedRoom(async ({ shard }) => {
+		const payload = await exportPayload(shard);
+		assert.ok(payload.W6N6?.layout.some(line => line.includes('K')));
+		const { rooms } = importPayload(payload);
+		const keeperLair = Fn.find(
+			rooms.find(room => room.name === 'W6N6')?.['#objects'] ?? [],
+			instanceOfPredicate(StructureKeeperLair));
+		assert.strictEqual(keeperLair?.['#user'], kSourceKeeperUserId);
 	}));
 });

--- a/packages/xxscreeps/scripts/payload.ts
+++ b/packages/xxscreeps/scripts/payload.ts
@@ -119,11 +119,14 @@ function importRoom(roomName: string, info: PayloadRoom) {
 				throw new Error(`Room ${roomName} holds more markers than metadata`);
 			}
 			terrain.set(xx, yy, C.TERRAIN_MASK_WALL);
-			const object = codec.decode(meta, room);
-			object.id = meta.id;
-			object.pos = new RoomPosition(xx, yy, roomName);
-			object['#posId'] = object.pos['#id'];
-			room['#insertObject'](object);
+			const decoded = codec.decode(meta, room);
+			const objects = Array.isArray(decoded) ? decoded : [ decoded ] as const;
+			objects[0].id = meta.id;
+			for (const object of objects) {
+				object.pos = new RoomPosition(xx, yy, roomName);
+				object['#posId'] = object.pos['#id'];
+				room['#insertObject'](object);
+			}
 		}
 	}
 	room['#flushObjects'](null);

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -75,10 +75,12 @@ export interface PayloadCodec {
 	/** The fields this codec encodes for `object`, or undefined when it doesn't own the object. */
 	encode: (object: RoomObject) => Omit<PayloadObject, 'id'> | undefined;
 	/**
-	 * Rebuilds the object `meta` describes. The engine stamps its id and position and inserts it
-	 * into `room`, which is passed only for the room-level state an object implies.
+	 * Rebuilds the object `meta` describes, plus any companions sharing its tile. The engine
+	 * stamps every object's position and the first one's id -- companions carry ids of their
+	 * own -- and inserts them into `room`, which is passed only for the room-level state an
+	 * object implies.
 	 */
-	decode: (meta: PayloadObject, room: Room) => RoomObject;
+	decode: (meta: PayloadObject, room: Room) => RoomObject | [ RoomObject, ...RoomObject[] ];
 }
 
 export const hooks = makeHookRegistration<{


### PR DESCRIPTION
A controller-less room's prebuilt objects had no codecs, so exporting one silently dropped them: the default shard loses all 32 keeper lairs and 9 extractors, and a generated source-keeper room exports 4 of its 9 objects. Lairs take the `K` marker. The extractor shares its mineral's tile, so it can't own a marker and rides the `M` metadata instead -- which is why `decode` may now return companion objects for one tile; the engine stamps the position on all of them and the id on the first. Only a neutral extractor is carried; a player-built one stays behind like every other owned structure.

## Validation

- Build, eslint, and the full test suite (647 passed), including new round-trip tests in the source and mineral mods.
- Exported the vanilla default shard: 72 `@`, 141 `E` (27 keeper), 81 `M` (9 with an extractor), 32 `K` -- every object except the bot spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
