### PR TITLE
fix(controller): credit a renewed reservation by the creep's CLAIM power, not power + 1

### DIFF
--- a/packages/xxscreeps/mods/classic/controller/processor.ts
+++ b/packages/xxscreeps/mods/classic/controller/processor.ts
@@ -124,8 +124,9 @@ const intents = [
 		if (CreepLib.checkReserveController(creep, controller) === C.OK) {
 			const power = creep.getActiveBodyparts(C.CLAIM) * C.CONTROLLER_RESERVE;
 			const reservationEndTime = controller['#reservationEndTime'];
+			// A renewal adds `power`; only a fresh reservation starts from `gameTime + 1`.
 			const endTime = reservationEndTime
-				? Math.min(Game.time + C.CONTROLLER_RESERVE_MAX, reservationEndTime + power + 1)
+				? Math.min(Game.time + C.CONTROLLER_RESERVE_MAX, reservationEndTime + power)
 				: Game.time + power + 1;
 			reserve(context, controller, creep['#user'], endTime);
 			saveAction(creep, 'reserveController', controller.pos);

--- a/packages/xxscreeps/mods/classic/controller/test.ts
+++ b/packages/xxscreeps/mods/classic/controller/test.ts
@@ -207,6 +207,30 @@ describe('mods/classic/controller', () => {
 				assert.strictEqual(Game.creeps.worker!.reserveController(controller), C.ERR_INVALID_TARGET);
 			});
 		}));
+
+		// Short of CONTROLLER_RESERVE_MAX, so the cap does not hide the arithmetic.
+		const renewableReservation = simulate({
+			W3N3: room => {
+				room['#user'] = '100';
+				room.controller!['#reservationEndTime'] = 200;
+				room['#insertObject'](create(pos, [ C.CLAIM, C.MOVE ], 'claimer', '100'));
+			},
+		});
+
+		test('renewing a reservation with one CLAIM part leaves the ticks remaining unchanged',
+			() => renewableReservation(async ({ player, tick }) => {
+				let before = 0;
+				await player('100', Game => {
+					before = Game.rooms.W3N3!.controller!['#reservationEndTime'] - Game.time;
+					assert.strictEqual(
+						Game.creeps.claimer?.reserveController(Game.rooms.W3N3!.controller!), C.OK);
+				});
+				await tick();
+				await player('100', Game => {
+					const after = Game.rooms.W3N3!.controller!['#reservationEndTime'] - Game.time;
+					assert.strictEqual(after, before);
+				});
+			}));
 	});
 
 	describe('upgradeController', () => {


### PR DESCRIPTION
Renewing a reservation credits `power + 1` ticks instead of `power`, so a one-CLAIM reserver banks a tick every tick instead of holding even against the countdown. The official engine renews with `reservation.endTime += effect`. The added test fails on the current code.

I've been trying to improve early-game econ for my bot and this came up as a deviation in speedrun behavior between `xxscreeps` and `engine`.