### PR TITLE
decorations: gate the client's `inventory` feature on config

### DIFF
--- a/.changeset/decorations-inventory.md
+++ b/.changeset/decorations-inventory.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Decorations are opt-in: `decorations.grantAll` and the new `decorations.inventory` both default off, so a server renders what is placed without handing anybody the catalog or the client's inventory section. Taking a decoration down stays served either way.

--- a/packages/xxscreeps/mods/meta/decorations/README.md
+++ b/packages/xxscreeps/mods/meta/decorations/README.md
@@ -216,8 +216,11 @@ was — the user's badge is a fact of its own, not a view onto the grant.
 decorations:
   # Load the pack bundled with the server. Default: true
   builtin: true
-  # Every user owns the whole catalog. Default: true
-  grantAll: true
+  # Every user owns the whole catalog, instead of only what they were granted. Default: false
+  grantAll: false
+  # Players have an inventory: the client's inventory section, the room view's decorations panel,
+  # and the routes which place one. Default: false
+  inventory: false
   # Placing a decoration requires controlling or reserving the room. Default: true
   requireRoomOwnership: true
   # Extra packs, as a path to a pack.yaml or the directory holding one
@@ -228,11 +231,24 @@ backend:
   assetBaseUrl: https://screeps.example.com
 ```
 
+`inventory` is the one which changes what the client is, and it is off unless you ask for it: the
+`inventory` feature gates both the client's inventory section and the room view's decorations panel,
+so a default server renders the decorations standing in its rooms while offering nobody a way to
+place one. The official season servers run exactly like that — their `/api/version` names no
+`inventory` feature and the room view draws decorations all the same. Turn it on for a server where
+players are meant to place their own.
+
+The routes go with the flag rather than merely the section: a server which offers no inventory
+should not take an activation from a client which asks for one anyway. Deactivation is the
+exception, and stays served either way — it only ever takes a decoration down, and what players
+placed before the flag was turned off has to stay reachable. `manage decoration` is no substitute:
+under `grantAll` those placements have no stored grant to revoke, so nothing but the route can reach
+them.
+
 ## Handing out decorations
 
-With `grantAll` (the default) there is nothing to do — everybody owns everything, and the ids the
-inventory reports name a decoration rather than a stored grant, so there is nothing to revoke either.
-With it off:
+Ownership is explicit by default: a user owns what they were given, and a fresh server has given
+nobody anything.
 
 ```sh
 xxscreeps manage decoration catalog
