### PR TITLE
game: compose effects and renderers across mods

### DIFF
--- a/.changeset/composable-effects.md
+++ b/.changeset/composable-effects.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Effects and renderers compose across mods instead of replacing what another mod bound.

--- a/packages/xxscreeps/backend/index.ts
+++ b/packages/xxscreeps/backend/index.ts
@@ -94,11 +94,15 @@ export function bindRenderer<Type extends RoomObject>(
 ) {
 	const { prototype } = object;
 	const parent = Object.getPrototypeOf(prototype) as RoomObject;
+	// A downstream mod may add keys to a class another mod already renders, so a renderer already
+	// bound here is captured and layered under this one. The parent stays a late lookup, since base
+	// classes are not guaranteed to have bound theirs yet.
+	const bound = Object.hasOwn(prototype, Render) ? prototype[Render] : undefined;
 	prototype[Render] = function(...rest) {
-		const renderParent = () => parent[Render].call(this, ...rest) ?? function() {
+		const renderPrevious = () => (bound ?? parent[Render]).call(this, ...rest) ?? function() {
 			throw new Error('Render fell through to empty prototype');
 		}();
-		return render(this, renderParent, ...rest);
+		return render(this, renderPrevious, ...rest);
 	};
 }
 

--- a/packages/xxscreeps/game/runtime.ts
+++ b/packages/xxscreeps/game/runtime.ts
@@ -5,8 +5,8 @@ import { hooks, registerGlobal } from './symbols.js';
 const { apply } = Reflect;
 
 declare global {
-	function cached(target: object, key: string, descriptor: PropertyDescriptor): void;
-	function enumerable(target: object, key: string, descriptor: PropertyDescriptor): void;
+	function cached(target: object, key: string, descriptor: PropertyDescriptor): PropertyDescriptor;
+	function enumerable(target: object, key: string, descriptor: PropertyDescriptor): PropertyDescriptor;
 }
 
 globalThis.cached = (target: object, key: string, descriptor: PropertyDescriptor) => {

--- a/packages/xxscreeps/mods/classic/controller/constants.ts
+++ b/packages/xxscreeps/mods/classic/controller/constants.ts
@@ -35,9 +35,6 @@ export const CONTROLLER_MAX_UPGRADE_PER_TICK = 15;
 export const CONTROLLER_ATTACK_BLOCKED_UPGRADE = 1000;
 export const CONTROLLER_NUKE_BLOCKED_UPGRADE = 200;
 
-// TODO: Find a home for it?
-export const EFFECT_INVULNERABILITY = 1001;
-
 export const SAFE_MODE_DURATION = 20000;
 export const SAFE_MODE_COOLDOWN = 50000;
 export const SAFE_MODE_COST = 1000;

--- a/packages/xxscreeps/mods/classic/controller/controller.ts
+++ b/packages/xxscreeps/mods/classic/controller/controller.ts
@@ -1,4 +1,3 @@
-import type { RoomObjectEffect } from 'xxscreeps/game/object.js';
 import type { Room } from 'xxscreeps/game/room/index.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
 import { Game, hooks, intents, userInfo } from 'xxscreeps/game/index.js';
@@ -109,16 +108,6 @@ export class StructureController extends withOverlay(OwnedStructure, controllerS
 		} : undefined;
 		Object.defineProperty(this, 'sign', { value });
 		return value;
-	}
-
-	/**
-	 * Applied effects, an array of {@link RoomObjectEffect} objects.
-	 * @public
-	 * @see https://docs.screeps.com/api/#StructureController.effects
-	 */
-	@enumerable override get effects(): RoomObjectEffect[] | undefined {
-		const ticksRemaining = optionalExpiryTime(this['#upgradeInvulnerableUntil']);
-		return ticksRemaining === undefined ? undefined : [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining } ];
 	}
 
 	/**

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -21,6 +21,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/meta/visual',
 
 		'xxscreeps/mods/modern/deposit',
+		'xxscreeps/mods/modern/effects',
 		'xxscreeps/mods/modern/factory',
 		'xxscreeps/mods/modern/nuker',
 		'xxscreeps/mods/modern/observer',

--- a/packages/xxscreeps/mods/modern/effects/constants.ts
+++ b/packages/xxscreeps/mods/modern/effects/constants.ts
@@ -1,0 +1,1 @@
+export const EFFECT_INVULNERABILITY = 1001;

--- a/packages/xxscreeps/mods/modern/effects/game.ts
+++ b/packages/xxscreeps/mods/modern/effects/game.ts
@@ -28,15 +28,13 @@ declare module 'xxscreeps/game/object.js' {
 RoomObject.prototype['#effects'] = function*() {};
 
 extend(RoomObject, {
-	effects: {
+	effects: cached(RoomObject.prototype, 'effects', {
 		enumerable: true,
-		get() {
+		get(this: RoomObject) {
 			const effects = [ ...this['#effects']() ];
-			const value = effects.length > 0 ? effects : undefined;
-			Object.defineProperty(this, 'effects', { value });
-			return value;
+			return effects.length > 0 ? effects : undefined;
 		},
-	},
+	}),
 });
 
 // `#upgradeInvulnerableUntil` belongs to the controller mod, but the effect id and the derived view

--- a/packages/xxscreeps/mods/modern/effects/game.ts
+++ b/packages/xxscreeps/mods/modern/effects/game.ts
@@ -1,0 +1,52 @@
+import type { RoomObjectEffect } from 'xxscreeps/game/object.js';
+import { RoomObject, optionalExpiryTime } from 'xxscreeps/game/object.js';
+import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
+import { extend } from 'xxscreeps/utility/utility.js';
+import * as C from 'xxscreeps:mods/constants';
+
+declare module 'xxscreeps/game/object.js' {
+	interface RoomObject {
+		/**
+		 * Yields the entries behind the `effects` getter. A mod contributes entries for the state it
+		 * owns by wrapping the previous implementation:
+		 *
+		 *   Type.prototype['#effects'] = function(effects) {
+		 *     return function*() { yield* effects.apply(this); yield ...; };
+		 *   }(Type.prototype['#effects']);
+		 *
+		 * A class which controls its own body chains with `yield* super['#effects']()` instead.
+		 *
+		 * Wrapping captures the chain below as of load time, so a later contribution to an ancestor
+		 * prototype does not reach a class already wrapped; `super` resolves late and is immune.
+		 */
+		// Declared as a method because `super['#effects']()` is only legal against a method.
+		// eslint-disable-next-line @typescript-eslint/method-signature-style
+		'#effects'(): Iterable<RoomObjectEffect>;
+	}
+}
+
+RoomObject.prototype['#effects'] = function*() {};
+
+extend(RoomObject, {
+	effects: {
+		enumerable: true,
+		get() {
+			const effects = [ ...this['#effects']() ];
+			const value = effects.length > 0 ? effects : undefined;
+			Object.defineProperty(this, 'effects', { value });
+			return value;
+		},
+	},
+});
+
+// `#upgradeInvulnerableUntil` belongs to the controller mod, but the effect id and the derived view
+// are modern-era surface, so this mod contributes the entry.
+StructureController.prototype['#effects'] = function(effects) {
+	return function*(this: StructureController) {
+		yield* effects.apply(this);
+		const ticksRemaining = optionalExpiryTime(this['#upgradeInvulnerableUntil']);
+		if (ticksRemaining !== undefined) {
+			yield { effect: C.EFFECT_INVULNERABILITY, ticksRemaining };
+		}
+	};
+}(StructureController.prototype['#effects']);

