### PR TITLE
export: report the objects no codec claims

### DIFF
--- a/.changeset/export-drop-report.md
+++ b/.changeset/export-drop-report.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+`xxscreeps export` reports the objects no codec claims, counted by class, on stderr.

--- a/packages/xxscreeps/mods/classic/mineral/terrain.ts
+++ b/packages/xxscreeps/mods/classic/mineral/terrain.ts
@@ -84,6 +84,9 @@ hooks.register('payload', {
 				...extractor !== undefined && { extractor: extractor.id },
 			};
 		}
+		if (object instanceof StructureExtractor && object['#user'] === null) {
+			return null;
+		}
 	},
 	decode(meta) {
 		const mineral = new Mineral();

--- a/packages/xxscreeps/mods/classic/mineral/test.ts
+++ b/packages/xxscreeps/mods/classic/mineral/test.ts
@@ -77,7 +77,9 @@ describe('mods/classic/mineral', () => {
 	});
 
 	test('payload round trip', () => prebuiltExtractor(async ({ shard }) => {
-		const payload = await exportPayload(shard);
+		const { payload, dropped } = await exportPayload(shard);
+		// W6N6's neutral extractor rides the mineral's entry; only W6N1's owned one is left behind.
+		assert.strictEqual(dropped.get('StructureExtractor'), 1);
 		const extractorId = payload.W6N6?.objects?.find(object => object.extractor !== undefined)?.extractor;
 		assert.ok(extractorId !== undefined);
 		const { rooms } = importPayload(payload);

--- a/packages/xxscreeps/mods/classic/source/test.ts
+++ b/packages/xxscreeps/mods/classic/source/test.ts
@@ -73,7 +73,7 @@ describe('mods/classic/source', () => {
 	});
 
 	test('payload round trip', () => guardedRoom(async ({ shard }) => {
-		const payload = await exportPayload(shard);
+		const { payload } = await exportPayload(shard);
 		assert.ok(payload.W6N6?.layout.some(line => line.includes('K')));
 		const { rooms } = importPayload(payload);
 		const keeperLair = Fn.find(

--- a/packages/xxscreeps/scripts/export.ts
+++ b/packages/xxscreeps/scripts/export.ts
@@ -2,7 +2,11 @@ import * as fs from 'node:fs/promises';
 import { checkArguments } from 'xxscreeps/config/arguments.js';
 import { config } from 'xxscreeps/config/index.js';
 import { Database, Shard } from 'xxscreeps/engine/db/index.js';
+import { mappedInvertedNumericComparator } from 'xxscreeps/functional/comparator.js';
+import { Fn } from 'xxscreeps/functional/fn.js';
 import { exportPayload } from 'xxscreeps/scripts/payload.js';
+
+const plural = (count: number) => count === 1 ? '' : 's';
 
 async function main() {
 	const argv = checkArguments({
@@ -18,10 +22,16 @@ async function main() {
 
 	await using db = await Database.connect();
 	await using shard = await Shard.connect(db, argv.shard ?? config.shards[0]!.name);
-	const payload = await exportPayload(shard);
+	const { payload, dropped } = await exportPayload(shard);
 	await fs.writeFile(file, JSON.stringify(payload, null, 1));
 	const count = Object.keys(payload).length;
-	console.log(`Exported ${count} room${count === 1 ? '' : 's'} to ${file}`);
+	console.log(`Exported ${count} room${plural(count)} to ${file}`);
+	if (dropped.size > 0) {
+		const total = Fn.accumulate(dropped.values());
+		const byCount = [ ...dropped ].sort(mappedInvertedNumericComparator(([ , value ]) => value));
+		const breakdown = Fn.join(Fn.map(byCount, ([ name, value ]) => `  ${value} ${name}`), '\n');
+		console.error(`Dropped ${total} object${plural(total)} no payload codec claims:\n${breakdown}`);
+	}
 }
 
 if (process.argv[1] === 'export') {

--- a/packages/xxscreeps/scripts/payload.ts
+++ b/packages/xxscreeps/scripts/payload.ts
@@ -25,6 +25,13 @@ export interface PayloadRoom {
 /** An authored world: every room's terrain and objects, by room name. */
 export type Payload = Record<string, PayloadRoom>;
 
+/** An export, plus a tally of what it couldn't carry. */
+export interface ExportedPayload {
+	payload: Payload;
+	/** How many objects no codec claimed, by class name. */
+	dropped: Map<string, number>;
+}
+
 // Index 3 is wall+swamp, which reads back as wall: `Terrain.get` documents three values, and
 // `packExits` would read anything else as a border opening.
 const terrainMask = [ ' ', '#', ',', '?' ];
@@ -57,16 +64,21 @@ function encodeObject(object: RoomObject) {
 	}), encoded => encoded !== undefined);
 }
 
-async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Promise<PayloadRoom> {
+async function exportRoom(shard: Shard, roomName: string, terrain: Terrain) {
 	const room = await shard.loadRoom(roomName);
+	// The layout and the drop tally read one encode pass; a second would re-run every codec.
+	const encodings = [ ...Fn.map(room['#objects'], object => ({ object, encoded: encodeObject(object) })) ];
 	const objects = Fn.pipe(
-		room['#objects'],
-		$$ => Fn.map($$, object => {
-			const encoded = encodeObject(object);
-			return encoded == null ? undefined : [ `${object.pos.x},${object.pos.y}`, encoded ] as const;
-		}),
+		encodings,
+		$$ => Fn.map($$, ({ object, encoded }) =>
+			encoded == null ? undefined : [ `${object.pos.x},${object.pos.y}`, encoded ] as const),
 		$$ => Fn.filter($$),
 		$$ => new Map($$));
+	const dropped = Fn.pipe(
+		encodings,
+		$$ => Fn.filter($$, ({ encoded }) => encoded === undefined),
+		$$ => Fn.map($$, ({ object }) => object.constructor.name),
+		$$ => [ ...$$ ]);
 	// Metadata rides the layout's scan order and nothing else, so both come off one resolved array.
 	const cells = [ ...Fn.map(Fn.range(50), yy => [ ...Fn.map(Fn.range(50), xx => {
 		const object = objects.get(`${xx},${yy}`);
@@ -78,24 +90,30 @@ async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Pro
 		$$ => Fn.transform($$, row => Fn.map(row, cell => cell.meta)),
 		$$ => Fn.filter($$),
 		$$ => [ ...$$ ]);
-	return { layout, ...metadata.length > 0 && { objects: metadata } };
+	return { payload: { layout, ...metadata.length > 0 && { objects: metadata } }, dropped };
 }
 
 /**
  * Renders every room of `shard` as a terrain layout, with each object a registered codec claims
- * folded in as that codec's character plus an entry in the room's metadata.
+ * folded in as that codec's character plus an entry in the room's metadata. Objects no codec
+ * claims are absent from the payload and counted in `dropped`.
  */
-export async function exportPayload(shard: Shard): Promise<Payload> {
+export async function exportPayload(shard: Shard): Promise<ExportedPayload> {
 	const world = await shard.loadWorld();
 	// Sort map so that rooms will be continuous in the JSON top to bottom, left to right.
 	const rooms = [ ...world.entries() ].sort(compositeComparator<readonly [ string, Terrain ]>([
 		mappedNumericComparator(([ roomName ]) => parseRoomName(roomName).rx),
 		mappedNumericComparator(([ roomName ]) => parseRoomName(roomName).ry),
 	]));
-	return Fn.fromEntries(await Fn.mapAwait(rooms, async ([ roomName, terrain ]) => [
-		roomName,
-		await exportRoom(shard, roomName, terrain),
-	] as const));
+	const exported = await Fn.mapAwait(rooms, async ([ roomName, terrain ]) =>
+		[ roomName, await exportRoom(shard, roomName, terrain) ] as const);
+	return {
+		payload: Fn.fromEntries(exported, ([ roomName, { payload } ]) => [ roomName, payload ]),
+		dropped: Fn.reduce(
+			Fn.transform(exported, ([ , { dropped } ]) => dropped),
+			new Map<string, number>(),
+			(counts, name) => counts.set(name, (counts.get(name) ?? 0) + 1)),
+	};
 }
 
 function importRoom(roomName: string, info: PayloadRoom) {

--- a/packages/xxscreeps/scripts/payload.ts
+++ b/packages/xxscreeps/scripts/payload.ts
@@ -4,7 +4,6 @@ import type { RoomObject } from 'xxscreeps/game/object.js';
 import type { Terrain } from 'xxscreeps/game/terrain.js';
 import { compositeComparator, mappedNumericComparator } from 'xxscreeps/functional/comparator.js';
 import { Fn } from 'xxscreeps/functional/fn.js';
-import { nonNullPredicate } from 'xxscreeps/functional/predicate.js';
 import * as C from 'xxscreeps/game/constants/index.js';
 import * as MapSchema from 'xxscreeps/game/map.js';
 import { RoomPosition } from 'xxscreeps/game/position.js';
@@ -49,12 +48,13 @@ const codecs = function() {
 }();
 
 // Objects no codec claims -- creeps, roads, anything a payload doesn't carry -- yield undefined and
-// leave their tile's terrain showing.
+// leave their tile's terrain showing. A codec's null is an object it carries in a companion's
+// entry: it earns no marker of its own, but the payload does bring it back.
 function encodeObject(object: RoomObject) {
 	return Fn.find(Fn.map(codecs.values(), codec => {
 		const fields = codec.encode(object);
-		return fields === undefined ? undefined : { marker: codec.marker, meta: { id: object.id, ...fields } };
-	}), nonNullPredicate);
+		return fields == null ? fields : { marker: codec.marker, meta: { id: object.id, ...fields } };
+	}), encoded => encoded !== undefined);
 }
 
 async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Promise<PayloadRoom> {
@@ -63,7 +63,7 @@ async function exportRoom(shard: Shard, roomName: string, terrain: Terrain): Pro
 		room['#objects'],
 		$$ => Fn.map($$, object => {
 			const encoded = encodeObject(object);
-			return encoded === undefined ? undefined : [ `${object.pos.x},${object.pos.y}`, encoded ] as const;
+			return encoded == null ? undefined : [ `${object.pos.x},${object.pos.y}`, encoded ] as const;
 		}),
 		$$ => Fn.filter($$),
 		$$ => new Map($$));

--- a/packages/xxscreeps/scripts/scripts-test.ts
+++ b/packages/xxscreeps/scripts/scripts-test.ts
@@ -5,12 +5,16 @@ import * as assert from 'node:assert';
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { instanceOfPredicate } from 'xxscreeps/functional/predicate.js';
 import * as C from 'xxscreeps/game/constants/index.js';
+import { RoomPosition } from 'xxscreeps/game/position.js';
 import { makeSignedRoomName, parseSignedRoomName } from 'xxscreeps/game/room/name.js';
 import { flushUsers } from 'xxscreeps/game/room/room.js';
 import { StructureController } from 'xxscreeps/mods/classic/controller/controller.js';
+import { create as createWall } from 'xxscreeps/mods/classic/defense/wall.js';
+import { StructureSpawn, create as createSpawn } from 'xxscreeps/mods/classic/spawn/spawn.js';
 import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
 import { instantiateTestShard } from 'xxscreeps/test/import.js';
-import { describe, test } from 'xxscreeps/test/index.js';
+import { describe, simulate, test } from 'xxscreeps/test/index.js';
+import { exportPayload } from './payload.js';
 import { generateRoom, generateSector } from './room-gen.js';
 
 interface SideInfo {
@@ -309,4 +313,25 @@ describe('scripts/room-gen', () => {
 		assert.deepStrictEqual([ ...terrain.get('W30N25')?.sectors ?? [] ].sort(), [ 'W25N25', 'W35N25' ]);
 		assert.ok(terrain.get('W25N25')?.sectorControl, 'the first sector keeps its control record');
 	});
+});
+
+describe('scripts/payload', () => {
+	const playerBase = simulate({
+		W9N9: room => {
+			room['#insertObject'](createSpawn(new RoomPosition(26, 25, room.name), '100', 'Spawn1'));
+			room['#insertObject'](createWall(new RoomPosition(27, 25, room.name)));
+			room['#insertObject'](createWall(new RoomPosition(28, 25, room.name)));
+		},
+	});
+
+	test('counts the objects no codec claims', () => playerBase(async ({ shard }) => {
+		const { payload, dropped } = await exportPayload(shard);
+		assert.strictEqual(dropped.size, 2);
+		assert.strictEqual(dropped.get('StructureSpawn'), 1);
+		assert.strictEqual(dropped.get('StructureWall'), 2);
+		// The room keeps everything the codecs do cover, so the tally names the whole of the loss.
+		const spawn = Fn.find((await shard.loadRoom('W9N9'))['#objects'], instanceOfPredicate(StructureSpawn));
+		assert.ok(payload.W9N9?.layout.some(line => line.includes('@')));
+		assert.strictEqual(payload.W9N9?.objects?.some(object => object.id === spawn?.id), false);
+	}));
 });

--- a/packages/xxscreeps/scripts/symbols.ts
+++ b/packages/xxscreeps/scripts/symbols.ts
@@ -72,8 +72,11 @@ export interface PayloadCodec {
 	 * object occupies. May not be one the terrain alphabet spells, and that tile reads back as wall.
 	 */
 	marker: string;
-	/** The fields this codec encodes for `object`, or undefined when it doesn't own the object. */
-	encode: (object: RoomObject) => Omit<PayloadObject, 'id'> | undefined;
+	/**
+	 * The fields this codec encodes for `object`, null when it owns `object` but folds it into a
+	 * companion's entry, or undefined when it doesn't own the object.
+	 */
+	encode: (object: RoomObject) => Omit<PayloadObject, 'id'> | null | undefined;
 	/**
 	 * Rebuilds the object `meta` describes, plus any companions sharing its tile. The engine
 	 * stamps every object's position and the first one's id -- companions carry ids of their


### PR DESCRIPTION
`exportPayload` drops every object no codec claims and says nothing, so a world anyone has played in exports without its spawns, roads or creeps and still reports success. `export` now tallies the drop to stderr.

```
Exported 121 rooms to world.json
Dropped 5 objects no payload codec claims:
  5 StructureSpawn
```

Warn rather than gate: every world with a base in it drops something today, so an opt-in flag would be mandatory noise, and the payload is still correct for what it does carry. Per class rather than a total, because that is what says whether the loss matters. The class name is the identifier: `#lookType` reads `structure` for all twenty structure types, and `structureType` isn't on `RoomObject`.

The first commit is the seam the tally needs. The mineral codec folds the neutral prebuilt extractor into the mineral's entry, so `encode` never sees the extractor as an object of its own and the tally would count a carried object as lost, once per keeper and center room. `encode` may now return null for an object it carries in a companion's entry.

`exportPayload` returns `{ payload, dropped }`.

## Validation

`tsc -b`, the full suite, and `eslint --max-warnings 0 packages` all passed. Imported a world, placed a spawn with `manage bot add smoke <dir> --spawn W7N7`, exported: the report named the spawn and nothing else, and the JSON was byte-identical to the same export taken before the codec commit.
