### PR TITLE
email: move the account address into a backend mod

### DIFF
--- a/.changeset/email-provider-mod.md
+++ b/.changeset/email-provider-mod.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Move the email address into a backend mod, normalize its case, and reject duplicates.

--- a/packages/xxscreeps/backend/endpoints/register.ts
+++ b/packages/xxscreeps/backend/endpoints/register.ts
@@ -3,37 +3,6 @@ import type { Endpoint } from 'xxscreeps/backend/index.js';
 import { makeValidatedPayloadRoute, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
 
-function validateEmail(email: string) {
-	return /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(email);
-}
-
-interface CheckEmailRequest {
-	email: string;
-}
-
-const checkEmailRequestSchema: JSONSchemaType<CheckEmailRequest> = {
-	type: 'object',
-	properties: {
-		email: { type: 'string' },
-	},
-	required: [ 'email' ],
-};
-
-const CheckEmailEndpoint: Endpoint = {
-	method: 'get',
-	path: '/api/register/check-email',
-	execute: makeValidatedQueryRoute(checkEmailRequestSchema, async context => {
-		const { email } = context.request.query;
-		if (!validateEmail(email)) {
-			return { error: 'invalid' };
-		}
-		if (await User.findUserByProvider(context.db, 'email', email) !== null) {
-			return { error: 'exists' };
-		}
-		return { ok: 1 };
-	}),
-};
-
 interface CheckUsernameRequest {
 	username: string;
 }
@@ -93,14 +62,14 @@ const SetUsernameEndpoint: Endpoint = {
 		// Sanity check
 		const { username, email: maybeEmail } = context.request.body;
 		const email = maybeEmail === '' ? undefined : maybeEmail;
-		if (!User.checkUsername(username) || (email != null && !validateEmail(email))) {
+		if (!User.checkUsername(username) || (email != null && !User.checkEmail(email))) {
 			return { error: 'invalid' };
 		}
 
 		// Register
 		const providers = [ { provider, id: providerId } ];
 		if (email != null) {
-			providers.push({ provider: 'email', id: email });
+			providers.push({ provider: User.emailProvider, id: email });
 		}
 		await User.create(context.db, newUserId, username, providers);
 		context.state.userId = newUserId;
@@ -111,5 +80,5 @@ const SetUsernameEndpoint: Endpoint = {
 	}),
 };
 
-const endpoints = [ CheckEmailEndpoint, CheckUsernameEndpoint, SetUsernameEndpoint ];
+const endpoints = [ CheckUsernameEndpoint, SetUsernameEndpoint ];
 export default endpoints;

--- a/packages/xxscreeps/config/config.ts
+++ b/packages/xxscreeps/config/config.ts
@@ -325,6 +325,7 @@ export const initializationDefaults = {
 	mods: [
 		'xxscreeps/mods/classic',
 		'xxscreeps/mods/backend/cookie',
+		'xxscreeps/mods/backend/email',
 		'xxscreeps/mods/backend/password',
 		'xxscreeps/mods/backend/steam',
 	],

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -17,6 +17,14 @@ const providerMembersKey = (provider: string) => `usersByProvider/${provider}`;
 const userProvidersKey = (userId: string) => `user/${userId}/provider`;
 export const infoKey = (userId: string) => `user/${userId}`;
 
+/**
+ * Provider under which an account's email address is filed. An address is an identity the same way
+ * a username is, so checking, flattening and looking one up sit beside their username counterparts
+ * rather than in the backend mod which makes a feature of them. Every service which can create a
+ * user has to agree on all three, and the mod is only loaded by the backend.
+ */
+export const emailProvider = 'email';
+
 interface BackendUserInfo {
 	username: string;
 	badge: Badge | null;
@@ -34,8 +42,19 @@ export function checkUsername(username: string) {
 	);
 }
 
+export function checkEmail(email: string) {
+	return (
+		email.length <= 254 &&
+		/^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i.test(email)
+	);
+}
+
 function flattenUsername(username: string) {
 	return username.replace(/[-_ ]/g, '').toLowerCase();
+}
+
+function flattenEmail(email: string) {
+	return email.toLowerCase();
 }
 
 export async function create(db: Database, userId: string, username: string, providers: { provider: string; id: string }[] = []) {
@@ -44,7 +63,8 @@ export async function create(db: Database, userId: string, username: string, pro
 	// Check for existing associations
 	const allProviders = [
 		{ provider: 'username', id: flattenUsername(username) },
-		...providers,
+		...Fn.map(providers, ({ provider, id }) =>
+			({ provider, id: provider === emailProvider ? flattenEmail(id) : id })),
 	];
 	const providerConflicts = await Promise.all(Fn.map(allProviders,
 		({ provider, id }) => db.data.hGet(providerMembersKey(provider), id)));
@@ -110,6 +130,15 @@ export async function findUserByProvider(db: Database, provider: string, provide
 
 export async function findUserByName(db: Database, username: string) {
 	return findUserByProvider(db, 'username', flattenUsername(username));
+}
+
+export async function findUserByEmail(db: Database, email: string) {
+	return findUserByProvider(db, emailProvider, flattenEmail(email));
+}
+
+/** The address on a user's account, or `null` if they registered without one. */
+export function emailForUser(db: Database, userId: string) {
+	return providerIdForUser(db, emailProvider, userId);
 }
 
 export async function loadBackendUserInfo(db: Database, userId: string): Promise<BackendUserInfo | undefined> {

--- a/packages/xxscreeps/engine/db/user/index.ts
+++ b/packages/xxscreeps/engine/db/user/index.ts
@@ -17,12 +17,6 @@ const providerMembersKey = (provider: string) => `usersByProvider/${provider}`;
 const userProvidersKey = (userId: string) => `user/${userId}/provider`;
 export const infoKey = (userId: string) => `user/${userId}`;
 
-/**
- * Provider under which an account's email address is filed. An address is an identity the same way
- * a username is, so checking, flattening and looking one up sit beside their username counterparts
- * rather than in the backend mod which makes a feature of them. Every service which can create a
- * user has to agree on all three, and the mod is only loaded by the backend.
- */
 export const emailProvider = 'email';
 
 interface BackendUserInfo {
@@ -43,10 +37,7 @@ export function checkUsername(username: string) {
 }
 
 export function checkEmail(email: string) {
-	return (
-		email.length <= 254 &&
-		/^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i.test(email)
-	);
+	return email.length <= 254 && /^[a-z0-9._%'+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i.test(email);
 }
 
 function flattenUsername(username: string) {

--- a/packages/xxscreeps/engine/db/user/test.ts
+++ b/packages/xxscreeps/engine/db/user/test.ts
@@ -16,6 +16,38 @@ describe('engine/db/user', () => {
 		}
 	});
 
+	test('an address is found from either side, however it was capitalized', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '400', 'MailUser', [ { provider: User.emailProvider, id: 'Mail@User.test' } ]);
+		assert.strictEqual(await User.findUserByEmail(db, 'mail@user.test'), '400');
+		assert.strictEqual(await User.findUserByEmail(db, 'MAIL@USER.TEST'), '400');
+		assert.strictEqual(await User.emailForUser(db, '400'), 'mail@user.test');
+	});
+
+	test('an address another account holds cannot be registered under a different case', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '401', 'FirstUser', [ { provider: User.emailProvider, id: 'shared@user.test' } ]);
+		await assert.rejects(() => User.create(db, '402', 'SecondUser',
+			[ { provider: User.emailProvider, id: 'Shared@User.test' } ]));
+	});
+
+	test('an account registered without an address has none', async () => {
+		await using testShard = await instantiateTestShard();
+		const { db } = testShard;
+		await User.create(db, '403', 'PlainUser');
+		assert.strictEqual(await User.emailForUser(db, '403'), null);
+		assert.strictEqual(await User.findUserByEmail(db, 'mail@user.test'), null);
+	});
+
+	test('checkEmail takes an address in any case and rejects a username', () => {
+		assert.strictEqual(User.checkEmail('mail@user.test'), true);
+		assert.strictEqual(User.checkEmail('John.Doe@Example.com'), true);
+		assert.strictEqual(User.checkEmail('MailUser'), false);
+		assert.strictEqual(User.checkEmail(`${'long'.repeat(64)}@user.test`), false);
+	});
+
 	test('removed user is no longer found', async () => {
 		await using testShard = await instantiateTestShard();
 		const { db } = testShard;

--- a/packages/xxscreeps/mods/backend/cookie/index.ts
+++ b/packages/xxscreeps/mods/backend/cookie/index.ts
@@ -1,7 +1,3 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
-import * as types from 'xxscreeps/tsroot.js';
 
-export const manifest: Manifest = {
-	provides: 'backend',
-	types,
-};
+export const manifest: Manifest = { provides: 'backend' };

--- a/packages/xxscreeps/mods/backend/email/backend.ts
+++ b/packages/xxscreeps/mods/backend/email/backend.ts
@@ -1,0 +1,42 @@
+import type { JSONSchemaType } from 'ajv';
+import { hooks, makeValidatedQueryRoute } from 'xxscreeps/backend/index.js';
+import { checkEmail, emailForUser, findUserByEmail } from 'xxscreeps/engine/db/user/index.js';
+
+interface CheckEmailRequest {
+	email: string;
+}
+
+const checkEmailRequestSchema: JSONSchemaType<CheckEmailRequest> = {
+	type: 'object',
+	properties: {
+		email: { type: 'string' },
+	},
+	required: [ 'email' ],
+};
+
+// Tells the registration form whether an address is free before it is submitted
+hooks.register('route', {
+	method: 'get',
+	path: '/api/register/check-email',
+
+	execute: makeValidatedQueryRoute(checkEmailRequestSchema, async context => {
+		const { email } = context.request.query;
+		if (!checkEmail(email)) {
+			return { error: 'invalid' };
+		}
+		if (await findUserByEmail(context.db, email) !== null) {
+			return { error: 'exists' };
+		}
+		return { ok: 1 };
+	}),
+});
+
+// Report the address back to the account which owns it, and to nobody else
+hooks.register('sendUserInfo', async (db, userId, userInfo, privateSelf) => {
+	if (privateSelf) {
+		const email = await emailForUser(db, userId);
+		if (email !== null) {
+			userInfo.email = email;
+		}
+	}
+});

--- a/packages/xxscreeps/mods/backend/email/index.ts
+++ b/packages/xxscreeps/mods/backend/email/index.ts
@@ -1,7 +1,6 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
-import * as types from 'xxscreeps/tsroot.js';
 
 export const manifest: Manifest = {
 	provides: 'backend',
-	types,
+	dependencies: [ 'xxscreeps/mods/backend/email' ],
 };

--- a/packages/xxscreeps/mods/backend/email/index.ts
+++ b/packages/xxscreeps/mods/backend/email/index.ts
@@ -1,0 +1,7 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+import * as types from 'xxscreeps/tsroot.js';
+
+export const manifest: Manifest = {
+	provides: 'backend',
+	types,
+};

--- a/packages/xxscreeps/mods/backend/password/backend.ts
+++ b/packages/xxscreeps/mods/backend/password/backend.ts
@@ -3,17 +3,17 @@ import type { Database } from 'xxscreeps/engine/db/index.js';
 import { hooks, makeValidatedPayloadRoute } from 'xxscreeps/backend/index.js';
 import { config } from 'xxscreeps/config/index.js';
 import * as User from 'xxscreeps/engine/db/user/index.js';
-import { findUserByName, findUserByProvider, infoKey } from 'xxscreeps/engine/db/user/index.js';
 import * as Id from 'xxscreeps/engine/schema/id.js';
 import { checkPassword, setPassword } from './model.js';
 
 const { allowEmailRegistration } = config.backend;
 
+// The sign-in form takes one field for either identity
 async function findUserByUsernameOrEmail(db: Database, value: string) {
 	if (value.includes('@')) {
-		return findUserByProvider(db, 'email', value);
+		return User.findUserByEmail(db, value);
 	}
-	return findUserByName(db, value);
+	return User.findUserByName(db, value);
 }
 
 // HTTP Basic Auth
@@ -125,35 +125,34 @@ hooks.register('route', {
 	path: '/api/register/submit',
 
 	execute: makeValidatedPayloadRoute(registerRequestSchema, async context => {
-		const { username, email, password } = context.request.body;
-		if (!User.checkUsername(username)) {
-			return { error: 'invalid' };
-		}
-		if (await User.findUserByName(context.db, username) !== null) {
-			return { error: 'exists' };
-		}
-		if (allowEmailRegistration) {
-			const newUserId = Id.generateId(12);
-			await User.create(context.db, newUserId, username, [ { provider: 'email', id: email } ]);
-			await setPassword(context.db, newUserId, password);
-			return { ok: 1 };
-		} else {
+		if (!allowEmailRegistration) {
 			context.status = 500;
 			return { error: 'registration disabled' };
 		}
+		const { username, email, password } = context.request.body;
+		if (!User.checkUsername(username) || !User.checkEmail(email)) {
+			return { error: 'invalid' };
+		}
+		const [ userByName, userByEmail ] = await Promise.all([
+			User.findUserByName(context.db, username),
+			User.findUserByEmail(context.db, email),
+		]);
+		if (userByName !== null || userByEmail !== null) {
+			return { error: 'exists' };
+		}
+		const newUserId = Id.generateId(12);
+		await User.create(context.db, newUserId, username, [ { provider: User.emailProvider, id: email } ]);
+		await setPassword(context.db, newUserId, password);
+		return { ok: 1 };
 	}),
 });
 
-// Add password flag and email to user info payload
+// Add password flag to user info payload
 hooks.register('sendUserInfo', async (db, userId, userInfo, privateSelf) => {
 	if (privateSelf) {
-		const password = await db.data.hGet(infoKey(userId), 'password');
+		const password = await db.data.hGet(User.infoKey(userId), 'password');
 		if (password !== null) {
 			userInfo.password = true;
-		}
-		const email = await User.providerIdForUser(db, 'email', userId);
-		if (email !== null) {
-			userInfo.email = email;
 		}
 	}
 });

--- a/packages/xxscreeps/mods/backend/steam/index.ts
+++ b/packages/xxscreeps/mods/backend/steam/index.ts
@@ -1,7 +1,3 @@
 import type { Manifest } from 'xxscreeps/config/mods.js';
-import * as types from 'xxscreeps/tsroot.js';
 
-export const manifest: Manifest = {
-	provides: 'backend',
-	types,
-};
+export const manifest: Manifest = {	provides: 'backend' };

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -123,8 +123,11 @@ async function userCreate(name: string, email?: string) {
 	if (!User.checkUsername(name)) {
 		throw new Error(`Invalid username: ${name}`);
 	}
+	if (email !== undefined && !User.checkEmail(email)) {
+		throw new Error(`Invalid email address: ${email}`);
+	}
 	const id = Id.generateId(12);
-	await User.create(db, id, name, email === undefined ? [] : [ { provider: 'email', id: email } ]);
+	await User.create(db, id, name, email === undefined ? [] : [ { provider: User.emailProvider, id: email } ]);
 	await save();
 	out(`Created user ${name} (${id}).`);
 }


### PR DESCRIPTION
The address a user registers with was split between the backend core, which served the availability
check, and the password mod, which reported it back on the user info payload. Neither owned the
idea, so the backend surface moves into a mod alongside cookie, password and steam.

The identity itself stays in core beside its username counterparts. Checking, flattening and looking
up an address have to agree across every service which can create a user, and the mod is only loaded
by the backend, so `emailProvider`, `checkEmail`, `findUserByEmail` and `emailForUser` sit next to
`checkUsername` and `findUserByName`.

Addresses are now flattened on the way in and on lookup, the way usernames already were, so a
differently capitalized address is the same identity rather than a second account. `checkEmail`
accepts any case and bounds the length. Password registration looks both identities up together and
answers `exists` for either, where a duplicate address previously reached `User.create` and came
back as a failed request.

## Validation

`tsc -b` and the full suite (649 tests) on Node 24. The two normalization tests in
`engine/db/user/test.ts` were confirmed to fail with the `create` flatten reverted.
