### PR TITLE
processor: share the shard cron due-schedule

### DIFF
--- a/.changeset/shard-due-set.md
+++ b/.changeset/shard-due-set.md
@@ -1,0 +1,5 @@
+---
+"xxscreeps": patch
+---
+
+Share one due-schedule primitive between the deposit and power-bank shard crons.

--- a/packages/xxscreeps/engine/processor/shard.ts
+++ b/packages/xxscreeps/engine/processor/shard.ts
@@ -24,6 +24,35 @@ export const everyNTicks = (period: number, fn: ShardTickProcessor): ShardTickPr
 		}
 	};
 
+export interface DueSet {
+	/** Members due at or before `at`, soonest first. */
+	due: (shard: Shard, at: number) => Promise<string[]>;
+	/** Overwrite `member`'s due time. `earliest` lowers an existing one instead of replacing it. */
+	schedule: (shard: Shard, member: string, dueAt: number, options?: { earliest?: boolean }) => Promise<number>;
+	/** Seed a batch at startup. */
+	seed: (shard: Shard, entries: [ score: number, member: string ][]) => Promise<number>;
+	/** @internal Lets a spec read the schedule without knowing the key shape. */
+	entriesForTest: (shard: Shard) => Promise<[ score: number, member: string ][]>;
+}
+
+/**
+ * A due schedule for a shard-tick processor that sweeps something periodically: score = when the
+ * member is next due, member = the room or sector it stands for. `at` and the scores share whatever
+ * clock the caller sweeps on, wall-clock or tick.
+ *
+ * It lives in `scratch` because it is rebuildable — a schedule reshuffled by a restart violates
+ * nothing, and `main` flushes scratch before running the shard initializer that seeds it.
+ */
+export function makeDueSet(key: string): DueSet {
+	return {
+		due: (shard, at) => shard.scratch.zRange(key, 0, at, { by: 'SCORE' }),
+		schedule: (shard, member, dueAt, options) =>
+			shard.scratch.zAdd(key, [ [ dueAt, member ] ], options?.earliest === true ? { up: 'LT' } : undefined),
+		seed: (shard, entries) => shard.scratch.zAdd(key, entries),
+		entriesForTest: shard => shard.scratch.zRangeWithScores(key, 0, -1),
+	};
+}
+
 export async function runShardTickProcessors(shard: Shard, time: number) {
 	await Fn.mapAwait(shardTickProcessors, fn => fn(shard, time));
 }

--- a/packages/xxscreeps/mods/modern/deposit/main.ts
+++ b/packages/xxscreeps/mods/modern/deposit/main.ts
@@ -7,7 +7,7 @@ import { Fn } from 'xxscreeps/functional/fn.js';
 import { iterateSectors, makeSectorRadiusPredicate } from 'xxscreeps/mods/modern/sector/sector.js';
 import * as C from 'xxscreeps:mods/constants';
 import { Deposit } from './deposit.js';
-import { dueSectorsAt, scheduleSector, seedSectors } from './model.js';
+import { dueSectors } from './model.js';
 
 // Deposits are placed in highway-room sectors: a per-sector wall-clock schedule drives periodic
 // evaluation, and a sector below its throughput target gains a deposit. Decay events pull a
@@ -116,7 +116,7 @@ registerShardInitializer(async shard => {
 		$$ => [ ...$$ ],
 	);
 	if (seeds.length > 0) {
-		await seedSectors(shard, seeds);
+		await dueSectors.seed(shard, seeds);
 	}
 });
 