--- a/packages/xxscreeps/mods/modern/effects/index.ts
+++ b/packages/xxscreeps/mods/modern/effects/index.ts
@@ -1,0 +1,10 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+import * as types from 'xxscreeps/tsroot.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/classic/controller',
+	],
+	provides: [ 'constants', 'game' ],
+	types,
+};

--- a/packages/xxscreeps/mods/modern/stronghold/game.ts
+++ b/packages/xxscreeps/mods/modern/stronghold/game.ts
@@ -2,7 +2,6 @@ import { registerVariant } from 'xxscreeps/engine/schema/index.js';
 import { optionalExpiryTime } from 'xxscreeps/game/object.js';
 import { Structure } from 'xxscreeps/mods/classic/structure/structure.js';
 import { compose } from 'xxscreeps/schema/index.js';
-import { extend } from 'xxscreeps/utility/utility.js';
 import * as C from 'xxscreeps:mods/constants';
 import { StructureInvaderCore } from './invader-core.js';
 import { invaderCoreShape } from './schema.js';
@@ -12,14 +11,13 @@ export type StrongholdRoomSchema = typeof invaderCoreSchema;
 const invaderCoreSchema = registerVariant('Room.objects', compose(invaderCoreShape, StructureInvaderCore));
 
 // Deployed stronghold peers surface their shared collapse timer. This mod registers
-// `#collapseTime` on every structure, so it also owns the derived view; subclasses with their own
-// `effects` getters (the invader core, controllers) shadow it with their own state.
-extend(Structure, {
-	effects: {
-		enumerable: true,
-		get() {
-			const ticksRemaining = optionalExpiryTime(this['#collapseTime']);
-			return ticksRemaining === undefined ? undefined : [ { effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining } ];
-		},
-	},
-});
+// `#collapseTime` on every structure, so it also contributes the entry.
+Structure.prototype['#effects'] = function(effects) {
+	return function*(this: Structure) {
+		yield* effects.apply(this);
+		const ticksRemaining = optionalExpiryTime(this['#collapseTime']);
+		if (ticksRemaining !== undefined) {
+			yield { effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining };
+		}
+	};
+}(Structure.prototype['#effects']);

