### PR TITLE
powercreep: implement PWR_OPERATE_FACTORY

### DIFF
--- a/.changeset/power-operate-factory.md
+++ b/.changeset/power-operate-factory.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+PWR_OPERATE_FACTORY sets a factory's permanent level and gates its leveled recipes.

--- a/packages/xxscreeps/engine/processor/room.ts
+++ b/packages/xxscreeps/engine/processor/room.ts
@@ -41,6 +41,12 @@ export interface ProcessorContext {
 	readonly state: GameState;
 
 	/**
+	 * The tick whose intents are being processed. `state.time` is the tick being written, one
+	 * ahead of this, so a check that re-validates a player's intent reads this instead.
+	 */
+	readonly time: number;
+
+	/**
 	 * Invoke this from a processor when game state has been modified in a processor
 	 */
 	didUpdate: () => void;

--- a/packages/xxscreeps/game/object.ts
+++ b/packages/xxscreeps/game/object.ts
@@ -26,6 +26,12 @@ export interface RoomObjectEffect {
 	effect?: number;
 
 	/**
+	 * Power ID of the applied effect. Absent if the effect is not a Power effect.
+	 * @public
+	 */
+	power?: number;
+
+	/**
 	 * Power level of the applied effect. Absent if the effect is not a Power effect.
 	 * @public
 	 */

--- a/packages/xxscreeps/mods/classic/index.ts
+++ b/packages/xxscreeps/mods/classic/index.ts
@@ -30,6 +30,7 @@ export const manifest: Manifest = {
 		'xxscreeps/mods/modern/powerspawn',
 		'xxscreeps/mods/modern/stronghold',
 
+		'xxscreeps/mods/mmo/operator',
 		'xxscreeps/mods/mmo/powercreep',
 		'xxscreeps/mods/mmo/wallstreet',
 

--- a/packages/xxscreeps/mods/mmo/operator/backend.ts
+++ b/packages/xxscreeps/mods/mmo/operator/backend.ts
@@ -1,0 +1,19 @@
+import { bindRenderer } from 'xxscreeps/backend/index.js';
+import { StructureFactory } from 'xxscreeps/mods/modern/factory/factory.js';
+import * as C from 'xxscreeps:mods/constants';
+
+// Layered over the factory mod's own renderer, which knows the window but not the power filling it.
+bindRenderer(StructureFactory, (factory, next) => {
+	const { endTime, level } = factory['#operator'];
+	return {
+		...next(),
+		...endTime > 0 && {
+			effects: [ {
+				effect: C.PWR_OPERATE_FACTORY,
+				power: C.PWR_OPERATE_FACTORY,
+				level,
+				endTime,
+			} ],
+		},
+	};
+});

--- a/packages/xxscreeps/mods/mmo/operator/game.ts
+++ b/packages/xxscreeps/mods/mmo/operator/game.ts
@@ -1,0 +1,22 @@
+import { untilTime } from 'xxscreeps/game/object.js';
+import { StructureFactory } from 'xxscreeps/mods/modern/factory/factory.js';
+import * as C from 'xxscreeps:mods/constants';
+import 'xxscreeps/mods/modern/effects/game.js';
+
+// The factory declares and reads the operated window; the power id that fills out the entry is
+// this mod's, so it contributes the derived view.
+StructureFactory.prototype['#effects'] = function(effects) {
+	return function*(this: StructureFactory) {
+		yield* effects.apply(this);
+		const operator = this['#operator'];
+		const ticksRemaining = untilTime(operator.endTime);
+		if (ticksRemaining !== undefined) {
+			yield {
+				effect: C.PWR_OPERATE_FACTORY,
+				power: C.PWR_OPERATE_FACTORY,
+				level: operator.level,
+				ticksRemaining,
+			};
+		}
+	};
+}(StructureFactory.prototype['#effects']);

--- a/packages/xxscreeps/mods/mmo/operator/index.ts
+++ b/packages/xxscreeps/mods/mmo/operator/index.ts
@@ -1,0 +1,12 @@
+import type { Manifest } from 'xxscreeps/config/mods.js';
+import * as types from 'xxscreeps/tsroot.js';
+
+export const manifest: Manifest = {
+	dependencies: [
+		'xxscreeps/mods/mmo/powercreep',
+		'xxscreeps/mods/modern/effects',
+		'xxscreeps/mods/modern/factory',
+	],
+	provides: [ 'backend', 'game', 'processor', 'test' ],
+	types,
+};

--- a/packages/xxscreeps/mods/mmo/operator/processor.ts
+++ b/packages/xxscreeps/mods/mmo/operator/processor.ts
@@ -1,0 +1,20 @@
+import { powerDuration } from 'xxscreeps/mods/mmo/powercreep/powercreep.js';
+import { registerPowerProcessor } from 'xxscreeps/mods/mmo/powercreep/processor.js';
+import { StructureFactory } from 'xxscreeps/mods/modern/factory/factory.js';
+import * as C from 'xxscreeps:mods/constants';
+
+registerPowerProcessor(C.PWR_OPERATE_FACTORY, (_creep, context, info, level, target) => {
+	if (!(target instanceof StructureFactory)) {
+		return false;
+	}
+	// The first operator to reach a fresh factory fixes its level permanently.
+	if (target['#level'] === 0) {
+		target['#level'] = level;
+	} else if (target['#level'] !== level) {
+		return false;
+	}
+	const operator = target['#operator'];
+	operator.endTime = context.time + powerDuration(info, level);
+	operator.level = level;
+	return true;
+});

--- a/packages/xxscreeps/mods/mmo/operator/test.ts
+++ b/packages/xxscreeps/mods/mmo/operator/test.ts
@@ -1,0 +1,133 @@
+import type { Database } from 'xxscreeps/engine/db/index.js';
+import type { GameConstructor } from 'xxscreeps/game/index.js';
+import type { Room } from 'xxscreeps/game/room/index.js';
+import * as User from 'xxscreeps/engine/db/user/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
+import { lookForStructures } from 'xxscreeps/mods/classic/structure/structure.js';
+import * as Model from 'xxscreeps/mods/mmo/powercreep/model.js';
+import { createPowerCreep, powerDuration, powerOpsCost } from 'xxscreeps/mods/mmo/powercreep/powercreep.js';
+import { create as createFactory } from 'xxscreeps/mods/modern/factory/factory.js';
+import { create as createPowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn.js';
+import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
+import * as C from 'xxscreeps:mods/constants';
+
+const owner = '100';
+const operateInfo = C.POWER_INFO[C.PWR_OPERATE_FACTORY]!;
+const operateOps = powerOpsCost(operateInfo, 1);
+
+describe('mods/mmo/operator', () => {
+	const createAliceWith = async (db: Database, powers: Record<string, number>) => {
+		await db.data.hSet(User.infoKey(owner), 'power', '16000');
+		await Model.create(db, owner, 'Alice', C.POWER_CLASS.OPERATOR);
+		const [ created ] = await Model.loadRoster(db, owner);
+		assert.strictEqual(await Model.upgrade(db, owner, created!.id, powers), C.OK);
+		return created!.id;
+	};
+
+	const spawnAlice = (Game: GameConstructor, id: string) => {
+		const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+		assert.strictEqual(createPowerCreep(id, 'Alice', C.POWER_CLASS.OPERATOR, owner).spawn(powerSpawn), C.OK);
+	};
+
+	// A factory two tiles from the power spawn, well inside `PWR_OPERATE_FACTORY`'s range of 3.
+	const factorySim = simulate({
+		W1N1: room => {
+			room['#insertObject'](createPowerSpawn(new RoomPosition(25, 25, 'W1N1'), owner));
+			room['#insertObject'](createFactory(new RoomPosition(27, 25, 'W1N1'), owner));
+			room['#level'] = 8;
+			room['#user'] = room.controller!['#user'] = owner;
+			room.controller!.isPowerEnabled = true;
+		},
+	});
+
+	const getFactory = (room: Room | undefined) => lookForStructures(room, C.STRUCTURE_FACTORY)[0]!;
+
+	// Exactly one use worth of ops, so any charge to Alice shows up as an empty store.
+	const giveOps = (room: Room) => {
+		room['#lookFor'](C.LOOK_POWER_CREEPS)[0]!.store['#add'](C.RESOURCE_OPS, operateOps);
+	};
+
+	test('OPERATE_FACTORY stamps the level and applies the effect', () => factorySim(async ({ peekRoom, player, poke, tick, shard }) => {
+		const id = await createAliceWith(shard.db, { [C.PWR_OPERATE_FACTORY]: 1 });
+		await player(owner, Game => spawnAlice(Game, id));
+		await tick();
+		await poke('W1N1', owner, (Game, room) => giveOps(room));
+		await tick();
+		await player(owner, Game => {
+			const factory = getFactory(Game.rooms.W1N1);
+			assert.strictEqual(factory.level, undefined);
+			assert.strictEqual(Game.powerCreeps.Alice?.usePower(C.PWR_OPERATE_FACTORY, factory), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const alice = Game.powerCreeps.Alice!;
+			const factory = getFactory(Game.rooms.W1N1);
+			assert.strictEqual(factory.level, 1);
+			assert.deepStrictEqual(factory.effects, [ {
+				effect: C.PWR_OPERATE_FACTORY,
+				power: C.PWR_OPERATE_FACTORY,
+				level: 1,
+				ticksRemaining: powerDuration(operateInfo, 1) - 1,
+			} ]);
+			assert.strictEqual(alice.store[C.RESOURCE_OPS], 0);
+			assert.deepStrictEqual({ ...alice.powers }, {
+				[C.PWR_OPERATE_FACTORY]: { cooldown: operateInfo.cooldown, level: 1 },
+			});
+		});
+		await peekRoom('W1N1', room => {
+			const event = room.getEventLog().find(event => event.event === C.EVENT_POWER);
+			assert.strictEqual(event?.objectId, id);
+			assert.strictEqual(event.data?.power, C.PWR_OPERATE_FACTORY);
+		});
+	}));
+
+	test('a level mismatch costs nothing', () => factorySim(async ({ peekRoom, player, poke, tick, shard }) => {
+		const id = await createAliceWith(shard.db, { [C.PWR_OPERATE_FACTORY]: 1 });
+		await player(owner, Game => spawnAlice(Game, id));
+		await tick();
+		// A factory's level is permanent, so a rank-1 operator can never work this one.
+		await poke('W1N1', owner, (Game, room) => {
+			giveOps(room);
+			getFactory(room)['#level'] = 2;
+		});
+		await tick();
+		await player(owner, Game => {
+			const factory = getFactory(Game.rooms.W1N1);
+			assert.strictEqual(Game.powerCreeps.Alice?.usePower(C.PWR_OPERATE_FACTORY, factory), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const alice = Game.powerCreeps.Alice!;
+			const factory = getFactory(Game.rooms.W1N1);
+			assert.strictEqual(factory.level, 2);
+			assert.strictEqual(factory.effects, undefined);
+			assert.strictEqual(alice.store[C.RESOURCE_OPS], operateOps);
+			assert.deepStrictEqual({ ...alice.powers }, {
+				[C.PWR_OPERATE_FACTORY]: { cooldown: 0, level: 1 },
+			});
+		});
+		await peekRoom('W1N1', room => {
+			assert.strictEqual(room.getEventLog().some(event => event.event === C.EVENT_POWER), false);
+		});
+	}));
+
+	test('a non-factory target costs nothing', () => factorySim(async ({ player, poke, tick, shard }) => {
+		const id = await createAliceWith(shard.db, { [C.PWR_OPERATE_FACTORY]: 1 });
+		await player(owner, Game => spawnAlice(Game, id));
+		await tick();
+		await poke('W1N1', owner, (Game, room) => giveOps(room));
+		await tick();
+		await player(owner, Game => {
+			const powerSpawn = lookForStructures(Game.rooms.W1N1, C.STRUCTURE_POWER_SPAWN)[0]!;
+			assert.strictEqual(Game.powerCreeps.Alice?.usePower(C.PWR_OPERATE_FACTORY, powerSpawn), C.OK);
+		});
+		await tick();
+		await player(owner, Game => {
+			const alice = Game.powerCreeps.Alice!;
+			assert.strictEqual(alice.store[C.RESOURCE_OPS], operateOps);
+			assert.deepStrictEqual({ ...alice.powers }, {
+				[C.PWR_OPERATE_FACTORY]: { cooldown: 0, level: 1 },
+			});
+		});
+	}));
+});

--- a/packages/xxscreeps/mods/mmo/powercreep/powercreep.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/powercreep.ts
@@ -432,6 +432,12 @@ export function powerOpsCost(info: PowerInfo, level: number) {
 	return (Array.isArray(ops) ? ops[level - 1] : ops) ?? 0;
 }
 
+/** Ticks an applied effect lasts — flat, or per-rank when the table carries an array. */
+export function powerDuration(info: PowerInfo, level: number) {
+	const { duration } = info;
+	return (Array.isArray(duration) ? duration[level - 1] : duration) ?? 0;
+}
+
 export function checkUsePower(creep: PowerCreep, power: number, target?: RoomObject) {
 	const info: PowerInfo | undefined = powerInfoTable[power];
 	const entry = creep['#powers'].find(entry => entry.power === power);

--- a/packages/xxscreeps/mods/mmo/powercreep/processor.ts
+++ b/packages/xxscreeps/mods/mmo/powercreep/processor.ts
@@ -1,3 +1,4 @@
+import type { PowerInfo } from './powercreep.js';
 import type { ProcessorContext } from 'xxscreeps/engine/processor/room.js';
 import type { RoomObject } from 'xxscreeps/game/object.js';
 import type { Direction } from 'xxscreeps/game/position.js';
@@ -19,6 +20,15 @@ import { StructurePowerSpawn } from 'xxscreeps/mods/modern/powerspawn/powerspawn
 import * as C from 'xxscreeps:mods/constants';
 import * as Model from './model.js';
 import { PowerCreep, checkEnableRoom, checkRenew, checkUsePower, createSpawnedPowerCreep, powerInfoTable, powerOpsCost } from './powercreep.js';
+
+// Per-power processor arms. A mod implementing a power registers its arm here; the shared
+// cost/cooldown/event tail runs only when the handler reports the power applied.
+type PowerProcessor = (creep: PowerCreep, context: ProcessorContext, info: PowerInfo, level: number, target: RoomObject | undefined) => boolean;
+const powerProcessors = new Map<number, PowerProcessor>();
+
+export function registerPowerProcessor(power: number, processor: PowerProcessor) {
+	powerProcessors.set(power, processor);
+}
 
 function buryPowerCreep(creep: PowerCreep) {
 	const tombstone = createRoomObject(new Tombstone(), creep.pos);
@@ -136,9 +146,13 @@ const intents = [
 				}
 				break;
 			}
-			default:
-				// Powers land one at a time; an unimplemented power's intent drops without cost.
-				return;
+			default: {
+				// An unimplemented or unapplied power's intent drops without cost.
+				const processor = powerProcessors.get(power);
+				if (!processor?.(creep, context, info, entry.level, target)) {
+					return;
+				}
+			}
 		}
 		creep.store['#subtract'](C.RESOURCE_OPS, powerOpsCost(info, entry.level));
 		entry.cooldownTime = Game.time + info.cooldown;

--- a/packages/xxscreeps/mods/modern/factory/factory.ts
+++ b/packages/xxscreeps/mods/modern/factory/factory.ts
@@ -1,7 +1,7 @@
 import type { RoomPosition } from 'xxscreeps/game/position.js';
 import type { ResourceType } from 'xxscreeps/mods/classic/resource/resource.js';
 import { chainIntentChecks } from 'xxscreeps/game/checks.js';
-import { intents, registerGlobal } from 'xxscreeps/game/index.js';
+import { Game, intents, registerGlobal } from 'xxscreeps/game/index.js';
 import { cooldownTime, createRoomObject } from 'xxscreeps/game/object.js';
 import { registerBuildableStructure } from 'xxscreeps/mods/classic/construction/game.js';
 import { OpenStore } from 'xxscreeps/mods/classic/resource/store.js';
@@ -109,35 +109,14 @@ export function getCommodityRecipe(resource: string): CommodityRecipe | undefine
 	return C.COMMODITIES[resource];
 }
 
-/**
- * Resolves the effective factory level for recipe validation. In vanilla Screeps the level
- * comes from either a permanent value (stored by depositing power into the factory) or an
- * active PWR_OPERATE_FACTORY effect, whichever is present.
- *
- * Until an effects substrate exists, this only returns the permanent level. When effects
- * land, extend this to prefer an active PWR_OPERATE_FACTORY effect level over the permanent
- * value, and update `checkRecipeLevel` to apply the bars-block rule.
- */
-function getEffectiveLevel(factory: StructureFactory): number {
-	return factory['#level'];
-}
-
-/**
- * Validates a recipe's level requirement against the factory's effective level.
- *
- * Vanilla has a subtlety not captured here: when a factory has BOTH a permanent level and
- * an active PWR_OPERATE_FACTORY effect whose level differs from the permanent value, all
- * level-0 recipes (bars, battery, etc.) are also blocked. That rule requires the effects
- * substrate to observe and cannot be implemented until power creeps exist — add it here.
- */
 function checkRecipeLevel(factory: StructureFactory, recipe: CommodityRecipe) {
-	if (recipe.level !== undefined && recipe.level !== getEffectiveLevel(factory)) {
+	if (recipe.level !== undefined && recipe.level !== factory['#level']) {
 		return C.ERR_INVALID_TARGET;
 	}
 }
 
-// Validation order: ownership, cooldown, recipe checks, then RCL gate.
-export function checkProduce(factory: StructureFactory, resourceType: ResourceType) {
+// Validation order: ownership, cooldown, recipe checks, RCL gate, then the operated window.
+export function checkProduce(factory: StructureFactory, resourceType: ResourceType, time = Game.time) {
 	let recipe: CommodityRecipe | undefined;
 	return chainIntentChecks(
 		() => checkMyStructure(factory, StructureFactory),
@@ -160,6 +139,12 @@ export function checkProduce(factory: StructureFactory, resourceType: ResourceTy
 		() => {
 			if (recipe === undefined) {
 				return C.ERR_INVALID_ARGS;
+			}
+			// Unlike every other gate here, this one must be live for the intent to succeed, so it
+			// reads the tick being validated: the processor stands one tick ahead of the runtime.
+			const { endTime } = factory['#operator'];
+			if (recipe.level !== undefined && (endTime === 0 || endTime < time)) {
+				return C.ERR_BUSY;
 			}
 			let componentsTotal = 0;
 			for (const [ component, amount ] of Object.entries(recipe.components)) {

--- a/packages/xxscreeps/mods/modern/factory/processor.ts
+++ b/packages/xxscreeps/mods/modern/factory/processor.ts
@@ -9,7 +9,7 @@ export type FactoryIntents = typeof intents;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const intents = [
 	registerIntentProcessor(StructureFactory, 'produce', {}, (factory, context, resourceType: ResourceType) => {
-		if (checkProduce(factory, resourceType) !== C.OK) {
+		if (checkProduce(factory, resourceType, context.time) !== C.OK) {
 			return;
 		}
 		const recipe = getCommodityRecipe(resourceType)!;

--- a/packages/xxscreeps/mods/modern/factory/schema.ts
+++ b/packages/xxscreeps/mods/modern/factory/schema.ts
@@ -25,6 +25,9 @@ export const factoryShape = declare('StructureFactory', struct(ownedStructureSha
 	'#actionLog': actionLogFormat,
 	'#cooldownTime': 'int32',
 	'#level': 'int32',
+
+	/** Operated window stamped by a power creep; live while `endTime` is in the future. */
+	'#operator': struct({ endTime: 'int32', level: 'int8' }),
 }));
 
 // Register commodity resource types into `ResourceType` enum and `RESOURCES_ALL`

--- a/packages/xxscreeps/mods/modern/factory/test.ts
+++ b/packages/xxscreeps/mods/modern/factory/test.ts
@@ -190,6 +190,8 @@ describe('mods/modern/factory', () => {
 						[C.RESOURCE_ENERGY]: 20,
 					});
 				factory['#level'] = 1;
+				factory['#operator'].endTime = 1000;
+				factory['#operator'].level = 1;
 				room['#insertObject'](factory);
 				room['#level'] = 7;
 				room['#user'] = room.controller!['#user'] = '100';
@@ -256,6 +258,83 @@ describe('mods/modern/factory', () => {
 			await player('100', Game => {
 				const factory = getFactory(Game);
 				assert.strictEqual(factory.produce(C.RESOURCE_UTRIUM_BAR), C.ERR_RCL_NOT_ENOUGH);
+			});
+		}));
+	});
+
+	// =========================================================================
+	// produce — the operated window
+	// =========================================================================
+	describe('operated window', () => {
+		// An unoperated level-1 factory, stocked for both a leveled recipe (composite) and a
+		// level-0 one (utrium bar).
+		const operateSim = simulate({
+			W1N1: room => {
+				const factory = createFactoryWithResources(
+					new RoomPosition(25, 25, 'W1N1'), '100',
+					{
+						[C.RESOURCE_UTRIUM_BAR]: 20,
+						[C.RESOURCE_ZYNTHIUM_BAR]: 20,
+						[C.RESOURCE_ENERGY]: 220,
+						[C.RESOURCE_UTRIUM]: 500,
+					});
+				factory['#level'] = 1;
+				room['#insertObject'](factory);
+				room['#level'] = 7;
+				room['#user'] = room.controller!['#user'] = '100';
+			},
+		});
+
+		const operate = (room: Room, until: number) => {
+			const operator = lookForStructures(room, C.STRUCTURE_FACTORY)[0]!['#operator'];
+			operator.endTime = until;
+			operator.level = 1;
+		};
+
+		test('a leveled recipe needs the factory operated', () => operateSim(async ({ player, poke, tick }) => {
+			await player('100', Game => {
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_COMPOSITE), C.ERR_BUSY);
+			});
+			await poke('W1N1', '100', (Game, room) => operate(room, Game.time + 1000));
+			await tick();
+			await player('100', Game => {
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_COMPOSITE), C.OK);
+			});
+		}));
+
+		test('a level-0 recipe produces unoperated', () => operateSim(async ({ player }) => {
+			await player('100', Game => {
+				// Bars carry no recipe level, so a leveled factory produces them unoperated.
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_UTRIUM_BAR), C.OK);
+			});
+		}));
+
+		test('the gate holds through the last operated tick', () => operateSim(async ({ player, poke, tick }) => {
+			await poke('W1N1', '100', (Game, room) => operate(room, Game.time + 1));
+			await tick();
+			await player('100', Game => {
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_COMPOSITE), C.OK);
+			});
+			await tick();
+			await player('100', Game => {
+				assert.strictEqual(getFactory(Game).store[C.RESOURCE_COMPOSITE], 20);
+			});
+		}));
+
+		test('the gate closes when the window lapses', () => operateSim(async ({ player, poke, tick }) => {
+			await poke('W1N1', '100', (Game, room) => operate(room, Game.time));
+			await tick();
+			await player('100', Game => {
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_COMPOSITE), C.ERR_BUSY);
+			});
+		}));
+
+		test('a wrong-level recipe is rejected before the operated gate', () => operateSim(async ({ player, poke, tick }) => {
+			await poke('W1N1', '100', (Game, room) => operate(room, Game.time + 1000));
+			await tick();
+			await player('100', Game => {
+				// Crystal is level 2; the level gate answers before the operated gate can.
+				assert.strictEqual(getFactory(Game).produce(C.RESOURCE_CRYSTAL), C.ERR_INVALID_TARGET);
 			});
 		}));
 	});

--- a/packages/xxscreeps/scripts/manage.ts
+++ b/packages/xxscreeps/scripts/manage.ts
@@ -377,6 +377,7 @@ async function botSpawn(userId: string, roomName: string, coords?: string) {
 	const context = {
 		shard,
 		state,
+		time,
 		didUpdate() {},
 		setActive() {},
 		wakeAt() {},


### PR DESCRIPTION
Implements PWR_OPERATE_FACTORY, the first power that puts an effect on a target.

**Factory.** `factoryShape` gains an `'#operator': { endTime, level }` struct. `checkProduce` returns ERR_BUSY for a leveled recipe while the window is closed. The `getEffectiveLevel` seam folds into `checkRecipeLevel`, since the first application fixes `#level` permanently and an effective level can never differ from it. The factory names no power.

**New `mods/mmo/operator`.** Writes the window. Contributes the effect entry through the `'#effects'` chain. Layers a renderer sending the absolute `endTime`. Reaches the `usePower` switch through a new `registerPowerProcessor(power, fn)`.

**Core.** `RoomObjectEffect` gains an optional `power`, which bots read.

## Why ProcessorContext grew a field

This is the first check in the tree that needs a timer to be *live* for an intent to succeed. Every other one is blocking: cooldowns, `#reservationEndTime`.

A room processor's `GameState` is the tick it writes, one ahead of the tick whose intents it processes. For a blocking check that skew is harmless, because it only ever makes the processor more permissive. Here it inverts, and the processor rejects an intent the runtime already answered OK.

`RoomProcessor` has always held both ticks. `ProcessorContext` now exposes the one being validated, and `checkProduce` reads it.

## Deferred

**Blob upgrade.** A struct member missing from the archived layout reaches the writer as `undefined` and throws, so existing worlds with a factory need the separate diff from #340. Until then a `#level` arriving without a window reads as never operated, and the gate stays closed.

**ERR_FULL.** Vanilla returns ERR_FULL when the target already carries a stronger effect of the same power (`power-creeps.js:285`); this returns OK. Game state agrees either way, since the processor rejects the level mismatch at no cost. The return code does not.

## Validation

672 tests passed and eslint reported zero warnings. Reverting the processor's `context.time` argument failed the last-operated-tick test.

A live world ran two 1000-tick windows. Every produce that returned OK made composite, the last operated tick produced with `effects` already empty, and the room socket carried `effects` beside `store` and `level`.