@@ -124,7 +124,7 @@ registerShardInitializer(async shard => {
 // retry next tick instead of dropping it silently.
 registerShardTickProcessor(async shard => {
 	const now = Date.now();
-	const due = await dueSectorsAt(shard, now);
+	const due = await dueSectors.due(shard, now);
 	if (due.length === 0) {
 		return;
 	}
@@ -133,6 +133,6 @@ registerShardTickProcessor(async shard => {
 		await evaluateSector(shard, world, sector);
 		// Re-poll at the cadence ceiling whether or not a deposit lands (placement can fail);
 		// decay pulls the schedule forward sooner.
-		await scheduleSector(shard, sector, now + DEPOSIT_CHECK_INTERVAL);
+		await dueSectors.schedule(shard, sector, now + DEPOSIT_CHECK_INTERVAL);
 	});
 });

--- a/packages/xxscreeps/mods/modern/deposit/model.ts
+++ b/packages/xxscreeps/mods/modern/deposit/model.ts
@@ -1,24 +1,5 @@
-import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { makeDueSet } from 'xxscreeps/engine/processor/shard.js';
 
-// Sorted set in scratch (rebuildable on restart — it's fine to drop wall time): score = wall-clock
-// ms when this sector should be re-evaluated (0 = immediately), member = central room name (e.g.
-// `W5N5`). One row per sector, regardless of how many highway rooms it owns.
-const dueSectorsKey = 'deposits/dueSectors';
-
-// `{ earliest: true }` only lowers an existing score (the decay path, freeing throughput);
-// otherwise the score is overwritten (the evaluator pushing the next check forward).
-export function scheduleSector(shard: Shard, sector: string, dueAt: number, options?: { earliest?: boolean }) {
-	return shard.scratch.zAdd(dueSectorsKey, [ [ dueAt, sector ] ],
-		options?.earliest === true ? { up: 'LT' } : undefined);
-}
-
-// Seed a batch of sectors, staggered by their scatter offsets. `up: 'LT'` keeps a re-seed (a fresh
-// service start over surviving scratch) from clobbering sectors a prior run already advanced.
-export function seedSectors(shard: Shard, seeds: [ score: number, sector: string ][]) {
-	return shard.scratch.zAdd(dueSectorsKey, seeds, { up: 'LT' });
-}
-
-// Central rooms due for re-evaluation at or before `now`.
-export function dueSectorsAt(shard: Shard, now: number) {
-	return shard.scratch.zRange(dueSectorsKey, 0, now, { by: 'SCORE' });
-}
+// Score = wall-clock ms when this sector should be re-evaluated (0 = immediately), member = central
+// room name (e.g. `W5N5`). One row per sector, regardless of how many highway rooms it owns.
+export const dueSectors = makeDueSet('deposits/dueSectors');

--- a/packages/xxscreeps/mods/modern/deposit/processor.ts
+++ b/packages/xxscreeps/mods/modern/deposit/processor.ts
@@ -13,7 +13,7 @@ import { makeSectorRadiusPredicate } from 'xxscreeps/mods/modern/sector/sector.j
 import { shuffledSquare } from 'xxscreeps/utility/random.js';
 import * as C from 'xxscreeps:mods/constants';
 import { Deposit } from './deposit.js';
-import { scheduleSector } from './model.js';
+import { dueSectors } from './model.js';
 
 // The first wall position in 5..44, in random order, with at least one non-wall neighbor (incl.
 // diagonals), inside the sector's 250-square radius, and 2 squares clear of any other room object.
@@ -60,7 +60,7 @@ registerObjectTickProcessor(Deposit, (deposit, context) => {
 		const owning =
 			sectors.find(sectorName => makeSectorRadiusPredicate(sectorName, roomName, sectors)(deposit.pos.x, deposit.pos.y));
 		if (owning !== undefined) {
-			context.task(scheduleSector(context.shard, owning, 0, { earliest: true }));
+			context.task(dueSectors.schedule(context.shard, owning, 0, { earliest: true }));
 		}
 		deposit.room['#removeObject'](deposit);
 		context.didUpdate();

--- a/packages/xxscreeps/mods/modern/deposit/test.ts
+++ b/packages/xxscreeps/mods/modern/deposit/test.ts
@@ -15,7 +15,7 @@ import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
 import { Deposit } from './deposit.js';
 import { depositTypeForRoom, loadSectorDeposits, setDepositBootstrapScatterForTesting } from './main.js';
-import { scheduleSector } from './model.js';
+import { dueSectors } from './model.js';
 
 interface DepositSimOptions {
 	body?: PartType[];
@@ -173,7 +173,7 @@ describe('mods/modern/deposit', () => {
 			assert.strictEqual((await findDepositsInSector(shard, 'W5N5')).length, 1);
 			// Force a sector re-eval by bumping its score to 0 (= due immediately); `earliest` matches
 			// the decay path's bump-down semantics.
-			await scheduleSector(shard, 'W5N5', 0, { earliest: true });
+			await dueSectors.schedule(shard, 'W5N5', 0, { earliest: true });
 			await tick(2);
 			assert.strictEqual((await findDepositsInSector(shard, 'W5N5')).length, 1,
 				'saturated sector should not gain a second deposit');

--- a/packages/xxscreeps/mods/modern/powerbank/main.ts
+++ b/packages/xxscreeps/mods/modern/powerbank/main.ts
@@ -3,7 +3,7 @@ import { pushIntentsForRoomNextTick } from 'xxscreeps/engine/processor/model.js'
 import { Fn } from 'xxscreeps/functional/fn.js';
 import { iterateSectors } from 'xxscreeps/mods/modern/sector/sector.js';
 import * as C from 'xxscreeps:mods/constants';
-import { dueRoomsAt, scheduleRoom, seedRooms } from './model.js';
+import { dueRooms } from './model.js';
 
 // World-management placement policy for power banks. Each highway room runs an independent respawn
 // countdown; the next-due tick is authoritative on the room (`#nextPowerBankTime`) and the scratch
@@ -39,12 +39,12 @@ registerShardInitializer(async shard => {
 			const deadline = room['#nextPowerBankTime'] || shard.time + respawnTime();
 			return [ deadline, roomName ];
 		}));
-	await seedRooms(shard, seeds);
+	await dueRooms.seed(shard, seeds);
 });
 
 // Peek-and-reschedule (no zrem): a crash between peek and reschedule leaves the entry for retry.
 registerShardTickProcessor(async (shard, time) => {
-	const due = await dueRoomsAt(shard, time);
+	const due = await dueRooms.due(shard, time);
 	if (due.length === 0) return;
 	await Fn.mapAwait(due, async roomName => {
 		// Placement waits for the room intent stage (live terrain); the timer advances now.
@@ -56,7 +56,7 @@ registerShardTickProcessor(async (shard, time) => {
 				local: { placePowerBank: [ [ power, nextDue ] ] },
 				internal: true,
 			}),
-			scheduleRoom(shard, roomName, nextDue),
+			dueRooms.schedule(shard, roomName, nextDue),
 		]);
 	});
 });

--- a/packages/xxscreeps/mods/modern/powerbank/model.ts
+++ b/packages/xxscreeps/mods/modern/powerbank/model.ts
@@ -1,26 +1,5 @@
-import type { Shard } from 'xxscreeps/engine/db/index.js';
+import { makeDueSet } from 'xxscreeps/engine/processor/shard.js';
 
-// Sorted set in scratch (rebuilt on restart from each room's persisted `#nextPowerBankTime`): score =
-// the tick a room is next due, member = highway room name. One row per room.
-const dueRoomsKey = 'powerbanks/dueRooms';
-
-// Overwrites a room's next-due score; shared by the reschedule and tests.
-export function scheduleRoom(shard: Shard, roomName: string, dueAt: number) {
-	return shard.scratch.zAdd(dueRoomsKey, [ [ dueAt, roomName ] ]);
-}
-
-// Seed a batch of rooms at startup. `up: 'LT'` keeps a re-seed (a fresh service start over surviving
-// scratch) from clobbering a room a prior run already advanced.
-export function seedRooms(shard: Shard, seeds: [ score: number, roomName: string ][]) {
-	return shard.scratch.zAdd(dueRoomsKey, seeds, { up: 'LT' });
-}
-
-// Highway rooms due to place at or before `time`.
-export function dueRoomsAt(shard: Shard, time: number) {
-	return shard.scratch.zRange(dueRoomsKey, 0, time, { by: 'SCORE' });
-}
-
-// Test-only accessor so specs don't have to know the redis key shape.
-export function inspectDuePowerBankRoomsForTest(shard: Shard): Promise<[ score: number, roomName: string ][]> {
-	return shard.scratch.zRangeWithScores(dueRoomsKey, 0, -1);
-}
+// Score = the tick a room is next due, member = highway room name. One row per room, rebuilt on
+// restart from each room's persisted `#nextPowerBankTime`.
+export const dueRooms = makeDueSet('powerbanks/dueRooms');

--- a/packages/xxscreeps/mods/modern/powerbank/test.ts
+++ b/packages/xxscreeps/mods/modern/powerbank/test.ts
@@ -11,7 +11,7 @@ import { iterateSectors } from 'xxscreeps/mods/modern/sector/sector.js';
 import { deterministicRandomForTesting } from 'xxscreeps/test/fixtures.js';
 import { assert, describe, simulate, test } from 'xxscreeps/test/index.js';
 import * as C from 'xxscreeps:mods/constants';
-import { inspectDuePowerBankRoomsForTest, scheduleRoom } from './model.js';
+import { dueRooms } from './model.js';
 import { StructurePowerBank, create as createPowerBank } from './powerbank.js';
 
 interface PowerBankSimOptions {
@@ -151,7 +151,7 @@ describe('mods/modern/powerbank', () => {
 			using rng = deterministicRandomForTesting();
 			const seededAt = shard.time;
 			await runShardInitializers(shard);
-			const due = await inspectDuePowerBankRoomsForTest(shard);
+			const due = await dueRooms.entriesForTest(shard);
 			const world = await shard.loadWorld();
 			const highways = new Set(Fn.transform(iterateSectors(world), ([ , sector ]): Iterable<string> => sector.edges));
 			assert.strictEqual(due.length, highways.size, 'every sector edge room was seeded exactly once');
@@ -169,7 +169,7 @@ describe('mods/modern/powerbank', () => {
 		test('a due highway room places one valid power bank', () => emptyWorld(async ({ shard, tick }) => {
 			using rng = deterministicRandomForTesting();
 			const scheduledAt = shard.time;
-			await scheduleRoom(shard, 'W0N0', 0);
+			await dueRooms.schedule(shard, 'W0N0', 0);
 			// Tick 1: the shard processor pushes a placement intent and reschedules. Tick 2: the room
 			// processor receives the intent and inserts the bank.
 			await tick(2);
@@ -188,7 +188,7 @@ describe('mods/modern/powerbank', () => {
 			assert.strictEqual(bank.hits, C.POWER_BANK_HITS);
 			assert.strictEqual(bank['#nextDecayTime'], shard.time + C.POWER_BANK_DECAY);
 			// The room's timer advanced into the future instead of staying due.
-			const due = await inspectDuePowerBankRoomsForTest(shard);
+			const due = await dueRooms.entriesForTest(shard);
 			const entry = due.find(([ , roomName ]) => roomName === 'W0N0');
 			assert.ok(entry, 'W0N0 remains scheduled');
 			assert.ok(entry[0] - scheduledAt >= C.POWER_BANK_RESPAWN_TIME * 0.75, 'rescheduled into the future');
@@ -200,7 +200,7 @@ describe('mods/modern/powerbank', () => {
 		test('non-highway rooms are never seeded', () => emptyWorld(async ({ shard }) => {
 			using rng = deterministicRandomForTesting();
 			await runShardInitializers(shard);
-			const seeded = new Set((await inspectDuePowerBankRoomsForTest(shard)).map(([ , roomName ]) => roomName));
+			const seeded = new Set((await dueRooms.entriesForTest(shard)).map(([ , roomName ]) => roomName));
 			assert.ok(!seeded.has('W5N5'), 'sector center is not seeded');
 			assert.ok(!seeded.has('W3N3'), 'interior room is not seeded');
 		}));
@@ -208,7 +208,7 @@ describe('mods/modern/powerbank', () => {
 		test('a critical roll adds the max-capacity bonus', () => emptyWorld(async ({ shard, tick }) => {
 			// base roll 0.5 -> 2750; crit roll 0.1 < POWER_BANK_CAPACITY_CRIT adds POWER_BANK_CAPACITY_MAX.
 			using rng = makeRngWithPrefix([ 0.5, 0.1 ]);
-			await scheduleRoom(shard, 'W0N0', 0);
+			await dueRooms.schedule(shard, 'W0N0', 0);
 			await tick(2);
 			const bank = await findPowerBank(shard, 'W0N0');
 			assert.ok(bank, 'a power bank was placed');
@@ -223,7 +223,7 @@ describe('mods/modern/powerbank', () => {
 		})(async ({ shard }) => {
 			using rng = deterministicRandomForTesting();
 			await runShardInitializers(shard);
-			const due = await inspectDuePowerBankRoomsForTest(shard);
+			const due = await dueRooms.entriesForTest(shard);
 			const entry = due.find(([ , roomName ]) => roomName === 'W0N0');
 			assert.ok(entry, 'W0N0 was seeded');
 			assert.strictEqual(entry[0], 12345, 'seeded from the persisted deadline, not a fresh roll');


### PR DESCRIPTION
`mods/modern/deposit` and `mods/modern/powerbank` each carry the same three-function scratch sorted-set model, and the stronghold placement cron in the next PR wanted a third copy. This lifts the shape into `makeDueSet(key)` next to `everyNTicks`, and points both existing mods at it.

One behavior note: the seed dropped its `up: 'LT'`. `engine/service/main.ts` flushes scratch before running shard initializers, so a seed never met a surviving entry and the option could not fire; the comments in both mods said otherwise.

Tradeoff worth naming: powerbank's test-only schedule inspector moved onto the shared interface as an `@internal` `entriesForTest`, so a test affordance now sits on an engine type instead of a mod-local free function.

## Validation
`npm run build`, `npx xxscreeps test` (664/664), `eslint --max-warnings 0 packages`.
