### PR TITLE
notifications: drain queued rows and fan out to delivery consumers

### DIFF
--- a/.changeset/notify-delivery.md
+++ b/.changeset/notify-delivery.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Notification rows drain on a cadence and fan out to `deliver` hook consumers.

--- a/packages/xxscreeps/mods/meta/notify-cron/main.ts
+++ b/packages/xxscreeps/mods/meta/notify-cron/main.ts
@@ -1,4 +1,44 @@
+import type { Shard } from 'xxscreeps/engine/db/index.js';
 import { everyNTicks, registerShardTickProcessor } from 'xxscreeps/engine/processor/index.js';
-import { pruneExpiredNotifications } from './model.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
+import { getNotifyPrefs } from 'xxscreeps/mods/meta/notifications/prefs.js';
+import { consumeDueUsers, getDueNotifications, getLastNotifyDate, hooks, kDefaultIntervalMinutes, nextPendingDueAt, removeNotifications, scheduleUserDrain, setLastNotifyDate } from './model.js';
 
-registerShardTickProcessor(everyNTicks(100, shard => pruneExpiredNotifications(shard, Date.now())));
+const deliverHooks = hooks.makeMapped('deliver');
+
+async function drainUser(shard: Shard, userId: string) {
+	const [ prefs, lastNotifyDate ] = await Promise.all([
+		getNotifyPrefs(shard.db, userId),
+		getLastNotifyDate(shard.db, userId),
+	]);
+	const now = Date.now();
+	const throttleEndsAt = lastNotifyDate + (prefs.interval ?? kDefaultIntervalMinutes) * 60_000;
+	if (throttleEndsAt > now) {
+		// Throttled — push the user's drain to the throttle deadline. Row groups maturing in the
+		// meantime will be picked up at the same drain pass.
+		await scheduleUserDrain(shard, userId, throttleEndsAt);
+		return;
+	}
+	const items = await getDueNotifications(shard, userId, now);
+	if (items.length > 0) {
+		// Rows are removed even when a consumer rejects; keeping them would redeliver to the
+		// consumers that did accept, on every later pass.
+		await Fn.mapAwait(deliverHooks(shard, userId, items.map(item => item.row)), delivery =>
+			delivery.catch(err => console.error(`Notification delivery failed for user ${userId}`, err)));
+		await Promise.all([
+			removeNotifications(shard, userId, items.map(item => item.id)),
+			setLastNotifyDate(shard.db, userId, now),
+		]);
+	}
+	const next = await nextPendingDueAt(shard, userId);
+	if (next !== undefined) {
+		await scheduleUserDrain(shard, userId, next);
+	}
+}
+
+async function drainAndDeliver(shard: Shard) {
+	const userIds = await consumeDueUsers(shard, Date.now());
+	await Fn.mapAwait(userIds, userId => drainUser(shard, userId));
+}
+
+registerShardTickProcessor(everyNTicks(10, drainAndDeliver));

--- a/packages/xxscreeps/mods/meta/notify-cron/model.ts
+++ b/packages/xxscreeps/mods/meta/notify-cron/model.ts
@@ -1,7 +1,8 @@
-import type { Shard } from 'xxscreeps/engine/db/index.js';
+import type { Database, Shard } from 'xxscreeps/engine/db/index.js';
 import type { NotificationType } from 'xxscreeps/mods/meta/notifications/transport.js';
 import { createHash } from 'node:crypto';
 import { Fn } from 'xxscreeps/functional/fn.js';