@@ -242,7 +258,9 @@ xxscreeps manage decoration revoke  <name|id> <itemId>
 xxscreeps manage decoration cleanup [name|id]
 ```
 
-Grants are stored either way, so turning `grantAll` off later leaves each user with exactly what
-they were given. What it does not leave them is the placements they made while ownership was
-implicit: those have no grant behind them, so they go invisible and nothing can reach them any more.
+With `grantAll` on there is nothing to hand out — everybody owns everything, and the ids the
+inventory reports name a decoration rather than a stored grant, so there is nothing to revoke
+either. Grants are stored either way, so turning it back off leaves each user with exactly what they
+were given. What it does not leave them is the placements they made while ownership was implicit:
+those have no grant behind them, so they go invisible and nothing can reach them any more.
 `decoration cleanup` deactivates them — for one user, or with no argument for all of them.

--- a/packages/xxscreeps/mods/meta/decorations/backend.ts
+++ b/packages/xxscreeps/mods/meta/decorations/backend.ts
@@ -6,6 +6,7 @@ import type { Database } from 'xxscreeps/engine/db/index.js';
 import type { Shard } from 'xxscreeps/engine/db/shard.js';
 import * as fs from 'node:fs/promises';
 import { hooks, makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
+import { config } from 'xxscreeps/config/index.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { acquireWith } from 'xxscreeps/utility/async.js';
 import { disposableToEffect } from 'xxscreeps/utility/utility.js';
@@ -44,36 +45,45 @@ export const placementToWire = (id: string, placement: Placement): Record<string
 	_id: id,
 });
 
-hooks.register('route', {
-	path: '/api/user/decorations/inventory',
+/**
+ * Whether players have a decoration inventory here. With it off the client is never told the
+ * `inventory` feature exists and the routes which place one are not served; what already stands
+ * goes on being rendered, and taking it down stays open.
+ */
+const hasInventory = config.decorations?.inventory ?? false;
 
-	async execute(context) {
-		const { userId } = context.state;
-		if (userId === undefined) {
-			return { ok: 1, list: [] };
-		}
-		const items = await listForUser(context.db, userId);
-		return {
-			ok: 1,
-			list: items.map(item => ({
-				_id: item.id,
-				createdAt: new Date(item.createdAt).toISOString(),
-				activatedAt: item.activatedAt === undefined ? undefined : new Date(item.activatedAt).toISOString(),
-				// `null` is how the client spells "owned, not placed".
-				active: item.active === undefined ? null : placementToWire(item.id, item.active),
-				decoration: toClientDefinition(item.definition),
-			})),
-		};
-	},
-});
+if (hasInventory) {
+	hooks.register('route', {
+		path: '/api/user/decorations/inventory',
 
-hooks.register('route', {
-	path: '/api/user/decorations/themes',
+		async execute(context) {
+			const { userId } = context.state;
+			if (userId === undefined) {
+				return { ok: 1, list: [] };
+			}
+			const items = await listForUser(context.db, userId);
+			return {
+				ok: 1,
+				list: items.map(item => ({
+					_id: item.id,
+					createdAt: new Date(item.createdAt).toISOString(),
+					activatedAt: item.activatedAt === undefined ? undefined : new Date(item.activatedAt).toISOString(),
+					// `null` is how the client spells "owned, not placed".
+					active: item.active === undefined ? null : placementToWire(item.id, item.active),
+					decoration: toClientDefinition(item.definition),
+				})),
+			};
+		},
+	});
 
-	execute() {
-		return { ok: 1, list: catalog.themes.map(({ id, ...rest }) => ({ _id: id, ...rest })) };
-	},
-});
+	hooks.register('route', {
+		path: '/api/user/decorations/themes',
+
+		execute() {
+			return { ok: 1, list: catalog.themes.map(({ id, ...rest }) => ({ _id: id, ...rest })) };
+		},
+	});
+}
 
 interface ActivateRequest {
 	_id: string;
@@ -221,19 +231,21 @@ export async function activate(db: Database, shard: Shard, userId: string, itemI
 	}
 }
 
-hooks.register('route', {
-	path: '/api/user/decorations/activate',
-	method: 'post',
+if (hasInventory) {
+	hooks.register('route', {
+		path: '/api/user/decorations/activate',
+		method: 'post',
 
-	execute: makeValidatedPayloadRoute(activateSchema, async context => {
-		const { userId } = context.state;
-		if (userId === undefined) {
-			return { error: 'not authenticated' };
-		}
-		const { _id, active } = context.request.body;
-		return await activate(context.db, context.shard, userId, _id, active) ?? { ok: 1 };
-	}),
-});
+		execute: makeValidatedPayloadRoute(activateSchema, async context => {
+			const { userId } = context.state;
+			if (userId === undefined) {
+				return { error: 'not authenticated' };
+			}
+			const { _id, active } = context.request.body;
+			return await activate(context.db, context.shard, userId, _id, active) ?? { ok: 1 };
+		}),
+	});
+}
 
 interface DeactivateRequest {
 	decorations: string[];
@@ -250,6 +262,9 @@ const deactivateSchema: JSONSchemaType<DeactivateRequest> = {
 	required: [ 'decorations' ],
 };
 
+// Served whether or not there is an inventory: it only ever takes a decoration down, and what was
+// placed before the feature was turned off has to stay reachable. Implicit ownership leaves no
+// grant to revoke, so `manage decoration` cannot reach those placements either.
 hooks.register('route', {
 	path: '/api/user/decorations/deactivate',
 	method: 'post',
@@ -413,16 +428,19 @@ const mapDecoration = (definition: DecorationDefinition) => ({
 });
 
 // The client gates its inventory section on this flag, and builds the section's route and sidebar
-// entry from the menu payload riding along with it.
-hooks.register('version', serverData => {
-	serverData.features.push({
-		name: 'inventory',
-		version: 1,
-		menuData: [ {
-			section: 0,
-			after: 'World',
-			item: { id: 'menu-item-inventory', label: 'Inventory', routerLink: '/inventory', svg: 'inventory' },
-			module: 'InventoryModule',
-		} ],
+// entry from the menu payload riding along with it. The room view's decorations panel hangs off the
+// same flag.
+if (hasInventory) {
+	hooks.register('version', serverData => {
+		serverData.features.push({
+			name: 'inventory',
+			version: 1,
+			menuData: [ {
+				section: 0,
+				after: 'World',
+				item: { id: 'menu-item-inventory', label: 'Inventory', routerLink: '/inventory', svg: 'inventory' },
+				module: 'InventoryModule',
+			} ],
+		});
 	});
-});
+}

--- a/packages/xxscreeps/mods/meta/decorations/config.schema.json
+++ b/packages/xxscreeps/mods/meta/decorations/config.schema.json
@@ -16,7 +16,12 @@
                 "grantAll": {
                     "description": "Whether every user owns the whole decoration catalog. With this off, decorations must be handed out explicitly with `xxscreeps manage decoration grant`.",
                     "type": "boolean",
-                    "default": true
+                    "default": false
+                },
+                "inventory": {
+                    "description": "Whether players have a decoration inventory. With this off the client is never told the `inventory` feature exists, so it offers neither the inventory section nor the room view's decorations panel, and the routes which place one are not served. Decorations already placed are still rendered, and taking one down is still served.",
+                    "type": "boolean",
+                    "default": false
                 },
                 "packs": {
                     "description": "Additional decoration packs to load. Each entry is a path to a `pack.json`, or to the directory holding one.",

--- a/packages/xxscreeps/mods/meta/decorations/config.ts
+++ b/packages/xxscreeps/mods/meta/decorations/config.ts
@@ -8,9 +8,18 @@ export interface DecorationsSettings {
 	/**
 	 * Whether every user owns the whole decoration catalog. With this off, decorations must be
 	 * handed out explicitly with `xxscreeps manage decoration grant`.
-	 * @default true
+	 * @default false
 	 */
 	grantAll?: boolean;
+
+	/**
+	 * Whether players have a decoration inventory. With this off the client is never told the
+	 * `inventory` feature exists, so it offers neither the inventory section nor the room view's
+	 * decorations panel, and the routes which place one are not served. Decorations already placed
+	 * are still rendered, and taking one down is still served.
+	 * @default false
+	 */
+	inventory?: boolean;
 
 	/**
 	 * Additional decoration packs to load. Each entry is a path to a `pack.yaml`, or to the

--- a/packages/xxscreeps/mods/meta/decorations/model.ts
+++ b/packages/xxscreeps/mods/meta/decorations/model.ts
@@ -19,10 +19,11 @@ import { conflicts, decodeProps, encodeProps } from './placement.js';
 // so it lives in the shared `db.data` store next to the other per-user records — `active.shard`
 // says which shard a placement points at.
 //
-// With `decorations.grantAll` (the default) the whole catalog is owned by everybody and no grant is
-// read from the store at all — the natural setup for a private server, where decorations are a
-// customisation option rather than something to earn. Explicit grants are still written and kept;
-// they take effect once `grantAll` is turned off. Placements are stored either way.
+// Ownership is earned or handed out: a user owns what `xxscreeps manage decoration grant` wrote for
+// them, and nothing else. With `decorations.grantAll` the whole catalog is owned by everybody
+// instead and no grant is read from the store at all — a private server treating decorations as a
+// customisation option rather than something to earn. Explicit grants are still written and kept
+// while it is on; they take effect again once it is off. Placements are stored either way.
 //
 // A placement made while `grantAll` is on has no stored grant behind it. Turning the flag off
 // strands it — invisible everywhere, unreachable from the client — until `xxscreeps manage
