### PR TITLE
pf: pin pnpm on the alpine test job

### DIFF
--- a/.github/workflows/pathfinder.yml
+++ b/.github/workflows/pathfinder.yml
@@ -292,7 +292,10 @@ jobs:
 
       # Setup
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
+      - if: matrix.host.container == 'alpine:3'
+        run: npm install -g pnpm@11.20.0
+      - if: matrix.host.container != 'alpine:3'
+        uses: pnpm/action-setup@v6
         with:
           cache: true
       - shell: sh
@@ -335,10 +338,7 @@ jobs:
           # Modern npm version required for nested package OIDC & provenance. This version can be removed when that is
           # standard.
           node-version: 24
-      - if: matrix.host.container == 'alpine:edge'
-        run: npm install -g pnpm@11.20.0
-      - if: matrix.host.container != 'alpine:edge'
-        uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6
         with:
           cache: true
       - shell: sh


### PR DESCRIPTION
I have now read this log enough times to recite it, so I figured I would fix it instead.

`Test [aarch64-alpine-linux-musl]` has failed on every run since the `packageManager` bump, before any of this repo's code executes:

```
Switching pnpm from v11.19.0 to v11.20.0...
[ERR_SQLITE_ERROR] disk I/O error
  at StoreIndex.openDatabase
```

`pnpm/action-setup` self-installs 11.19.0, pnpm then self-updates to the `packageManager` version, and opening the store index fails inside the `laverdet/alpine-arm64@v1` container. The x86_64 Alpine job makes the identical switch and passes.

06c7ee80 already carries the workaround, `npm install -g pnpm@11.20.0` instead of the action on Alpine, but it landed on `build` and on `release`. `release` has no matrix, so its `matrix.host.container` conditions matched nothing and the action ran there anyway; `test` is the job that needed the step and never got it. This moves it, and drops the dead conditions.

## Validation

- Editing `pathfinder.yml` triggers this workflow, so the Alpine test jobs on this PR are the check.
- Confirmed against run 32802377266: `Build [aarch64-alpine-linux-musl]` passed with the pinned install while `Test [aarch64-alpine-linux-musl]` died at setup in 13s.