--- a/packages/xxscreeps/mods/modern/stronghold/index.ts
+++ b/packages/xxscreeps/mods/modern/stronghold/index.ts
@@ -8,6 +8,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/classic/controller',
 		'xxscreeps/mods/classic/creep',
 		'xxscreeps/mods/classic/defense',
+		'xxscreeps/mods/modern/effects',
 		'xxscreeps/mods/modern/factory',
 		'xxscreeps/mods/classic/invader',
 		'xxscreeps/mods/classic/logistics',

--- a/packages/xxscreeps/mods/modern/stronghold/invader-core.ts
+++ b/packages/xxscreeps/mods/modern/stronghold/invader-core.ts
@@ -4,7 +4,7 @@ import type { PartType } from 'xxscreeps/mods/classic/creep/creep.js';
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { chainIntentChecks, checkSameRoom, checkTarget } from 'xxscreeps/game/checks.js';
 import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
-import { createRoomObject, optionalExpiryTime, requiredExpiryTime } from 'xxscreeps/game/object.js';
+import { createRoomObject, requiredExpiryTime } from 'xxscreeps/game/object.js';
 import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
 import { Creep } from 'xxscreeps/mods/classic/creep/creep.js';
 import { StructureTower } from 'xxscreeps/mods/classic/defense/tower.js';
@@ -31,16 +31,6 @@ import { invaderCoreShape } from './schema.js';
  * @see https://docs.screeps.com/api/#StructureInvaderCore
  */
 export class StructureInvaderCore extends withOverlay(OwnedStructure, invaderCoreShape) {
-	@enumerable override get effects(): RoomObjectEffect[] | undefined {
-		const { ticksToDeploy } = this;
-		const ticksToCollapse = optionalExpiryTime(this['#collapseTime']);
-		const effects = [
-			...ticksToDeploy === undefined ? [] : [ { effect: C.EFFECT_INVULNERABILITY, ticksRemaining: ticksToDeploy } ],
-			...ticksToCollapse === undefined ? [] : [ { effect: C.EFFECT_COLLAPSE_TIMER, ticksRemaining: ticksToCollapse } ],
-		];
-		return effects.length === 0 ? undefined : effects;
-	}
-
 	/**
 	 * Shows the timer for a not yet deployed stronghold, undefined otherwise.
 	 * @public
@@ -59,6 +49,14 @@ export class StructureInvaderCore extends withOverlay(OwnedStructure, invaderCor
 
 	override get '#invulnerable'() {
 		return this.ticksToDeploy !== undefined;
+	}
+
+	override *'#effects'(): Iterable<RoomObjectEffect> {
+		const { ticksToDeploy } = this;
+		if (ticksToDeploy !== undefined) {
+			yield { effect: C.EFFECT_INVULNERABILITY, ticksRemaining: ticksToDeploy };
+		}
+		yield* super['#effects']();
 	}
 
 	// These four actions are NPC-internal — only the invader loop calls them — so they're private

--- a/packages/xxscreeps/mods/modern/xx.d.ts
+++ b/packages/xxscreeps/mods/modern/xx.d.ts
@@ -1,5 +1,6 @@
 declare module 'xxscreeps:mods/constants' {
 	export * from 'xxscreeps/mods/modern/deposit/constants.js';
+	export * from 'xxscreeps/mods/modern/effects/constants.js';
 	export * from 'xxscreeps/mods/modern/factory/constants.js';
 	export * from 'xxscreeps/mods/modern/nuker/constants.js';
 	export * from 'xxscreeps/mods/modern/observer/constants.js';


### PR DESCRIPTION
Implements the composition half of #340. `bindRenderer` now captures a renderer already bound to the same class and layers under it, so a second mod can add keys without dropping the first mod's. A new `mods/modern/effects` owns a cached `effects` getter over a default `'#effects'` generator; mods contribute entries by wrapping the previous implementation, or with `yield* super['#effects']()` from their own class body, instead of shadowing a getter another mod bound.

The three existing producers move onto the chain: the stronghold collapse timer (contributed on `Structure`, so the invader core no longer restates it), the core's deploy invulnerability, and the controller's upgrade invulnerability. The controller entry and `EFFECT_INVULNERABILITY` land in the new mod because the classic tier cannot depend on modern, which also answers the "find a home for it" TODO; classic servers lose only a constant whose field nothing classic ever writes.

Two deliberate deviations from the #340 sketches: the parent renderer stays a late lookup, since an eager capture regresses a base class that binds after its subclass, and the invader core yields its own entry before `super`, preserving the tested [invulnerability, collapse] order.

The renderer layering has no consumer in this diff; its first is the operator mod's factory rebinding in the next PR. The stronghold peers' missing collapse render entry also stays a follow-up, since the client countdown wants the rolled collapse duration, which is not persisted.

## Validation

Ran the full suite (645/645) and eslint with zero warnings. The existing stronghold and controller effects tests pin the migrated entries and their order unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