@@ -47,7 +48,7 @@ const shardIndexKey = (shardName: string) => `decorations/${shardName}`;
 /** set: `userId/itemId` of the creep decorations, which follow their owner instead of a room. */
 const globalIndexKey = 'decorations/global';
 
-export const grantAll = () => config.decorations?.grantAll ?? true;
+export const grantAll = () => config.decorations?.grantAll ?? false;
 
 /**
  * Announces that what is placed in a room changed, so open room sockets re-read it. Creep

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -179,8 +179,8 @@ async function userBranch(who: string, branch: string) {
 	out(`Set active branch for ${who} (${id}) to '${branch}'.`);
 }
 
-// Decorations a user owns. `grantAll` (the default) hands out the whole catalog, in which case
-// `list` reports that implicit ownership; grants are still written and surface once it's off.
+// Decorations a user owns. `grantAll` hands out the whole catalog instead, in which case `list`
+// reports that implicit ownership; grants are still written and surface once it's off.
 function decorationCatalog() {
 	const definitions = [ ...catalog.definitions.values() ].sort(mappedPrimitiveComparator(definition => definition.id));
 	if (definitions.length === 0) {


### PR DESCRIPTION
This PR introduces a new inventory switch which allows to disable the the client inventory feature flag. ( This removes the Inventory entry from the menu and applied decorations are not listed in the room view)

This is for example used on the season server. There are decorations configured in config that are automatically applied to every room on the server. This would be a later PR.

Open Question: Would we want to support server wide decorations together with a player inventory ? that might make it more complicated to merge the decorations in rooms... like would they get appended or same object decorations would be replaced ... but some types like graffity or creep decorations also stack. It would probably much simpler if server wide decorations would only work when the user can't set own decorations on top or replace them.
The mixing of server wide decorations with user decorations also has the disadvantage that the client lists the season decoration in its decoration section for every room .. this is only disabled when the inventory is also disabled

It also disables the grantAll default true value that simply grants all decorations to every user ... which was more a debug feature.

btw I created a xxscreeps based server decoration for testing and it looks like this: 

<img width="989" height="981" alt="Screenshot 2026-08-19 at 13 33 28" src="https://github.com/user-attachments/assets/d6148b79-277a-49f2-af6c-b064ec1a2fe3" />
