### PR TITLE
notifications: honor the disabled preference at the send seam

### DIFF
--- a/.changeset/notify-disabled-seam.md
+++ b/.changeset/notify-disabled-seam.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Honor the `disabled` notification preference at the send seam, before any transport.

--- a/packages/xxscreeps/mods/meta/messages/backend.ts
+++ b/packages/xxscreeps/mods/meta/messages/backend.ts
@@ -114,10 +114,11 @@ const SendEndpoint: Endpoint = {
 
 		await sendMessage(context.db, userId, respondent, text);
 
-		// Best-effort message notification, gated by the recipient's notify prefs.
+		// Best-effort message notification. `disabled` is `sendNotification`'s to enforce; this mod
+		// owns only the message-specific pref.
 		try {
 			const prefs = await getNotifyPrefs(context.db, respondent);
-			if (!prefs.disabled && !prefs.disabledOnMessages) {
+			if (!prefs.disabledOnMessages) {
 				const sender = await context.db.data.hmGet(User.infoKey(userId), [ 'username' ]);
 				await sendNotification(context.shard, respondent, 'msg', `You have a new message from ${sender.username ?? 'a player'}`, kCoalesceForever);
 			}

--- a/packages/xxscreeps/mods/meta/notifications/test.ts
+++ b/packages/xxscreeps/mods/meta/notifications/test.ts
@@ -2,7 +2,8 @@ import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
 import { dispatchQueuedNotifications } from './driver.js';
 import { flush } from './notifications.js';
-import { captureNotificationsForTesting } from './transport.js';
+import { setNotifyPrefs } from './prefs.js';
+import { captureNotificationsForTesting, sendNotification } from './transport.js';
 
 const userA = '100';
 
@@ -14,8 +15,8 @@ describe('mods/meta/notifications', () => {
 
 	// The notify queue is module-level state that persists between tests (the test framework runs
 	// sequentially in one process and `simulate.tick()` does not fire runtimeConnector.send to drain
-	// it, the way prod does). Each test calls `flush()` first to start with a clean queue, mirroring
-	// the visual mod's "calls clear() to avoid shared state" pattern.
+	// it, the way prod does). Each test which queues calls `flush()` first to start with a clean
+	// queue, mirroring the visual mod's "calls clear() to avoid shared state" pattern.
 
 	test('returns OK on accept', () => empty(async ({ player }) => {
 		flush();
@@ -131,6 +132,16 @@ describe('mods/meta/notifications', () => {
 		assert.strictEqual(capture.sent.length, 1);
 		assert.strictEqual(capture.sent[0]?.message, 'undefined');
 		assert.strictEqual(capture.sent[0].type, 'msg');
+	}));
+
+	test('notifyPrefs.disabled drops before the transport', () => empty(async ({ shard }) => {
+		using capture = captureNotificationsForTesting();
+		await setNotifyPrefs(shard.db, userA, { disabled: true });
+		await sendNotification(shard, userA, 'msg', 'hi');
+		assert.strictEqual(capture.sent.length, 0, 'disabled user reaches no transport');
+		await setNotifyPrefs(shard.db, userA, { disabled: false });
+		await sendNotification(shard, userA, 'msg', 'hi');
+		assert.strictEqual(capture.sent.length, 1, 'the same call lands once the pref clears');
 	}));
 
 });

--- a/packages/xxscreeps/mods/meta/notifications/transport.ts
+++ b/packages/xxscreeps/mods/meta/notifications/transport.ts
@@ -1,5 +1,6 @@
 import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { makeProviderRegistration } from 'xxscreeps/utility/hook.js';
+import { getNotifyPrefs } from './prefs.js';
 
 export type NotificationType = 'msg' | 'error';
 
@@ -34,10 +35,19 @@ export const notificationTransport = makeProviderRegistration<NotificationTransp
  * Deliver a notification through the registered transport. `groupInterval` is a coalescing hint in
  * minutes which transports without their own grouping are free to ignore. `message` and
  * `groupInterval` are assumed already coerced by the caller.
+ *
+ * `disabled` is enforced here rather than in a transport's own delivery pass: the pref belongs to
+ * this mod, and a transport that keeps no store has nowhere else to check it. The read lands per
+ * notification, which is affordable only while the producers stay concurrent -- the processor's go
+ * through `context.task`, which holds an already-started promise.
  */
 export async function sendNotification(
 	shard: Shard, userId: string, type: NotificationType, message: string, groupInterval = 0,
 ) {
+	const { disabled } = await getNotifyPrefs(shard.db, userId);
+	if (disabled) {
+		return;
+	}
 	await notificationTransport.current.send(shard, { userId, type, message, groupInterval });
 }
 


### PR DESCRIPTION
`notifyPrefs.disabled` has had no reader on the `Game.notify` path since #373, so a player who
turns notifications off still gets a row recorded for every call (#379, first point).

It is enforced in `sendNotification` rather than in a transport's own pass: this mod owns the pref,
and a transport that keeps no store has nowhere else to check it. That costs an `hGetAll` per
notification, deliberately with no memo. Producers go through `context.task`, so a room's batch
pipelines into one round trip, about 0.2ms on loopback redis against a 250ms tick.
`/api/user/messages/send` now reads the prefs hash twice, which is human-rate.

## Validation

Added a test asserting a disabled user never reaches the transport, and that the call lands once
the pref clears; confirmed it fails with the check reverted. 665/665 tests, eslint clean. Live
smoke: setting `disabled` through `POST /api/user/notify-prefs` stopped a bot's `Game.notify` rows
and clearing it resumed them, and a processor-emitted controller notification went through the same
seam.