+import { makeHookRegistration } from 'xxscreeps/utility/hook.js';
 
 export interface NotificationRow {
 	user: string;
@@ -11,33 +12,77 @@ export interface NotificationRow {
 	type: NotificationType;
 }
 
-// Sorted set: score = due time (ms) -- the group deadline, or the latest occurrence for
-// coalesce-forever rows. Member = rowId.
+export const hooks = makeHookRegistration<{
+	/**
+	 * Fired at most once per user per drain pass, with every row whose group deadline has elapsed
+	 * and after the user's `interval` cadence has been honored. Consumers which deliver
+	 * notifications somewhere — a mailer, a chat bridge, an in-game inbox — hang off this rather
+	 * than claiming the transport slot, which stores rows and admits only one owner. Rows are
+	 * removed once the batch has been handed out, whether or not a consumer accepted it.
+	 *
+	 * The drain runs on `main`, so register from a consumer's own `main.ts`. A registration in
+	 * `processor.ts` is the trap: the suite loads that slot, so the tests pass, but in production it
+	 * loads only in the processor worker and never fires. The fan-out is awaited inside the shard
+	 * tick, so a consumer which blocks on slow I/O holds up every player on the shard.
+	 */
+	deliver: (shard: Shard, userId: string, rows: readonly NotificationRow[]) => Promise<unknown>;
+}>();
+
+// Sorted set: score = the group deadline in ms; coalesce-forever rows score 0 and are always due.
+// Member = rowId.
 const userIndexKey = (userId: string) => `user/${userId}/notifications`;
 const rowKey = (userId: string, rowId: string) => `user/${userId}/notifications/${rowId}`;
 // Sorted set: score = ms when the user's next drain is due, member = userId.
 const dueUsersKey = 'notifications/dueUsers';
+// Cadence cursor for the drain. Global like `notifyPrefs` itself, so an N-shard server delivers
+// once per interval rather than once per interval per shard.
+const lastNotifyDateKey = (userId: string) => `user/${userId}/notifications/lastDate`;
+
+export const kDefaultIntervalMinutes = 60;
 
 function rowIdFor(type: NotificationType, timeGroup: number, message: string) {
 	return createHash('sha1').update(JSON.stringify([ type, timeGroup, message ])).digest('hex');
 }
 
-async function readRows(shard: Shard, userId: string, ids: Iterable<string>): Promise<NotificationRow[]> {
-	return Fn.mapAwait(ids, async (id): Promise<NotificationRow> => {
+interface IndexedRow {
+	id: string;
+	row: NotificationRow;
+}
+
+async function readRows(shard: Shard, userId: string, ids: Iterable<string>): Promise<IndexedRow[]> {
+	return Fn.mapAwait(ids, async (id): Promise<IndexedRow> => {
 		const fields = await shard.data.hGetAll(rowKey(userId, id));
 		return {
-			user: userId,
-			message: fields.message!,
-			date: Number(fields.date),
-			count: Number(fields.count),
-			type: fields.type as NotificationType,
+			id,
+			row: {
+				user: userId,
+				message: fields.message!,
+				date: Number(fields.date),
+				count: Number(fields.count),
+				type: fields.type as NotificationType,
+			},
 		};
 	});
 }
 
-export async function getAllRowsForTesting(shard: Shard, userId: string) {
-	const ids = await shard.data.zRange(userIndexKey(userId), 0, Infinity, { by: 'SCORE' });
+// Paired with the ids the drain deletes them by.
+export async function getDueNotifications(shard: Shard, userId: string, nowMs: number) {
+	const ids = await shard.data.zRange(userIndexKey(userId), 0, nowMs, { by: 'SCORE' });
 	return readRows(shard, userId, ids);
+}
+
+export async function getAllRowsForTesting(shard: Shard, userId: string) {
+	const items = await getDueNotifications(shard, userId, Infinity);
+	return items.map(item => item.row);
+}
+
+export async function getLastNotifyDate(db: Database, userId: string): Promise<number> {
+	const value = await db.data.get(lastNotifyDateKey(userId));
+	return value === null ? 0 : Number(value);
+}
+
+export async function setLastNotifyDate(db: Database, userId: string, time: number) {
+	await db.data.set(lastNotifyDateKey(userId), String(time));
 }
 
 export async function removeNotifications(shard: Shard, userId: string, ids: string[]) {
@@ -79,15 +124,12 @@ async function recordNotification(
 ) {
 	const id = rowIdFor(type, timeGroup, message);
 	const key = rowKey(userId, id);
-	// Coalesce-forever rows (timeGroup 0) index at their latest occurrence, so they stay due
-	// immediately and retention counts from the last event rather than the first.
-	const dueAt = timeGroup === 0 ? date : timeGroup;
 	const [ created ] = await Promise.all([
 		shard.data.hSet(key, 'count', 1, { if: 'NX' }),
 		shard.data.hSet(key, 'date', date, { if: 'NX' }),
 		shard.data.hmSet(key, { message, type }),
-		shard.data.zAdd(userIndexKey(userId), [ [ dueAt, id ] ]),
-		scheduleUserDrain(shard, userId, dueAt),
+		shard.data.zAdd(userIndexKey(userId), [ [ timeGroup, id ] ]),
+		scheduleUserDrain(shard, userId, timeGroup),
 	]);
 	if (!created) {
 		await shard.data.hincrBy(key, 'count', 1);
@@ -112,24 +154,4 @@ export async function upsertNotification(
 		}
 	}();
 	await recordNotification(shard, userId, type, message, timeGroup, now);
-}
-
-// Unread rows wait this long for a consumer (an in-game inbox or mailer), then drop.
-export const kRetentionMs = 30 * 86_400_000;
-
-/**
- * Drop rows whose due time elapsed more than `kRetentionMs` ago; a user whose later rows survive
- * goes back on the due-user index for their next expiry.
- */
-export async function pruneExpiredNotifications(shard: Shard, nowMs: number) {
-	const cutoff = nowMs - kRetentionMs;
-	const userIds = await consumeDueUsers(shard, cutoff);
-	await Fn.mapAwait(userIds, async userId => {
-		const ids = await shard.data.zRange(userIndexKey(userId), 0, cutoff, { by: 'SCORE' });
-		await removeNotifications(shard, userId, ids);
-		const next = await nextPendingDueAt(shard, userId);
-		if (next !== undefined) {
-			await scheduleUserDrain(shard, userId, next);
-		}
-	});
 }

--- a/packages/xxscreeps/mods/meta/notify-cron/test.ts
+++ b/packages/xxscreeps/mods/meta/notify-cron/test.ts
@@ -1,7 +1,10 @@
+import type { NotificationRow } from './model.js';
+import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { setNotifyPrefs } from 'xxscreeps/mods/meta/notifications/prefs.js';
 import { sendNotification } from 'xxscreeps/mods/meta/notifications/transport.js';
 import { DeterministicClockForTesting } from 'xxscreeps/test/fixtures.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
-import { consumeDueUsers, getAllRowsForTesting, kRetentionMs, pruneExpiredNotifications, upsertNotification } from './model.js';
+import { consumeDueUsers, getAllRowsForTesting, hooks, upsertNotification } from './model.js';
 
 const userA = '100';
 const userB = '101';
@@ -10,7 +13,20 @@ const empty = simulate({
 	W0N0: () => {},
 });
 
+// `hooks.register` returns nothing disposable, and `makeMapped` locks its listener list on the
+// first call, so a consumer cannot be scoped to one test. One registers here; each test clears it.
+const delivered: NotificationRow[] = [];
+hooks.register('deliver', (shard, userId, rows) => {
+	delivered.push(...rows);
+	return Promise.resolve();
+});
+
+const seedRow = (shard: Shard, userId: string, message: string) =>
+	upsertNotification(shard, userId, 'msg', message, 0);
+
 describe('mods/meta/notify-cron', () => {
+
+	const baseTime = 10_000_000;
 
 	// This mod is the transport registered for the test process, so a plain `sendNotification`
 	// exercises the whole registration path.
@@ -63,7 +79,6 @@ describe('mods/meta/notify-cron', () => {
 	}));
 
 	test('recording schedules the user drain at the group deadline', () => empty(async ({ shard }) => {
-		const baseTime = 10_000_000;
 		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
 		await upsertNotification(shard, userA, 'msg', 'later', 60);
 		assert.deepStrictEqual(await consumeDueUsers(shard, baseTime), [],
@@ -75,42 +90,115 @@ describe('mods/meta/notify-cron', () => {
 	}));
 
 	test('due users pop independently', () => empty(async ({ shard }) => {
-		using clock = new DeterministicClockForTesting({ start: 10_000_000, step: 0 });
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
 		await upsertNotification(shard, userA, 'msg', 'a-msg', 0);
 		await upsertNotification(shard, userB, 'msg', 'b-msg', 0);
-		const dueUsers = await consumeDueUsers(shard, 10_000_000);
+		const dueUsers = await consumeDueUsers(shard, baseTime);
 		assert.deepStrictEqual(dueUsers.sort(), [ userA, userB ]);
 	}));
 
-	test('prune drops rows past retention', () => empty(async ({ shard }) => {
-		using clock = new DeterministicClockForTesting({ start: 1_000_000, step: 0 });
-		await upsertNotification(shard, userA, 'msg', 'stale', 0);
-		await pruneExpiredNotifications(shard, 1_000_000 + kRetentionMs + 1);
-		assert.deepStrictEqual(await getAllRowsForTesting(shard, userA), []);
+	// Delivery worker tests
+
+	test('drains at cadence boundary with full row shape', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
+		await seedRow(shard, userA, 'hi');
+		await tick(10);
+		assert.strictEqual(delivered.length, 1);
+		const [ row ] = delivered;
+		assert.strictEqual(row?.user, userA);
+		assert.strictEqual(row.message, 'hi');
+		assert.strictEqual(row.count, 1);
+		assert.strictEqual(row.type, 'msg');
+		assert.strictEqual(typeof row.date, 'number');
+		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 0);
 	}));
 
-	test('prune keeps unexpired rows scheduled', () => empty(async ({ shard }) => {
-		using clock = new DeterministicClockForTesting({ start: 1_000_000, step: 0 });
-		await upsertNotification(shard, userA, 'msg', 'stale', 0);
-		clock.set(2_000_000);
-		await upsertNotification(shard, userA, 'msg', 'fresh', 0);
-		await pruneExpiredNotifications(shard, 1_000_000 + kRetentionMs + 1);
-		const rows = await getAllRowsForTesting(shard, userA);
-		assert.deepStrictEqual(rows.map(row => row.message), [ 'fresh' ]);
-		// The surviving row keeps the user scheduled for its own expiry.
-		assert.deepStrictEqual(await consumeDueUsers(shard, 2_000_000), [ userA ]);
+	test('no drain between cadence boundaries', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
+		await tick(1);
+		await seedRow(shard, userA, 'hi');
+		await tick(9);
+		assert.strictEqual(delivered.length, 0,
+			'no drain expected before reaching cadence tick');
+		await tick(1);
+		assert.strictEqual(delivered.length, 1, 'drain at cadence boundary');
 	}));
 
-	test('coalesce-forever rows expire from their last occurrence', () => empty(async ({ shard }) => {
-		using clock = new DeterministicClockForTesting({ start: 1_000_000, step: 0 });
+	test('notifyPrefs.interval throttles', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
+		await seedRow(shard, userA, 'first');
+		await tick(10);
+		assert.strictEqual(delivered.length, 1);
+		// lastNotifyDate is now baseTime.
+		await seedRow(shard, userA, 'second');
+		clock.increment(30 * 60_000);
+		await tick(10);
+		assert.strictEqual(delivered.length, 1, 'still under throttle');
+		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 1);
+		// 30 + 31 clears the 60-minute throttle.
+		clock.increment(31 * 60_000);
+		await tick(10);
+		assert.strictEqual(delivered.length, 2);
+		assert.strictEqual(delivered[1]?.message, 'second');
+		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 0);
+	}));
+
+	// Every engine-generated notification takes this path, and its row indexes at `timeGroup` 0
+	// rather than at a bucket boundary.
+	test('coalesce-forever rows drain with their accumulated count', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
 		await upsertNotification(shard, userA, 'msg', 'under attack', Infinity);
-		clock.set(5_000_000);
+		clock.increment(86_400_000);
 		await upsertNotification(shard, userA, 'msg', 'under attack', Infinity);
-		await pruneExpiredNotifications(shard, 1_000_000 + kRetentionMs + 1);
-		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 1,
-			'the second occurrence refreshed retention');
-		await pruneExpiredNotifications(shard, 5_000_000 + kRetentionMs + 1);
-		assert.deepStrictEqual(await getAllRowsForTesting(shard, userA), []);
+		await tick(10);
+		assert.strictEqual(delivered.length, 1);
+		assert.strictEqual(delivered[0]?.message, 'under attack');
+		assert.strictEqual(delivered[0].count, 2);
+		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 0);
+	}));
+
+	test('drains multiple users independently', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
+		await seedRow(shard, userA, 'a-msg');
+		await seedRow(shard, userB, 'b-msg');
+		await tick(10);
+		assert.strictEqual(delivered.length, 2);
+		const byUser = new Map(delivered.map(row => [ row.user, row ]));
+		assert.strictEqual(byUser.get(userA)?.message, 'a-msg');
+		assert.strictEqual(byUser.get(userB)?.message, 'b-msg');
+	}));
+
+	test('short group does not drag long group', () => empty(async ({ shard, tick }) => {
+		using clock = new DeterministicClockForTesting({ start: baseTime, step: 0 });
+		delivered.length = 0;
+		// A cadence shorter than the gap between the two bucket boundaries, so delivery depends on
+		// each row's group deadline rather than on the throttle.
+		await setNotifyPrefs(shard.db, userA, { interval: 5 });
+		await upsertNotification(shard, userA, 'msg', 'long', 60);
+		// 1 is the smallest non-zero `groupInterval`.
+		await upsertNotification(shard, userA, 'msg', 'short', 1);
+
+		// Advance past the short group's bucket boundary; the long group's bucket is still ahead.
+		const shortBucket = Math.ceil(baseTime / 60_000) * 60_000;
+		clock.increment(shortBucket - baseTime + 1);
+		await tick(10);
+		assert.strictEqual(delivered.length, 1, 'only the short group fires at its bucket boundary');
+		assert.strictEqual(delivered[0]?.message, 'short');
+		const remaining = await getAllRowsForTesting(shard, userA);
+		assert.strictEqual(remaining.length, 1, 'long group stays queued under its own deadline');
+		assert.strictEqual(remaining[0]?.message, 'long');
+
+		const longBucket = Math.ceil(baseTime / (60 * 60_000)) * (60 * 60_000);
+		clock.increment(longBucket - shortBucket);
+		await tick(10);
+		assert.strictEqual(delivered.length, 2, 'long group fires once its deadline elapses');
+		assert.strictEqual(delivered[1]?.message, 'long');
+		assert.strictEqual((await getAllRowsForTesting(shard, userA)).length, 0);
 	}));
 
 });


### PR DESCRIPTION
Closes #379 (#381 merges first, and fixes the issue's first point). This PR deliberately does not
check `notifyPrefs.disabled`, which the send seam owns; landing it first would deliver to users who
have switched notifications off.

#373 left the stored rows with no reader, so `notifyPrefs.interval` went unread and nothing ever
removed a row. The drain comes back on a shard-tick cadence and hands each user's due batch to a
`deliver` hook on the mod that owns the rows. Storage is one owner so it stays a provider; delivery
is many, so a mailer and a chat bridge can both listen. Modelled on `meta/stats`'s `flush` hook,
with `meta/leaderboard` as the out-of-mod consumer precedent. @bastianh is porting SMTP and Discord
mods against the signature.

That retires the retention pruner, reversing a deliberate part of #373: `kRetentionMs` and
`pruneExpiredNotifications` were added in response to the finding that rows with no reader grow
without bound, which is #379's third point seen from the outside. The drain deletes a batch whether
or not a consumer accepted it, so the premise is gone.

Worth your eye: the fan-out logs and swallows a rejecting consumer, the "on error continue next"
shape you rejected on #165. `meta/stats` fans out with no catch, and vanilla's catch is per-user
around a synchronous emit, so neither is precedent; what argues for it is that the drain runs inside
`main`'s tick loop, where one unreachable mailer would stop time. Happy to drop it.

The cadence cursor is global in `db.data` since `notifyPrefs` is, because per-shard delivers once
per interval per shard. Rows stay per-shard, so the cadence is approximate; a global row store is
its own change. Rows already queued when a user disables are delivered once, where vanilla drops
them.

## Validation

Restored the five `delivery worker` tests #373 deleted, retargeted to the `deliver` hook, and
confirmed all five fail before the drain is wired; added a sixth for the coalesce-forever row shape
every engine notification takes. 667/667 tests, eslint clean. Live smoke with two consumers in a
separate mod: both fired, a deliberately rejecting one was logged without killing the service, rows
were deleted anyway, the cursor was written to `db.data`, and the 60-minute throttle held until the
cursor was cleared.
